### PR TITLE
Optimize linear interpolation between L1 and SSIM loss

### DIFF
--- a/fvdb_reality_capture/training/scene_optimization_runner.py
+++ b/fvdb_reality_capture/training/scene_optimization_runner.py
@@ -1232,7 +1232,7 @@ class SceneOptimizationRunner:
                         colors.permute(0, 3, 1, 2).contiguous(),
                         pixels.permute(0, 3, 1, 2).contiguous(),
                     )
-                    loss = l1loss * (1.0 - self.config.ssim_lambda) + ssimloss * self.config.ssim_lambda
+                    loss = torch.lerp(l1loss, ssimloss, self.config.ssim_lambda)
 
                     # Rgularize opacity to ensure Gaussian's don't become too opaque
                     if self.config.opacity_reg > 0.0:


### PR DESCRIPTION
Instead of performing two `torch.adds`, a `torch.mul`, and a `torch.sub`, we can fuse/optimize these operations into a single equivalent `torch.lerp` call to reduce memory bandwidth and the number of temporary intermediate tensors. Even though it's just a single element, it makes a marginal/noticeable difference, likely due to the reduced number of CUDA API calls required.