### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# fVDB-realitycapture CODEOWNERS
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# Default owner for all files is fvdb-dev. Later matches take precedence over this line
+* @openvdb/fvdb-dev


### PR DESCRIPTION
We need a CODEOWNERS file in order to have github auto-assign reviewers. For now, all files are owned by @openvdb/fvdb-dev . In the future if we have subsets of the code with more specific owners, we can add those teams and matchers to CODEOWNERS to get more specific automatic review assignments.