### PR TITLE
Loader for simple directory

### DIFF
--- a/download_example_data.py
+++ b/download_example_data.py
@@ -12,6 +12,8 @@ dataset_names = Literal[
     "all",
     "mipnerf360",
     "gettysburg",
+    "safety_park",
+    "miris_factory",
 ]
 
 

--- a/fvdb_reality_capture/sfm_scene/_load_colmap_scene.py
+++ b/fvdb_reality_capture/sfm_scene/_load_colmap_scene.py
@@ -122,7 +122,7 @@ def load_colmap_scene(colmap_path: pathlib.Path):
 
     cache = SfmCache.get_cache(colmap_path / "_cache", "sfm_dataset_cache", "Cache for SFM dataset")
 
-    logger = logging.getLogger(f"load colmap")  # FIXME: Proper logger name
+    logger = logging.getLogger(f"{__name__}.load_colmap_scene")
 
     image_world_to_cam_mats = []
     image_camera_ids = []

--- a/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
+++ b/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
@@ -46,7 +46,7 @@ def load_simple_scene(data_path: pathlib.Path):
         raise NotADirectoryError(f"images/ is not a directory in {data_path}")
     points_path = data_path / "points.ply"
     if not points_path.exists():
-        raise FileNotFoundError(f"points.ply not found in {data_path}")
+        raise FileNotFoundError(f"pointcloud.ply not found in {data_path}")
 
     with open(data_path / "cameras.json", "r") as f:
         cameras = json.load(f)

--- a/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
+++ b/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
@@ -1,0 +1,115 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import json
+import logging
+import pathlib
+
+import numpy as np
+import point_cloud_utils as pcu
+import tqdm
+
+from .sfm_cache import SfmCache
+from .sfm_metadata import SfmCameraMetadata, SfmCameraType, SfmImageMetadata
+
+
+def load_simple_scene(data_path: pathlib.Path):
+    """
+    Load cameras, posed-images, and points from a directory of images, camera parameters (stored as JSON),
+    and 3d points (stored as a PLY).
+
+    The directory should contain:
+        - images/: A directory of images.
+        - cameras.json: A JSON file containing camera parameters.
+            The cameras.json file is a list of dictionaries, each containing:
+                - camera_name: The name of the image file.
+                - width: The width of the image.
+                - height: The height of the image.
+                - camera_intrinsics: The perspective projection matrix
+                - world_to_camera: The world-to-camera transformation matrix.
+                - image_path: The path to the image file relative to the images directory.
+        - points.ply: A PLY file containing 3D points.
+    Args:
+        data_ (pathlib.Path): The path to the data
+
+    Returns:
+        sfm_scene (SfmScene): An in-memory representation of the SfmScene for the output of the COLMAP run.
+    """
+
+    cameras_json_path = data_path / "cameras.json"
+    if not cameras_json_path.exists():
+        raise FileNotFoundError(f"cameras.json not found in {data_path}")
+    images_path = data_path / "images"
+    if not images_path.exists():
+        raise FileNotFoundError(f"images/ directory not found in {data_path}")
+    if not images_path.is_dir():
+        raise NotADirectoryError(f"images/ is not a directory in {data_path}")
+    points_path = data_path / "points.ply"
+    if not points_path.exists():
+        raise FileNotFoundError(f"points.ply not found in {data_path}")
+
+    with open(data_path / "cameras.json", "r") as f:
+        cameras = json.load(f)
+
+    camera_metadata = {}
+    image_metadata = []
+
+    for i, camera in enumerate(cameras):
+        im_path = images_path / camera["image_path"]
+        im_path = im_path.absolute()
+        if not im_path.exists():
+            raise FileNotFoundError(f"Image {im_path} not found in images/ directory in {data_path}")
+        if not im_path.is_file():
+            raise FileNotFoundError(f"Image {im_path} is not a file in images/ directory in {data_path}")
+        width = camera["width"]
+        height = camera["height"]
+        projection_matrix = np.array(camera["camera_intrinsics"], dtype=np.float32).reshape(3, 3)
+        fx, fy, cx, cy = (
+            projection_matrix[0, 0],
+            projection_matrix[1, 1],
+            projection_matrix[0, 2],
+            projection_matrix[1, 2],
+        )
+        camera_type = SfmCameraType.PINHOLE
+        camera_id = i + 1
+        camera_metadata[camera_id] = SfmCameraMetadata(
+            img_width=width,
+            img_height=height,
+            fx=fx,
+            fy=fy,
+            cx=cx,
+            cy=cy,
+            camera_type=camera_type,
+            distortion_parameters=np.array([], dtype=np.float32),
+        )
+
+        world_to_camera_matrix = np.array(camera["world_to_camera"]).reshape(4, 4)
+        camera_to_world_matrix = np.linalg.inv(world_to_camera_matrix)
+        image_path = str(im_path)
+        image_metadata.append(
+            SfmImageMetadata(
+                world_to_camera_matrix=world_to_camera_matrix,
+                camera_to_world_matrix=camera_to_world_matrix,
+                camera_id=camera_id,
+                camera_metadata=camera_metadata[camera_id],
+                image_path=image_path,
+                mask_path="",
+                point_indices=np.array([], dtype=np.int32),
+                image_id=i,
+            )
+        )
+
+    points, colors = pcu.load_mesh_vc(points_path)
+    if points is None:
+        raise ValueError(f"Failed to load points from {points_path}")
+    if points.shape[0] == 0:
+        raise ValueError(f"No points found in {points_path}")
+    if colors is None:
+        raise ValueError(f"No colors found in {points_path}")
+    if colors.shape[0] != points.shape[0]:
+        raise ValueError(f"Number of colors does not match number of points in {points_path}")
+    errors = np.zeros((points.shape[0],), dtype=np.float32)
+
+    cache = SfmCache.get_cache(data_path / "_cache", "sfm_dataset_cache", "Cache for SFM dataset")
+
+    return camera_metadata, image_metadata, points, colors, errors, cache

--- a/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
+++ b/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
@@ -44,7 +44,7 @@ def load_simple_scene(data_path: pathlib.Path):
         raise FileNotFoundError(f"images/ directory not found in {data_path}")
     if not images_path.is_dir():
         raise NotADirectoryError(f"images/ is not a directory in {data_path}")
-    points_path = data_path / "points.ply"
+    points_path = data_path / "pointcloud.ply"
     if not points_path.exists():
         raise FileNotFoundError(f"pointcloud.ply not found in {data_path}")
 

--- a/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
+++ b/fvdb_reality_capture/sfm_scene/_load_simple_scene.py
@@ -94,7 +94,7 @@ def load_simple_scene(data_path: pathlib.Path):
                 camera_metadata=camera_metadata[camera_id],
                 image_path=image_path,
                 mask_path="",
-                point_indices=np.array([], dtype=np.int32),
+                point_indices=None,
                 image_id=i,
             )
         )
@@ -109,6 +109,7 @@ def load_simple_scene(data_path: pathlib.Path):
     if colors.shape[0] != points.shape[0]:
         raise ValueError(f"Number of colors does not match number of points in {points_path}")
     errors = np.zeros((points.shape[0],), dtype=np.float32)
+    colors = colors[:, :3]  # Drop alpha channel if present
 
     cache = SfmCache.get_cache(data_path / "_cache", "sfm_dataset_cache", "Cache for SFM dataset")
 

--- a/fvdb_reality_capture/sfm_scene/sfm_metadata.py
+++ b/fvdb_reality_capture/sfm_scene/sfm_metadata.py
@@ -307,7 +307,7 @@ class SfmImageMetadata:
         camera_id: int,
         image_path: str,
         mask_path: str,
-        point_indices: np.ndarray,
+        point_indices: np.ndarray | None,
         image_id: int,
     ):
         self._world_to_camera_matrix = world_to_camera_matrix
@@ -415,14 +415,14 @@ class SfmImageMetadata:
         return self._mask_path
 
     @property
-    def point_indices(self) -> np.ndarray:
+    def point_indices(self) -> np.ndarray | None:
         """
-        Return the indices of the 3D points that are visible in this image.
+        Return the indices of the 3D points that are visible in this image or None if the indices are not available.
 
         These indices correspond to the points in the point cloud that are visible in this image.
 
         Returns:
-            np.ndarray: An array of indices of the visible 3D points.
+            np.ndarray | None: An array of indices of the visible 3D points or None if not available.
         """
         return self._point_indices
 

--- a/fvdb_reality_capture/tools/_download_example_data.py
+++ b/fvdb_reality_capture/tools/_download_example_data.py
@@ -52,6 +52,7 @@ def download_example_data(dataset="all", download_path: str | pathlib.Path = pat
         "mipnerf360": "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/360_v2.zip",
         "gettysburg": "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/gettysburg.zip",
         "safety_park": "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/safety_park.zip",
+        "miris_factory": "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/miris_factory.zip",
     }
 
     # where each dataset goes
@@ -59,6 +60,7 @@ def download_example_data(dataset="all", download_path: str | pathlib.Path = pat
         "mipnerf360": "360_v2",
         "gettysburg": "gettysburg",
         "safety_park": "safety_park",
+        "miris_factory": "miris_factory",
     }
 
     if isinstance(download_path, str):

--- a/fvdb_reality_capture/training/scene_optimization_runner.py
+++ b/fvdb_reality_capture/training/scene_optimization_runner.py
@@ -19,7 +19,7 @@ import torch.utils.data
 import tqdm
 from fvdb import GaussianSplat3d
 from fvdb.utils.metrics import psnr, ssim
-from scipy.spatial import cKDTree
+from scipy.spatial import cKDTree  # type: ignore
 from torch.utils.tensorboard import SummaryWriter
 
 from ..sfm_scene import SfmScene
@@ -813,13 +813,16 @@ class SceneOptimizationRunner:
         Returns:
             scene_scale (float): An estimate of how far objects in the scene are from the cameras that captured them
         """
-        if use_sfm_depths:
+        if use_sfm_depths and sfm_scene.has_visible_point_indices:
             # Estimate the scene scale as the median across the median distances from cameras to the
             # sfm points they see. If there is not too much variance in how far the cameras are from the scene
             # this gives a rough estimate of the scene scale.
             median_depth_per_camera = []
             for image_meta in sfm_scene.images:
                 # Don't use cameras that don't see any points in the estimate
+                assert (
+                    image_meta.point_indices is not None
+                ), "SfmScene.has_visible_point_indices is True but image has no point indices"
                 if len(image_meta.point_indices) == 0:
                     continue
                 points = sfm_scene.points[image_meta.point_indices]

--- a/fvdb_reality_capture/training/scene_optimization_runner.py
+++ b/fvdb_reality_capture/training/scene_optimization_runner.py
@@ -859,6 +859,7 @@ class SceneOptimizationRunner:
         log_images_to_tensorboard: bool = False,
         save_eval_images: bool = False,
         save_results: bool = True,
+        dataset_type: Literal["colmap", "simple_directory"] = "colmap",
     ) -> "SceneOptimizationRunner":
         """
         Create a `Runner` instance for a new training run.
@@ -915,7 +916,12 @@ class SceneOptimizationRunner:
             transforms.append(CropScene(crop_bbox))
         transform = Compose(*transforms)
 
-        sfm_scene: SfmScene = SfmScene.from_colmap(dataset_path)
+        if dataset_type == "colmap":
+            sfm_scene: SfmScene = SfmScene.from_colmap(dataset_path)
+        elif dataset_type == "simple_directory":
+            sfm_scene: SfmScene = SfmScene.from_simple_directory(dataset_path)
+        else:
+            raise ValueError(f"Unsupported dataset_type {dataset_type}")
         sfm_scene = transform(sfm_scene)
 
         indices = np.arange(sfm_scene.num_images)

--- a/fvdb_reality_capture/training/sfm_dataset.py
+++ b/fvdb_reality_capture/training/sfm_dataset.py
@@ -161,9 +161,14 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         Returns:
             np.ndarray: An array of point indices that are visible in at least one image.
         """
+        if not self._sfm_scene.has_visible_point_indices:
+            return self._sfm_scene.points
         visible_points = set()
         for idx in self._indices:
             image_meta: SfmImageMetadata = self._sfm_scene.images[idx]
+            assert (
+                image_meta.point_indices is not None
+            ), "SfmScene.has_visible_point_indices is True but image has no point indices"
             visible_points.update(image_meta.point_indices.tolist())
         return np.array(list(visible_points))
 

--- a/fvdb_reality_capture/transforms/filter_images_with_low_points.py
+++ b/fvdb_reality_capture/transforms/filter_images_with_low_points.py
@@ -37,16 +37,27 @@ class FilterImagesWithLowPoints(BaseTransform):
 
     def __call__(self, input_scene: SfmScene) -> SfmScene:
         """
-        Perform the filtering on the input scene.
+        Perform the filtering on the input scene. If the scene does not have point indices for its images, the scene is returned unmodified.
 
         Args:
             input_scene (SfmScene): The input scene.
 
         Returns:
             output_scene (SfmScene): A new SfmScene containing only images which have more than `min_num_points` visible points.
+                If the input scene does not have point indices for its images, the input scene is returned unmodified.
         """
+        if not input_scene.has_visible_point_indices:
+            self._logger.info(
+                "Input scene does not have point indices for its images. Returning the input scene unmodified."
+            )
+            return input_scene
         image_mask = np.array(
-            [img_meta.point_indices.shape[0] > self._min_num_points for img_meta in input_scene.images], dtype=bool
+            [
+                img_meta.point_indices.shape[0] > self._min_num_points
+                for img_meta in input_scene.images
+                if img_meta.point_indices is not None
+            ],
+            dtype=bool,
         )
 
         return input_scene.filter_images(image_mask)

--- a/train.py
+++ b/train.py
@@ -29,6 +29,7 @@ def main(
     log_images_to_tensorboard: bool = False,
     save_results: bool = True,
     save_eval_images: bool = False,
+    dataset_type: Literal["colmap", "simple_directory"] = "colmap",
 ):
     logging.basicConfig(level=logging.INFO, format="%(levelname)s : %(message)s")
 
@@ -49,6 +50,7 @@ def main(
         log_images_to_tensorboard=log_images_to_tensorboard,
         save_results=save_results,
         save_eval_images=save_eval_images,
+        dataset_type=dataset_type,
     )
 
     runner.train()


### PR DESCRIPTION
Loading capability for a simple directory of image, camera poses in a json, and points with colors in a PLY.

```python
scene: SfmScene = SfmScene.from_simple_directory("path/to/directory")
```

Also add the `miris_factory` dataset to download example data. 

Since this dataset does not provide a mapping between images and visible points, I made this mapping optional which turned into a bigger plumbing change than I would have liked. Now `camera_metada.visible_point_indices` can be `None` but must be consitent across a whole dataset (which you can check with `sfm_scene.has_point_indices`.

I added tests for this which uncovered a small bug around how we were handing bounding boxes when they were not set which is now also fixed.