### PR TITLE
Download all data from s3

### DIFF
--- a/download_example_data.py
+++ b/download_example_data.py
@@ -1,80 +1,37 @@
-#!/usr/bin/env python
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Script to download benchmark dataset(s)"""
 
-import os
-import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 import tyro
 
 # dataset names
-dataset_names = Literal["mipnerf360"]
-
-# dataset urls
-urls = {"mipnerf360": "http://storage.googleapis.com/gresearch/refraw360/360_v2.zip"}
-
-# rename maps
-dataset_rename_map = {"mipnerf360": "360_v2"}
+dataset_names = Literal[
+    "all",
+    "mipnerf360",
+    "gettysburg",
+]
 
 
-@dataclass
-class DownloadData:
-    dataset: dataset_names = "mipnerf360"
-    save_dir: Path = Path(os.getcwd() + "/data")
+def main(
+    dataset: dataset_names = "all",
+    download_path: str | Path = Path.cwd() / "data",
+):
+    """
+    Download example datasets used in FVDB-RealityCapture.
 
-    def main(self):
-        self.save_dir.mkdir(parents=True, exist_ok=True)
-        self.dataset_download(self.dataset)
+    Args:
+        dataset (str): Name of the dataset to download. Options are "mipnerf360" or "gettysburg".
+        download_path (str | Path): Path to the directory where the dataset will be downloaded.
+            Default is the current working directory + "data".
+    """
 
-    def dataset_download(self, dataset: dataset_names):
-        (self.save_dir / dataset_rename_map[dataset]).mkdir(parents=True, exist_ok=True)
+    from fvdb_3dgs.tools._download_example_data import download_example_data
 
-        file_name = Path(urls[dataset]).name
-
-        # download
-        download_command = [
-            "wget",
-            "-P",
-            str(self.save_dir / dataset_rename_map[dataset]),
-            urls[dataset],
-        ]
-        try:
-            subprocess.run(download_command, check=True)
-            print("File file downloaded succesfully.")
-        except subprocess.CalledProcessError as e:
-            print(f"Error downloading file: {e}")
-
-        # if .zip
-        if Path(urls[dataset]).suffix == ".zip":
-            extract_command = [
-                "unzip",
-                self.save_dir / dataset_rename_map[dataset] / file_name,
-                "-d",
-                self.save_dir / dataset_rename_map[dataset],
-            ]
-        # if .tar
-        else:
-            extract_command = [
-                "tar",
-                "-xvzf",
-                self.save_dir / dataset_rename_map[dataset] / file_name,
-                "-C",
-                self.save_dir / dataset_rename_map[dataset],
-            ]
-
-        # extract
-        try:
-            subprocess.run(extract_command, check=True)
-            os.remove(self.save_dir / dataset_rename_map[dataset] / file_name)
-            print("Extraction complete.")
-        except subprocess.CalledProcessError as e:
-            print(f"Extraction failed: {e}")
+    download_example_data(dataset, download_path)
 
 
 if __name__ == "__main__":
-    tyro.cli(DownloadData).main()
+    tyro.cli(main)

--- a/fvdb_3dgs/foundation_models/dlnr.py
+++ b/fvdb_3dgs/foundation_models/dlnr.py
@@ -31,8 +31,10 @@ class DLNRModel:
             backbone (str): Backbone to use for the DLNR model. Options are "middleburry" or "sceneflow".
             device (torch.device | str): Device to load the model on (default is "cuda").
         """
-        middleburry_weights_url = "https://github.com/David-Zhao-1997/High-frequency-Stereo-Matching-Network/releases/download/v1.0.0/DLNR_Middlebury.pth"
-        sceneflow_weights_url = "wget https://github.com/David-Zhao-1997/High-frequency-Stereo-Matching-Network/releases/download/v1.0.0/DLNR_SceneFlow.pth"
+        middleburry_weights_url = (
+            "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/DLNR_Middlebury.pth"
+        )
+        sceneflow_weights_url = "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/DLNR_SceneFlow.pth"
 
         self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         if backbone == "middleburry":

--- a/fvdb_3dgs/tools/_download_example_data.py
+++ b/fvdb_3dgs/tools/_download_example_data.py
@@ -47,10 +47,17 @@ def _download_one_dataset(dataset_name: str, dataset_url: str, dataset_download_
 def download_example_data(dataset="mipnerf360", download_path: str | pathlib.Path = pathlib.Path.cwd() / "data"):
 
     # dataset urls
-    dataset_urls = {"mipnerf360": "http://storage.googleapis.com/gresearch/refraw360/360_v2.zip"}
+
+    dataset_urls = {
+        "mipnerf360": "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/360_v2.zip",
+        "gettysburg": "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/gettysburg.zip",
+    }
 
     # where each dataset goes
-    dataset_directories = {"mipnerf360": "360_v2"}
+    dataset_directories = {
+        "mipnerf360": "360_v2",
+        "gettysburg": "gettysburg",
+    }
 
     if isinstance(download_path, str):
         download_path = pathlib.Path(download_path)

--- a/fvdb_3dgs/training/lpips.py
+++ b/fvdb_3dgs/training/lpips.py
@@ -680,7 +680,7 @@ class LPIPSNetwork(torch.nn.Module):
         self.lins = torch.nn.ModuleList(self.lins)
 
         if pretrained:
-            weights_url = f"https://www.fwilliams.info/files/lpips_models/{backbone}.pth"
+            weights_url = f"https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/{backbone}.pth"
             path_to_weights = get_weights_path_for_model(f"{backbone}.pth", weights_url, model_name=backbone)
             self.load_state_dict(torch.load(path_to_weights, map_location="cpu", weights_only=False), strict=False)
 

--- a/scripts/upload_to_s3.py
+++ b/scripts/upload_to_s3.py
@@ -1,0 +1,66 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import logging
+import os
+import pathlib
+import sys
+import threading
+
+import boto3
+import tyro
+
+
+class ProgressPercentage(object):
+    """
+    Helper class to report progress of S3 uploads.
+    Taken from: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html
+    """
+
+    def __init__(self, filename):
+        self._filename = filename
+        self._size = float(os.path.getsize(filename))
+        self._seen_so_far = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, bytes_amount):
+        with self._lock:
+            self._seen_so_far += bytes_amount
+            percentage = (self._seen_so_far / self._size) * 100
+            sys.stdout.write("\r%s %s / %s (%.2f%%)" % (self._filename, self._seen_so_far, self._size, percentage))
+            sys.stdout.flush()
+
+
+def main(file_path: pathlib.Path):
+    """
+    Upload a file to the fvdb-data S3 bucket. This only works for developers with write access to the bucket.
+
+    Args:
+        file_path (pathlib.Path): Path to the file to upload.
+    """
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"File {file_path} does not exist.")
+    if not file_path.is_file():
+        raise ValueError(f"Path {file_path} is not a file.")
+
+    logger.info(f"Uploading file {file_path} to S3 bucket fvdb-data...")
+    s3 = boto3.client("s3")
+
+    local_file_path = str(file_path)
+    bucket_name = "fvdb-data"
+    s3_object_key = str(pathlib.Path("fvdb-reality-capture") / file_path.name)
+
+    try:
+        s3.upload_file(local_file_path, bucket_name, s3_object_key, Callback=ProgressPercentage(local_file_path))
+        logger.info(f"File '{local_file_path}' uploaded to S3 bucket '{bucket_name}' as '{s3_object_key}'")
+    except Exception as e:
+        logger.error(f"Error uploading file: {e}")
+
+
+if __name__ == "__main__":
+    args = tyro.cli(main)

--- a/tests/unit/test_sfm_scene.py
+++ b/tests/unit/test_sfm_scene.py
@@ -10,15 +10,15 @@ import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from fvdb_3dgs.sfm_scene import SfmCameraMetadata, SfmImageMetadata, SfmScene
-from fvdb_3dgs.transforms import DownsampleImages
+from fvdb_3dgs.tools import download_example_data
 
 
 class BasicSfmSceneTest(unittest.TestCase):
     def setUp(self):
-        # TODO: Auto-download this dataset if it doesn't exist.
-        # NOTE: For now, we assume you've downloaded this dataset. We'll do this automatically
-        # when we have access to S3 buckets
-        self.dataset_path = pathlib.Path(__file__).parent.parent.parent / "data" / "glomap_gettysburg_small_scaled"
+        # Auto-download this dataset if it doesn't exist.
+        self.dataset_path = pathlib.Path(__file__).parent.parent.parent / "data" / "gettysburg"
+        if not self.dataset_path.exists():
+            download_example_data("gettysburg", self.dataset_path.parent)
 
         self.expected_num_images = 154
         self.expected_num_cameras = 5

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -8,7 +8,8 @@ import unittest
 import cv2
 import numpy as np
 
-from fvdb_3dgs.sfm_scene import SfmCameraMetadata, SfmImageMetadata, SfmScene
+from fvdb_3dgs import SfmCameraMetadata, SfmImageMetadata, SfmScene
+from fvdb_3dgs.tools import download_example_data
 from fvdb_3dgs.transforms import (
     Compose,
     CropScene,
@@ -22,10 +23,10 @@ from fvdb_3dgs.transforms import (
 
 class BasicSfmSceneTransformTest(unittest.TestCase):
     def setUp(self):
-        # TODO: Auto-download this dataset if it doesn't exist.
-        # NOTE: For now, we assume you've downloaded this dataset. We'll do this automatically
-        # when we have access to S3 buckets
-        self.dataset_path = pathlib.Path(__file__).parent.parent.parent / "data" / "glomap_gettysburg_small_scaled"
+        # Auto-download this dataset if it doesn't exist.
+        self.dataset_path = pathlib.Path(__file__).parent.parent.parent / "data" / "gettysburg"
+        if not self.dataset_path.exists():
+            download_example_data("gettysburg", self.dataset_path.parent)
 
         self.expected_num_images = 154
         self.expected_num_cameras = 5


### PR DESCRIPTION
We had scattered URLs that we used for downloading data (weights, example datasets etc.). We now have one public S3 bucket and everything uses it.

This also downloads data during unit tests if it is not present (which can be slow). For CI, we should make sure this is just mounted in the container. 