### PR TITLE
Refactor and document GaussianSplatOptimizer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,4 +31,24 @@
         "--profile", "black"
     ],
     "json.format.keepLines": true,
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#39216e",
+        "activityBar.background": "#39216e",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#934c2c",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#39216e",
+        "statusBar.background": "#251547",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#39216e",
+        "statusBarItem.remoteBackground": "#251547",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#251547",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#25154799",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.remoteColor": "#251547",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,24 +31,4 @@
         "--profile", "black"
     ],
     "json.format.keepLines": true,
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#39216e",
-        "activityBar.background": "#39216e",
-        "activityBar.foreground": "#e7e7e7",
-        "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#934c2c",
-        "activityBarBadge.foreground": "#e7e7e7",
-        "commandCenter.border": "#e7e7e799",
-        "sash.hoverBorder": "#39216e",
-        "statusBar.background": "#251547",
-        "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#39216e",
-        "statusBarItem.remoteBackground": "#251547",
-        "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#251547",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#25154799",
-        "titleBar.inactiveForeground": "#e7e7e799"
-    },
-    "peacock.remoteColor": "#251547",
 }

--- a/fvdb_reality_capture/training/gaussian_splat_optimizer.py
+++ b/fvdb_reality_capture/training/gaussian_splat_optimizer.py
@@ -9,12 +9,29 @@ from typing import Any, Callable
 
 import numpy as np
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as nnf
 import torch.optim
 from fvdb import GaussianSplat3d
 
 
 class InsertionGrad2dThresholdMode(str, Enum):
+    """
+    The `GaussianSplatOptimizer` uses a threshold on the accumulated norm of 2D mean gradients to use during refinement.
+
+    There are several modes for computing this threshold, specified by the config:
+    - CONSTANT: Always use the fixed threshold specified by self._config.insertion_grad_2d_threshold.
+    - PERCENTILE_FIRST_ITERATION: During the first refinement step, set the threshold to the given percentile of the gradients.
+        For all subsequent refinement steps, use that fixed threshold.
+    - PERCENTILE_EVERY_ITERATION: During every refinement step, set the threshold to the given percentile of the gradients.
+
+    These modes let you adapt the refinement behavior to the statistics of the gradients during training.
+    Generally CONSTANT with a default value (0.0002) will produce okay results, but may not be optimal for all types
+    of captures. Using PERCENTILE_FIRST_ITERATION will have similar behavior to CONSTANT but will adapt to the scale of the gradients
+    which can be more robust across different capture types.
+    For highly detailed, scenes, PERCENTILE_EVERY_ITERATION may be useful to adaptively insert more Gaussians as the model learns more detail.
+    This generally produces many more Gaussians and more detailed results at the cost of more memory and compute.
+    """
+
     CONSTANT = "constant"
     PERCENTILE_FIRST_ITERATION = "percentile_first_iteration"
     PERCENTILE_EVERY_ITERATION = "percentile_every_iteration"
@@ -37,22 +54,28 @@ class GaussianSplatOptimizerConfig:
     # If a Gaussian's opacity drops below this value, delete it
     deletion_opacity_threshold: float = 0.005
 
-    # If a Gaussian's 3d scale drops below this value (units specfied by scale_3d_threshold_units) then delete it
+    # If a Gaussian's 3d scale drops below this value (units are specified by scale_3d_threshold_units) then delete it.
     deletion_scale_3d_threshold: float = 0.1
 
-    # If a projected Gaussian's 2d scale drops below this value (units specfied by scale_3d_threshold_units) then delete it
+    # If a projected Gaussian's 2d scale drops below this value (units are specified by scale_2d_threshold_units) then delete it.
+    # Note this parameter is only used if you call refine with use_screen_space_scales=True
     deletion_scale_2d_threshold: float = 0.15
 
-    # Duplicate or split Gaussians where the accumulated gradients of its 2d mean is above this value
-    # and whose 3d and 2d scales exceed insertion_scale_3d_threshold and insertion_scale_2d_threshold
+    # Threshold value on the accumulated norm of projected mean gradients between refinement scale to
+    # determine whether a Gaussian has high error and is a candidate for duplication or splitting.
+    # This value must be positive if using CONSTANT mode, or in the range (0.0, 1.0) if using
+    # PERCENTILE_FIRST_ITERATION or PERCENTILE_EVERY_ITERATION modes.
     insertion_grad_2d_threshold: float = 0.0002 if insertion_grad_2d_threshold_mode == "constant" else 0.9
 
-    # Duplicate or split Gaussians whose 3d scale exceeds this value and whose
-    # accumulated 2d gradient exceeds insertion_grad_2d_threshold
+    # Duplicate high-error (determined by insertion_grad_2d_threshold) Gaussians whose 3d scale is below this value.
+    # These Gaussians are too small to capture the detail in the region they cover, so we duplicate them to
+    # allow them to specialize.
     insertion_scale_3d_threshold: float = 0.01
 
-    # Duplicate or split Gaussians whose 2d scale exceeds this value and whose accumulated 2d gradient
-    # exceeds insertion_grad_2d_threshold
+    # Split high-error (determined by insertion_grad_2d_threshold) Gaussians whose maximum projected
+    # size exceeds this value. These Gaussians are too large to capture the detail in the region they cover,
+    # so we split them to allow them to specialize.
+    # Note this parameter is only used if you call refine with use_screen_space_scales=True
     insertion_scale_2d_threshold: float = 0.05
 
     # When splitting Gaussinas, update the opacities of the new Gaussians using the revised formulation from
@@ -61,8 +84,15 @@ class GaussianSplatOptimizerConfig:
     # older Gaussians.
     opacity_updates_use_revised_formulation: bool = False
 
-    # TODO: Document
-    use_absolute_gradients: bool = False
+    # When splitting Gaussians, during insertion, how many new Gaussians to create per split Gaussian.
+    # _e.g._ if this value is 2, each split Gaussian becomes 2 smaller Gaussians.
+    # This value must be >= 2.
+    insertion_split_factor: int = 2
+
+    # When duplicating Gaussians, during insertion, how many new Gaussians to create per duplicated Gaussian.
+    # _e.g._ if this value is 3, each duplicated Gaussian becomes 3 copies of itself
+    # This value must be >= 2.
+    insertion_duplication_factor: int = 2
 
     # Learning rate for the means
     means_lr: float = 1.6e-4
@@ -119,6 +149,10 @@ class GaussianSplatOptimizer:
         self._model = model
         self._model.accumulate_mean_2d_gradients = True  # Make sure we track the 2D gradients for refinement
         self._config = config
+        if self._config.insertion_split_factor < 2:
+            raise ValueError("insertion_split_factor must be >= 2")
+        if self._config.insertion_duplication_factor < 2:
+            raise ValueError("insertion_duplication_factor must be >= 2")
 
         # This hook counts the number of times we call backward between zeroing the gradients.
         # To determine whether a Gaussian should be split or duplicated, we threshold the *average*
@@ -140,6 +174,14 @@ class GaussianSplatOptimizer:
             if self._config.insertion_grad_2d_threshold_mode == InsertionGrad2dThresholdMode.CONSTANT
             else None
         )
+        if self._config.insertion_grad_2d_threshold_mode != InsertionGrad2dThresholdMode.CONSTANT:
+            if not (0.0 < self._config.insertion_grad_2d_threshold < 1.0):
+                raise ValueError(
+                    "insertion_grad_2d_threshold must be in the range (0.0, 1.0) when using percentile modes"
+                )
+        else:
+            if self._insertion_grad_2d_abs_threshold is None or self._insertion_grad_2d_abs_threshold <= 0.0:
+                raise ValueError("insertion_grad_2d_threshold must be > 0.0 when using CONSTANT mode")
 
         self._optimizer = optimizer
 
@@ -211,7 +253,7 @@ class GaussianSplatOptimizer:
 
     def step(self):
         """
-        Step the optimizers and update the learning rate schedulers, updating parameters of the model.
+        Step the optimizers (updating the model's parameters) and decay the learning rate of the means.
         """
         self._optimizer.step()
         # Decay the means learning rate
@@ -223,6 +265,9 @@ class GaussianSplatOptimizer:
     def zero_grad(self, set_to_none: bool = False):
         """
         Zero the gradients of all tensors being optimized.
+
+        Args:
+            set_to_none (bool): If True, set the gradients to None instead of zeroing them. This can be more memory efficient.
         """
         self._num_grad_accumulation_steps = 0
         self._optimizer.zero_grad(set_to_none=set_to_none)
@@ -244,53 +289,134 @@ class GaussianSplatOptimizer:
         }
 
     @torch.no_grad()
-    def refine_gaussians(self, use_scales: bool = False, use_screen_space_scales: bool = False):
-        if use_screen_space_scales:
-            if not self._model.accumulate_max_2d_radii:
-                raise ValueError(
-                    "use_screen_space_scales is set to True but the model is not configured to "
-                    + "track screen space scales. Set model.accumulate_max_2d_radii = True."
-                )
-        # Grow the number of Gaussians via:
-        # 1. Duplicating those whose loss gradients are high and spatial size are small (i.e. have small eigenvals)
-        # 2. Splitting those whose loss gradients are high and spatial size are large (i.e. have large eigenvals)
-        #    or whose (2D projected) spatial extent simply exceeds the threshold self.grow_scale2d_threshold
-        #
-        # Note that splitting a Gaussian with mean μ and covariance Σ is implemented by sampling two new means
-        # μ1, μ2 from N(μ, Σ), and setting the covariances Σ1 and Σ2 by dividing the eigenvalues of Σ by 1.6.
-        n_dupli, n_split = self._grow_gs(use_screen_space_scales)
-        # Prune Gaussians whose opacity is below a threshold or whose screen space spatial extent is too large
-        n_prune = self._prune_gs(use_scales, use_screen_space_scales)
-        # Reset running statistics used to determine which Gaussians to add/split/prune
-        self._model.reset_accumulated_gradient_state()
+    def filter_gaussians(self, indices_or_mask: torch.Tensor):
+        """
+        Filter the Gaussians in the model to only those specified by the given indices or mask
+        and update the optimizer state accordingly. This can be used to delete, shuffle, or expand
+        the Gaussians during optimization.
 
-        self._did_first_refinement = True
-        return n_dupli, n_split, n_prune
+        Args:
+            indices_or_mask (torch.Tensor): A 1D tensor of indices or a boolean mask indicating which Gaussians to keep.
+                It must have shape (num_gaussians,).
+        """
+        self._model = self._model[indices_or_mask]
+        self._update_optimizer_for_model(lambda x: x[indices_or_mask])
 
     @torch.no_grad()
     def reset_opacities(self):
         """
-        Reset the opacities to the given (post-sigmoid) value.
+        Clamp the logit_opacities of all Gaussians to a small value above the deletion threshold.
+        This is useful to call periodically during optimization to prevent Gaussians from becoming
+        completely occluded by denser Gaussians, and thus unable to be optimized.
         """
-
         # Reset all opacities to twice the deletion threshold
         value = self._config.deletion_opacity_threshold * 2.0
+        self._model.logit_opacities.clamp_(max=torch.logit(torch.tensor(value)).item())
+        self._update_optimizer_for_model(lambda x: x.zero_(), parameter_names={"logit_opacities"})
 
-        def param_fn(name: str, p: torch.Tensor) -> torch.Tensor:
-            if name == "logit_opacities":
-                return torch.clamp(p, max=torch.logit(torch.tensor(value)).item())
-            else:
-                raise ValueError(f"Unexpected parameter name: {name}")
+    @torch.no_grad()
+    def refine(self, use_scales_for_pruning, use_screen_space_scales) -> tuple[int, int, int]:
+        """
+        Perform a step of refinement by inserting Gaussians where more detail is needed and deleting Gaussians that are not contributing to the optimization.
+        Refinement happens via three mechanisms:
 
-        def optimizer_fn(name: str, key: str, v: torch.Tensor) -> torch.Tensor:
-            return torch.zeros_like(v)
+        **Duplication**: Make two exact copies of a Gaussian.
+          - We duplicate a Gaussian if it's 3D size is below some threshold and the gradient of its projected means over time is high on
+            average. Intuitively, this means the Gaussian is not taking up a lot of space in the scene, but consistently wants to change positions
+            when viewed from different images. Likely this Gaussian is stuck trying to represent too much of the scene and should
+            be split into multiple copies.
 
-        # update the parameters and the state in the optimizers
-        params = self._update_optimizer(param_fn, optimizer_fn, "logit_opacities")
-        self._model.logit_opacities = params["logit_opacities"]
+        **Splitting**: Split a Gaussian into two smaller ones.
+          - We split a Gaussian when its 3D size exceeds a threshold value and the gradient of its projected mean over time is high on average.
+            In this case, a Gaussian is likely too large for the amount of detail it represents and should be split to capture detail in the image.
+
+        **Deletion**: Removing a Gaussian from the scene.
+          - We delete a Gaussian if its opacity falls below a threshold since it is not contributing much to rendered images.
+
+
+        Args:
+            use_scales_for_deletion: If set to True, use the 3D scales to decide whether to delete Gaussians that are too large.
+            use_screen_space_scales: If set to true, threshold the maximum projected size of Gaussians between refinement steps
+                                     to decide whether to split or delete Gaussians that are too large.
+                                     Note that the model must have been configured to track these scales by setting
+                                     GaussianSplat3d.track_max_2d_radii = True.
+
+        Returns:
+            num_duplicated (int): The number of Gaussians that were duplicated.
+            num_split (int): The number of Gaussians that were split.
+            num_deleted (int): The number of Gaussians that were deleted.
+        """
+
+        is_duplicated, is_split = self._compute_insertion_masks(use_screen_space_scales)
+        duplication_indices = torch.where(is_duplicated)[0]
+        num_duplicated = len(duplication_indices)
+
+        split_indices = torch.where(is_split)[0]
+        num_split = len(split_indices)
+
+        is_deleted = self._compute_deletion_mask(use_scales_for_pruning, use_screen_space_scales)
+        num_deleted = int(is_deleted.sum().item())
+
+        kept_indices = torch.where(~(is_deleted & ~is_split))[0]
+
+        # Get the new Gaussians to add from splitting and duplication
+        duplicated_gaussians = self._compute_duplicated_gaussians(duplication_indices)
+        split_gaussians = self._compute_split_gaussians(split_indices)
+
+        # We no longer need the accumulated gradient state since we've used it to compute masks for refinement
+        # Reset it so we can start accumulating for the next refinement step
+        self._model.reset_accumulated_gradient_state()
+        self._model.set_state(
+            means=torch.cat(
+                [self._model.means[kept_indices], duplicated_gaussians["means"], split_gaussians["means"]], dim=0
+            ),
+            quats=torch.cat(
+                [self._model.quats[kept_indices], duplicated_gaussians["quats"], split_gaussians["quats"]], dim=0
+            ),
+            log_scales=torch.cat(
+                [
+                    self._model.log_scales[kept_indices],
+                    duplicated_gaussians["log_scales"],
+                    split_gaussians["log_scales"],
+                ],
+                dim=0,
+            ),
+            logit_opacities=torch.cat(
+                [
+                    self._model.logit_opacities[kept_indices],
+                    duplicated_gaussians["logit_opacities"],
+                    split_gaussians["logit_opacities"],
+                ],
+                dim=0,
+            ),
+            sh0=torch.cat([self._model.sh0[kept_indices], duplicated_gaussians["sh0"], split_gaussians["sh0"]], dim=0),
+            shN=torch.cat([self._model.shN[kept_indices], duplicated_gaussians["shN"], split_gaussians["shN"]], dim=0),
+        )
+
+        def update_state_function(x: torch.Tensor):
+            total_gaussians = kept_indices.shape[0] + num_duplicated + num_split * 2
+            ret = torch.zeros([total_gaussians] + list(x.shape[1:]), dtype=x.dtype, device=x.device)
+            ret[: kept_indices.shape[0]] = x[kept_indices]
+            return ret
+
+        self._update_optimizer_for_model(update_state_function)
+
+        return num_duplicated, num_split, num_deleted
 
     @staticmethod
     def _make_optimizer(model, batch_size, config):
+        """
+        Make an Adam optimizer for the given model and config.
+        This is just a helper function used by the constructors since this logic is shared and verbose.
+
+        Args:
+            model (GaussianSplat3d): The model to optimize.
+            batch_size (int): The batch size used for training. This is used to scale the learning rates.
+            config (GaussianSplatOptimizerConfig): The configuration for the optimizer.
+
+        Returns:
+            torch.optim.Adam: An Adam optimizer for the model.
+        """
         # Scale learning rate based on batch size, reference:
         # https://www.cs.princeton.edu/~smalladi/blog/2024/01/22/SDEs-ScalingRules/
         # Note that this would not make the training exactly equivalent to the original INRIA
@@ -319,6 +445,31 @@ class GaussianSplatOptimizer:
         )
 
     def _compute_insertion_grad_2d_threshold(self, accumulated_mean_2d_gradients: torch.Tensor) -> float:
+        """
+        Compute the threshold on the accumulated norm of 2D mean gradients to use during refinement.
+
+        There are several modes for computing this threshold, specified by the config:
+        - CONSTANT: Always use the fixed threshold specified by self._config.insertion_grad_2d_threshold.
+        - PERCENTILE_FIRST_ITERATION: During the first refinement step, set the threshold to the given percentile of the gradients.
+            For all subsequent refinement steps, use that fixed threshold.
+        - PERCENTILE_EVERY_ITERATION: During every refinement step, set the threshold to the given percentile of the gradients.
+
+        These modes let you adapt the refinement behavior to the statistics of the gradients during training.
+        Generally CONSTANT with a default value (0.0002) will produce okay results, but may not be optimal for all types
+        of captures. Using PERCENTILE_FIRST_ITERATION will have similar behavior to CONSTANT but will adapt to the scale of the gradients
+        which can be more robust across different capture types.
+        For highly detailed, scenes, PERCENTILE_EVERY_ITERATION may be useful to adaptively insert more Gaussians as the model learns more detail.
+        This generally produces many more Gaussians and more detailed results at the cost of more memory and compute.
+
+        Args:
+            accumulated_mean_2d_gradients (torch.Tensor): The average norm of the projected mean gradients of shape (num_gaussians,).
+                This is typically obtained from `model.accumulated_mean_2d_gradient_norms / model.accumulated_gradient_step_counts`
+                where `model.accumulated_gradient_step_counts` is the number of optimization steps since the last refinement.
+
+        Returns:
+            float: The threshold value to use for deciding whether to insert Gaussians during refinement.
+        """
+
         # Helper to compute the quantile of the gradients, using NumPy if we have too many Gaussians for torch.quantile
         # which has a cap at 2**24 elements
         def _grad_2d_quantile(quantile: float) -> float:
@@ -355,291 +506,256 @@ class GaussianSplatOptimizer:
         else:
             raise RuntimeError("Invalid mode for insertion_grad_2d_threshold.")
 
-    @torch.no_grad()
-    def _grow_gs(self, use_screen_space_scales) -> tuple[int, int]:
+    def _compute_insertion_masks(
+        self, use_screen_space_scales_for_splitting: bool
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """
-        Grow the number of Gaussians via:
-          1. Duplicating those whose loss gradients are high and spatial size are small (i.e. have small eigenvals)
-          2. Splitting those whose loss gradients are high and spatial size are large (i.e. have large eigenvals)
-             or whose (2D projected) spatial extent simply exceeds the threshold self.grow_scale2d_threshold
-
-        Note: Splitting a Gaussian with mean μ and covariance Σ is implemented by sampling two new means
-              μ1, μ2 from N(μ, Σ), and setting the covariances Σ1 and Σ2 by dividing the eigenvalues of Σ by 1.6.
+        Compute boolean masks indicating which Gaussians should be duplicated or split.
 
         Args:
-            use_screen_space_scales: If set to true, use the tracked screen space scales to decide whether to split.
-                                     Note that the model must have been configured to track these scales by setting
-                                     GaussianSplat3d.track_max_2d_radii = True.
-        """
+            use_screen_space_scales_for_splitting: If set to true, use the tracked screen space scales to decide whether to split.
+                                              Note that the model must have been configured to track these scales by setting
+                                              GaussianSplat3d.track_max_2d_radii = True.
 
-        # We use the average gradient ( over the the last N steps) of the projected Gaussians with respect to the
-        # loss to decide which Gaussians to add/split/prune
-        # count is the number of times a Gaussian has been projected (i.e. included in the loss gradient computation)
-        # grad_2d is the sum of the gradients of the projected Gaussians (dL/dμ2D) over the last N steps
+        Returns:
+            duplication_mask (torch.Tensor): A boolean mask indicating which Gaussians should be duplicated.
+            split_mask (torch.Tensor): A boolean mask indicating which Gaussians should be split.
+        """
+        # We use the average norm of the gradients of the projected Gaussians with respect to the
+        # loss (accumulated since the last refinement step) to decide which Gaussians to duplicate or split.
+
+        # model.accumulated_gradient_step_counts is the number of times a Gaussian has been projected
+        # to an image (i.e. included in the loss gradient computation)
+        # model.accumulated_mean_2d_gradient_norms is the sum of norms of the gradients of the
+        # projected Gaussians (dL/dμ2D) since the last refinement step.
         count = self._model.accumulated_gradient_step_counts.clamp_min(1)
         if self._num_grad_accumulation_steps > 1:
+            # Multiply the 2D gradient count by the number of times we've called backward since the last zero_grad()
+            # to get the correct average if we're calling backward multiple times per iteration.
             count *= self._num_grad_accumulation_steps
+        avg_norm_of_projected_mean_gradients = self._model.accumulated_mean_2d_gradient_norms / count
 
-        grads = self._model.accumulated_mean_2d_gradient_norms / count
-        device = grads.device
-
-        # If the 2D projected gradient is high and the spatial size is small, duplicate the Gaussian
-        is_grad_high = grads > self._compute_insertion_grad_2d_threshold(grads)
+        # If the average norm of 2D projected gradients is high, that Gaussians is likely introducing
+        # a lot of error into the reconstruction, and is a candidate for duplication or splitting.
+        # We use the configured threshold to determine what "high" means.
+        # If the 3D scale is small, we duplicate the Gaussian to allow it to specialize.
+        # If the 3D scale is large, we split the Gaussian to allow it to specialize.
+        # Note that a Gaussian can be both duplicated and split if it meets both criteria.
+        # In that case, we will create 3 new Gaussians (2 from duplication and 2 from splitting, with
+        # one of the split Gaussians replacing the original).
+        is_grad_high = avg_norm_of_projected_mean_gradients > self._compute_insertion_grad_2d_threshold(
+            avg_norm_of_projected_mean_gradients
+        )
         is_small = self._model.scales.max(dim=-1).values <= self._config.insertion_scale_3d_threshold
-        is_dupli = is_grad_high & is_small
-        n_dupli: int = int(is_dupli.sum().item())
+        is_duplicated = is_grad_high & is_small
 
-        # If the 2D projected gradient is high and the spatial size is large, split the Gaussian
+        # If the Gaussian is high error and its 3d spatial size is large, split the Gaussian
         is_large = ~is_small
         is_split = is_grad_high & is_large
-
-        # If the 2D projected spatial extent exceeds the threshold, split the Gaussian
-        if use_screen_space_scales:
+        # If a Gaussian is high error, and it projects to a large size in screen space, split it
+        # This is only done if use_screen_space_scales_for_splitting is True
+        if use_screen_space_scales_for_splitting:
+            if not self._model.accumulate_max_2d_radii:
+                raise ValueError(
+                    "use_screen_space_scales_for_splitting is set to True but the model is not configured to "
+                    + "track screen space scales. Set model.accumulate_max_2d_radii = True."
+                )
             is_split |= self._model.accumulated_max_2d_radii > self._config.insertion_scale_2d_threshold
-        n_split: int = int(is_split.sum().item())
 
-        # Hardcode these for now but could be made configurable
-        dup_factor = 1  # 1 means one gaussian becomes 2, 2 means one gaussian becomes 3, etc.
-        split_factor = 2
-
-        # First duplicate the Gaussians
-        if n_dupli > 0:
-            self.duplicate_gaussians(mask=is_dupli, dup_factor=dup_factor)
-
-        # Track new Gaussians added by duplication so we we don't split them
-        is_split = torch.cat([is_split] + [torch.zeros(n_dupli, dtype=torch.bool, device=device)] * dup_factor)
-
-        # Now split the Gaussians
-        if n_split > 0:
-            self.subdivide_gaussians(mask=is_split, split_factor=split_factor)
-        return n_dupli, n_split
+        return is_duplicated, is_split
 
     @torch.no_grad()
-    def _prune_gs(self, use_scales: bool = False, use_screen_space_scales: bool = False) -> int:
-        # Prune any Gaussians whose opacity is below the threshold or whose (2D projected) spatial extent is too large
-        is_prune = self._model.opacities.flatten() < self._config.deletion_opacity_threshold
-        if use_scales:
+    def _compute_deletion_mask(
+        self, use_scales_for_deletion: bool, use_screen_space_scales_for_deletion: bool
+    ) -> torch.Tensor:
+        """
+        Compute a boolean mask indicating which Gaussians should be deleted.
+
+        Args:
+            use_scales_for_deletion: If set to true, use a threshold on the the 3D scales to delete Gaussians that are too large.
+            use_screen_space_scales_for_deletion: If set to true, use a threshold on the the maximum 2D projected scale
+                between refinements to delete Gaussians that are too large.
+
+        Returns:
+            deletion_mask (torch.Tensor): A boolean mask indicating which Gaussians should be deleted.
+        """
+        # Delete a Gaussians if its opacity is below the threshold (meaning it doesn't contribute much to rendered images)
+        is_deleted = self._model.opacities.flatten() < self._config.deletion_opacity_threshold
+
+        # If you specify it, we will also delete Gaussians that are too large since they are likely not contributing
+        # meaningfully to the reconstruction.
+        if use_scales_for_deletion:
             is_too_big = self._model.scales.max(dim=-1).values > self._config.deletion_scale_3d_threshold
-            # The INRIA code also implements sreen-size pruning but
-            # it's actually not being used due to a bug:
-            # https://github.com/graphdeco-inria/gaussian-splatting/issues/123
-            # We implement it here for completeness but it doesn't really get used
-            if use_screen_space_scales:
-                is_too_big |= self._model.accumulated_max_2d_radii > self._config.deletion_scale_2d_threshold
+            is_deleted.logical_or_(is_too_big)
 
-            is_prune = is_prune | is_too_big
+        # We can also use the tracked screen space scales to delete Gaussians that
+        # project to a very large size in screen space between refinement steps.
+        # This is only done if use_screen_space_scales_for_deletion is True
+        if use_screen_space_scales_for_deletion:
+            # Here we track the maximum size a Gaussian has projected to in screen space between refinement steps
+            # if it's too big, we delete it
+            has_projected_too_big = self._model.accumulated_max_2d_radii > self._config.deletion_scale_2d_threshold
+            is_deleted.logical_or_(has_projected_too_big)
 
-        n_prune = is_prune.sum().item()
-        if n_prune > 0:
-            self.remove_gaussians(mask=is_prune)
-
-        return int(n_prune)
+        return is_deleted
 
     @torch.no_grad()
-    def subdivide_gaussians(self, mask: torch.Tensor, split_factor: int = 2):
-        """
-        Split the Gaussian with the given mask.
-
-        Args:
-            mask: A boolean mask with shape [num_means,] indicating which Gaussians to split.
-            split_factor: The number of splits for each Gaussian. Default: 4.
-        """
-
-        def _normalized_quat_to_rotmat(quat_: torch.Tensor) -> torch.Tensor:
-            """Convert normalized quaternion to rotation matrix.
-
-            Args:
-                quat: Normalized quaternion in wxyz convension. (..., 4)
-
-            Returns:
-                Rotation matrix (..., 3, 3)
-            """
-            assert quat_.shape[-1] == 4, quat_.shape
-            w, x, y, z = torch.unbind(quat_, dim=-1)
-            mat = torch.stack(
-                [
-                    1 - 2 * (y**2 + z**2),
-                    2 * (x * y - w * z),
-                    2 * (x * z + w * y),
-                    2 * (x * y + w * z),
-                    1 - 2 * (x**2 + z**2),
-                    2 * (y * z - w * x),
-                    2 * (x * z - w * y),
-                    2 * (y * z + w * x),
-                    1 - 2 * (x**2 + y**2),
-                ],
-                dim=-1,
-            )
-            return mat.reshape(quat_.shape[:-1] + (3, 3))
-
-        device = mask.device
-        sel = torch.where(mask)[0]
-        rest = torch.where(~mask)[0]
-
-        scales = self._model.scales[sel]  # [N,]
-        quats = F.normalize(self._model.quats[sel], dim=-1)
-        rotmats = _normalized_quat_to_rotmat(quats)  # [N, 3, 3]
-        samples = torch.einsum(
-            "nij,nj,bnj->bni",
-            rotmats,
-            scales,
-            torch.randn(split_factor, len(scales), 3, device=device),
-        )  # [S, N, 3]
-
-        def param_fn(name: str, p: torch.Tensor) -> torch.Tensor:
-            repeats = [split_factor] + [1] * (p.dim() - 1)
-            cat_dim = 0
-            if name == "means":
-                p_split = (p[sel] + samples).reshape(-1, 3)  # [S*N, 3]
-                p_rest = p[rest]
-            elif name == "log_scales":
-                # TODO: Adjust scale factor for splitting
-                p_split = torch.log(scales / 1.6).repeat(split_factor, 1)  # [2N, 3]
-                p_rest = p[rest]
-            elif name == "logit_opacities" and self._config.opacity_updates_use_revised_formulation:
-                new_opacities = 1.0 - torch.sqrt(1.0 - torch.sigmoid(p[sel]))
-                p_split = torch.logit(new_opacities).repeat(repeats)  # [2N]
-                p_rest = p[rest]
-            else:
-                p_split = p[sel].repeat(repeats)
-                p_rest = p[rest]
-            p_new = torch.cat([p_rest, p_split], dim=cat_dim)
-            return p_new
-
-        def optimizer_fn(name: str, key: str, v: torch.Tensor) -> torch.Tensor:
-            v_split = torch.zeros((split_factor * len(sel), *v.shape[1:]), device=device)
-            v_rest = v[rest]
-            return torch.cat([v_rest, v_split], dim=0)
-
-        # update the parameters and the state in the optimizers
-        self._update_param_with_optimizer(param_fn, optimizer_fn)
-
-    @torch.no_grad()
-    def duplicate_gaussians(self, mask: torch.Tensor, dup_factor: int = 1):
-        """Duplicate the Gaussian with the given mask.
-
-        Args:
-            mask: A boolean mask of shape [num_means,] indicating which Gaussians to duplicate.
-            dup_factor: The number of times to duplicate the selected Gaussians.
-        """
-        device = mask.device
-        sel = torch.where(mask)[0]
-
-        def param_fn(name: str, p: torch.Tensor) -> torch.Tensor:
-            repeats = [dup_factor] + [1] * (p.dim() - 1)
-            p_sel = p[sel]
-            return torch.cat([p, p_sel.repeat(repeats)], dim=0)
-
-        def optimizer_fn(name: str, key: str, v: torch.Tensor) -> torch.Tensor:
-            zpad = torch.zeros((len(sel) * dup_factor, *v.shape[1:]), device=device)
-            return torch.cat([v, zpad])
-
-        # update the parameters and the state in the optimizers
-        self._update_param_with_optimizer(param_fn, optimizer_fn)
-
-    @torch.no_grad()
-    def remove_gaussians(self, mask: torch.Tensor):
-        """Remove the Gaussian with the given mask.
-
-        Args:
-            mask: A boolean mask of shape [num_means,] indicating which Gaussians to remove.
-        """
-        sel = torch.where(~mask)[0]
-
-        def param_fn(name: str, p: torch.Tensor) -> torch.Tensor:
-            return p[sel]
-
-        def optimizer_fn(name: str, key: str, v: torch.Tensor) -> torch.Tensor:
-            return v[sel]
-
-        # update the parameters and the state in the optimizers
-        self._update_param_with_optimizer(param_fn, optimizer_fn)
-
-    @torch.no_grad()
-    def _update_optimizer(
+    def _update_optimizer_for_model(
         self,
-        param_fn: Callable[[str, torch.Tensor], torch.Tensor],
-        optimizer_fn: Callable[[str, str, torch.Tensor], torch.Tensor],
-        parameter_name: str | None = None,
-    ) -> dict[str, torch.Tensor]:
-        # Each optimizer only manages one tensor, so it should have exactly one param_group with a single parameter
-        #
-        # An adam param_group has the form (in PyTorch 2.8.0):
-        # {
-        #     'lr': lr,
-        #     'name': name,
-        #     'betas': (beta1, beta2),
-        #     'eps': eps,
-        #     'weight_decay': weight_decay,
-        #     'amsgrad': amsgrad,
-        #     'maximize': False,
-        #     'foreach': None,
-        #     'capturable': False,
-        #     'differentiable': False,
-        #     'fused': None,
-        #     'decoupled_weight_decay': False,
-        #     'initial_lr': lr_at_creation,
-        #     'params': [parameter_tensor],
-        # }
-        # where the parameter_tensor is a reference to the tensor being optimized (e.g. model.means)
-        #
-        # The adam optimizer also keeps a running average of the gradients, their squares, and the step count
+        optimizer_fn: Callable[[torch.Tensor], torch.Tensor],
+        parameter_names: set[str] | None = None,
+    ):
+        """
+        After changing the tensors in the model (e.g. after refinement or resetting opacities),
+        we need to update the optimizer state to point to the new tensors.
 
-        params = dict()
+        This method copies the model's tensors into the optimizer's param groups so they continue to be optimized.
+        It also applies the the Adam moments for each parameter being updated 'exp_avg' and 'exp_avg_sq'.
+
+        Args:
+            optimizer_fn (Callable[[torch.Tensor], torch.Tensor]): A function to apply to each Adam moment Tensor for each parameter.
+                Accepts the old moment Tensor and returns the new moment Tensor.
+            parameter_names (set[str] | None): If provided, only update the parameter groups with these names. If None, update all parameter groups.
+        """
         for i, param_group in enumerate(self._optimizer.param_groups):
-            if parameter_name is not None and param_group["name"] != parameter_name:
+            parameter_name = param_group["name"]
+            if parameter_names is not None and param_group["name"] not in parameter_names:
                 continue
             assert len(param_group["params"]) == 1, "Expected one parameter tensor per param group"
-            p = param_group["params"][0]
-            name = param_group["name"]
-            new_state = self._optimizer.state[p]
-            del self._optimizer.state[p]
-            for key, value in new_state.items():
+            old_parameter = param_group["params"][0]
+            optimizer_state = self._optimizer.state[old_parameter]
+            del self._optimizer.state[old_parameter]
+            for key, value in optimizer_state.items():
                 if key != "step":
-                    new_state[key] = optimizer_fn(name, key, value)
-            new_parameter = param_fn(name, p)
+                    optimizer_state[key] = optimizer_fn(value)
+            new_parameter = getattr(self._model, parameter_name)
             new_parameter.requires_grad = True
+            self._optimizer.state[new_parameter] = optimizer_state
             self._optimizer.param_groups[i]["params"] = [new_parameter]
-            self._optimizer.state[new_parameter] = new_state
-            params[name] = new_parameter
-        return params
+
+        if self._model.device.type == "cuda":
+            torch.cuda.empty_cache()
 
     @torch.no_grad()
-    def _update_param_with_optimizer(
-        self,
-        param_fn: Callable[[str, torch.Tensor], torch.Tensor],
-        optimizer_fn: Callable[[str, str, torch.Tensor], torch.Tensor],
-        names: list[str] | None = None,
-    ):
-        """Update the parameters and the state in the optimizers with defined functions.
+    def _compute_duplicated_gaussians(self, duplication_indices: torch.Tensor) -> dict[str, torch.Tensor]:
+        duplication_factor = self._config.insertion_duplication_factor
+        if duplication_factor < 2:
+            raise ValueError("duplication_factor must be >= 2")
+
+        if duplication_indices.numel() == 0:
+            return {
+                "means": torch.empty((0, 3), device=self._model.device),
+                "quats": torch.empty((0, 4), device=self._model.device),
+                "log_scales": torch.empty((0, 3), device=self._model.device),
+                "logit_opacities": torch.empty((0,), device=self._model.device),
+                "sh0": torch.empty((0, 1, 3), device=self._model.device),
+                "shN": torch.empty((0, self._model.shN.shape[1], 3), device=self._model.device),
+            }
+
+        num_new_gaussians = duplication_factor - 1  # We already have one copy of each Gaussian in the model
+
+        means_to_add = self._model.means[duplication_indices].repeat(num_new_gaussians, 1)  # [(D-1)*M, 3]
+        log_scales_to_add = self._model.log_scales[duplication_indices].repeat(num_new_gaussians, 1)  # [(D-1)*M, 3]
+        quats_to_add = self._model.quats[duplication_indices].repeat(num_new_gaussians, 1)  # [(D-1)*M, 4]
+        sh0_to_add = self._model.sh0[duplication_indices].repeat(num_new_gaussians, 1, 1)  # [(D-1)*M, 1, 3]
+        shN_to_add = self._model.shN[duplication_indices].repeat(num_new_gaussians, 1, 1)  # [(D-1)*M, K-1, 3]
+
+        if self._config.opacity_updates_use_revised_formulation:
+            # Update opacity values for the new Gaussians using the revised formulation from
+            # the paper "Revising Densification in Gaussian Splatting" (https://arxiv.org/abs/2404.06109).
+            # This removes a bias which weighs newly split Gaussians contribution to the image more heavily than
+            # older Gaussians.
+            logit_opacities_to_add = torch.logit(1.0 - torch.sqrt(1.0 - self._model.opacities[duplication_indices]))
+            logit_opacities_to_add = logit_opacities_to_add.repeat(num_new_gaussians)  # [(D-1)*M,]
+        else:
+            logit_opacities_to_add = self._model.logit_opacities[duplication_indices].repeat(
+                num_new_gaussians
+            )  # [(D-1)*M,]
+
+        return {
+            "means": means_to_add,
+            "quats": quats_to_add,
+            "log_scales": log_scales_to_add,
+            "logit_opacities": logit_opacities_to_add,
+            "sh0": sh0_to_add,
+            "shN": shN_to_add,
+        }
+
+    @torch.no_grad()
+    def _compute_split_gaussians(self, split_indices: torch.Tensor) -> dict[str, torch.Tensor]:
+        split_factor = self._config.insertion_split_factor
+        if split_indices.numel() == 0:
+            return {
+                "means": torch.empty((0, 3), device=self._model.device),
+                "quats": torch.empty((0, 4), device=self._model.device),
+                "log_scales": torch.empty((0, 3), device=self._model.device),
+                "logit_opacities": torch.empty((0,), device=self._model.device),
+                "sh0": torch.empty((0, 1, 3), device=self._model.device),
+                "shN": torch.empty((0, self._model.shN.shape[1], 3), device=self._model.device),
+            }
+        if split_factor < 2:
+            raise ValueError("split_factor must be >= 2")
+
+        split_scales = self._model.scales[split_indices]  # [M, 3]
+        split_quats = nnf.normalize(self._model.quats[split_indices], dim=-1)  # [M, 4]
+        rotmats = self._unit_quats_to_rotation_matrices(split_quats)  # [M, 3, 3]
+        split_mean_offsets = torch.einsum(
+            "nij,nj,bnj->bni",
+            rotmats,
+            split_scales,
+            torch.randn(split_factor, split_indices.shape[0], 3, device=self._model.device),
+        )  # [S, N, 3]
+
+        means_to_add = (self._model.means[split_indices] + split_mean_offsets).reshape(-1, 3)  # [S*M, 3]
+        log_scales_to_add = torch.log(split_scales / (0.8 * split_factor)).repeat(split_factor, 1)  # [S*M, 3]
+        quats_to_add = self._model.quats[split_indices].repeat(split_factor, 1)  # [S*M, 4]
+        sh0_to_add = self._model.sh0[split_indices].repeat(split_factor, 1, 1)  # [S*M, 1, 3]
+        shN_to_add = self._model.shN[split_indices].repeat(split_factor, 1, 1)  # [S*M, K-1, 3]
+
+        if self._config.opacity_updates_use_revised_formulation:
+            # Update opacity values for the new Gaussians using the revised formulation from
+            # the paper "Revising Densification in Gaussian Splatting" (https://arxiv.org/abs/2404.06109).
+            # This removes a bias which weighs newly split Gaussians contribution to the image more heavily than
+            # older Gaussians.
+            logit_opacities_to_add = torch.logit(1.0 - torch.sqrt(1.0 - self._model.opacities[split_indices]))
+            logit_opacities_to_add = logit_opacities_to_add.repeat(split_factor)  # [S*M]
+        else:
+            logit_opacities_to_add = self._model.logit_opacities[split_indices].repeat(split_factor)  # [S*M]
+
+        return {
+            "means": means_to_add,
+            "quats": quats_to_add,
+            "log_scales": log_scales_to_add,
+            "logit_opacities": logit_opacities_to_add,
+            "sh0": sh0_to_add,
+            "shN": shN_to_add,
+        }
+
+    @staticmethod
+    def _unit_quats_to_rotation_matrices(quaternions: torch.Tensor) -> torch.Tensor:
+        """
+        Convert a tensor of unit quaternions (encoding 3d rotations) to a tensor of rotation matrices.
 
         Args:
-            param_fn: A function that takes the name of the parameter and the parameter itself,
-                and returns the new parameter.
-            optimizer_fn: A function that takes the key of the optimizer state and the state value,
-                and returns the new state value.
-            params: A dictionary of parameters.
-            optimizers: A dictionary of optimizers, each corresponding to a parameter.
-            names: A list of key names to update. If None, update all. Default: None.
-        """
-        params = {
-            "means": self._model.means,
-            "log_scales": self._model.log_scales,
-            "quats": self._model.quats,
-            "logit_opacities": self._model.logit_opacities,
-            "sh0": self._model.sh0,
-            "shN": self._model.shN,
-        }
-        if names is None:
-            # If names is not provided, update all parameters
-            names = list(params.keys())
+            quaternions (torch.Tensor): A Tensor of unit quaternions in wxyz convention with shape [*, 4]
 
-        params = self._update_optimizer(param_fn, optimizer_fn)
-        self._model.set_state(
-            means=params["means"],
-            quats=params["quats"],
-            log_scales=params["log_scales"],
-            logit_opacities=params["logit_opacities"],
-            sh0=params["sh0"],
-            shN=params["shN"],
+        Returns:
+            rotation_matrices (torch.Tensor): A tensor of rotation matrices of shape [*, 3, 3]
+        """
+        assert quaternions.shape[-1] == 4, quaternions.shape
+        w, x, y, z = torch.unbind(quaternions, dim=-1)
+        mat = torch.stack(
+            [
+                1 - 2 * (y**2 + z**2),
+                2 * (x * y - w * z),
+                2 * (x * z + w * y),
+                2 * (x * y + w * z),
+                1 - 2 * (x**2 + z**2),
+                2 * (y * z - w * x),
+                2 * (x * z - w * y),
+                2 * (y * z + w * x),
+                1 - 2 * (x**2 + y**2),
+            ],
+            dim=-1,
         )
+        return mat.reshape(quaternions.shape[:-1] + (3, 3))

--- a/fvdb_reality_capture/training/scene_optimization_runner.py
+++ b/fvdb_reality_capture/training/scene_optimization_runner.py
@@ -1053,7 +1053,7 @@ class SceneOptimizationRunner:
 
         # Viewer
         # self._viewer = ViewerLogger(self.model, self._training_dataset) if not disable_viewer else None
-        self._viewer = Viewer(ip_address="127.0.0.1", port=8080, verbose=False) if not disable_viewer else None
+        self._viewer = Viewer(ip_address="127.0.0.1", port=8888, verbose=False) if not disable_viewer else None
         if self._viewer is not None:
             with torch.no_grad():
                 self._viewer.add_gaussian_splat_3d("Gaussian Scene", self.model)
@@ -1277,8 +1277,8 @@ class SceneOptimizationRunner:
                     use_screen_space_scales_for_refinement: bool = self._global_step < refine_using_scale2d_stop_step
                     if not use_screen_space_scales_for_refinement:
                         self.model.accumulate_max_2d_radii = False
-                    num_dup, num_split, num_prune = self.optimizer.refine_gaussians(
-                        use_scales=use_scales_for_refinement,
+                    num_dup, num_split, num_prune = self.optimizer.refine(
+                        use_scales_for_pruning=use_scales_for_refinement,
                         use_screen_space_scales=use_screen_space_scales_for_refinement,
                     )
                     self._logger.debug(
@@ -1299,7 +1299,7 @@ class SceneOptimizationRunner:
                         outside_mask = torch.logical_or(outside_mask, points[:, 2] < bbox_min[2])
                         outside_mask = torch.logical_or(outside_mask, points[:, 2] > bbox_max[2])
 
-                        self.optimizer.remove_gaussians(outside_mask)
+                        self.optimizer.filter_gaussians(outside_mask)
                         ng_post = self.model.num_gaussians
                         nclip = ng_prior - ng_post
                         self._logger.debug(

--- a/visualize.py
+++ b/visualize.py
@@ -13,7 +13,7 @@ from fvdb.viz import Viewer
 
 def main(
     ply_path: pathlib.Path,
-    viewer_port: int = 8080,
+    viewer_port: int = 8888,
     verbose: bool = False,
     device: str | torch.device = "cuda",
 ):
@@ -38,11 +38,10 @@ def main(
         camera_origin=first_cam_pos, lookat_point=model.means.mean(dim=0).cpu().numpy(), up_direction=[0, 0, 1]
     )
 
-    # TODO: Bring back after viewer fix
-    # assert isinstance(metadata["projection_matrices"], torch.Tensor)
-    # viewer.add_camera_view(
-    #     "training cameras", metadata["camera_to_world_matrices"].cpu(), metadata["projection_matrices"].cpu()
-    # )
+    assert isinstance(metadata["projection_matrices"], torch.Tensor)
+    viewer.add_camera_view(
+        "training cameras", metadata["camera_to_world_matrices"].cpu(), metadata["projection_matrices"].cpu()
+    )
     logger = logging.getLogger("visualize")
     logger.info("Viewer running... Ctrl+C to exit.")
     time.sleep(1000000)


### PR DESCRIPTION
This PR adds much needed documentation and cleanup to `GaussianSplatOptimizer`.

It renames variables and functions to be consistent with our teminology:
 - refinement means inserting or deleting Gaussians
 - inserting Gaussians can be done via duplication or splitting

This PR also cleans up the `GaussianSplatOptimizer` to use a single Adam optimizer rather than one per parameter. This seems to make things faster and also makes the code much easier to read. The refinement logic is then split up into updating the model, and then copying the updated paramters to this optimizer via a single call to `_update_optimizer_for_model`. This gets called once during refinement rather than multiple times, reducing memory overhead and copies. I also clear the Pytorch allocator cache after updating the optimizer since this is often a torture case (Where we're constantly allocating a chunk that's too large and the allocator needs to double the size of the pool). This reduces memory usage to around half. 