### PR TITLE
Add extra parameters for meshing

### DIFF
--- a/extract_mesh.py
+++ b/extract_mesh.py
@@ -19,6 +19,8 @@ def main(
     near: float = 0.1,
     far: float = 4.0,
     use_scene_scale_units: bool = True,
+    alpha_threshold: float = 0.1,
+    image_downsample_factor: int = 1,
     output_path: pathlib.Path = pathlib.Path("mesh.ply"),
     device: str = "cuda",
 ):
@@ -33,6 +35,10 @@ def main(
             from the surface of the model.
         near (float): Near plane distance (as a multiple of the scene scale) below which we'll ignore depth samples (default is 0.1).
         far (float): Far plane distance (as a multiple of the scene scale) above which we'll ignore depth samples.
+        alpha_threshold (float): Alpha threshold to mask pixels where the Gaussian splat model is transparent,
+            usually indicating the background. (default is 0.1).
+        image_downsample_factor (int): Factor by which to downsample the rendered images for
+            depth estimation (default is 1, _i.e._ no downsampling).
         use_scene_scale_units (bool): Whether to use scene scale units for the near, plane, far plane and truncation margin.
         output_path (pathlib.Path): Path to save the extracted mesh (default is "mesh.ply").
         device (str): Device to use for computation (default is "cuda").
@@ -83,6 +89,8 @@ def main(
         grid_shell_thickness=grid_shell_thickness,
         near=near,
         far=far,
+        alpha_threshold=alpha_threshold,
+        image_downsample_factor=image_downsample_factor,
         show_progress=True,
     )
 

--- a/extract_mesh_dlnr.py
+++ b/extract_mesh_dlnr.py
@@ -20,6 +20,8 @@ def main(
     near: float = 4.0,
     far: float = 20.0,
     disparity_reprojection_threshold: float = 3.0,
+    alpha_threshold: float = 0.1,
+    image_downsample_factor: int = 1,
     dlnr_backbone: str = "middleburry",
     output_path: pathlib.Path = pathlib.Path("mesh.ply"),
     use_absolute_baseline: bool = False,
@@ -46,6 +48,10 @@ def main(
         near (float): Near plane distance (as a multiple of the baseline) below which we'll ignore depth samples (default is 4.0).
         far (float): Far plane distance (as a multiple of the baseline) above which we'll ignore depth samples (default is 20.0).
         disparity_reprojection_threshold (float): Reprojection error threshold for occlusion masking in pixels (default is 3.0).
+        alpha_threshold (float): Alpha threshold to mask pixels where the Gaussian splat model is transparent,
+            usually indicating the background. (default is 0.1).
+        image_downsample_factor (int): Factor by which to downsample the rendered images for
+            depth estimation (default is 1, _i.e._ no downsampling).
         dlnr_backbone (str): Backbone to use for the DLNR model, either "middleburry" or "sceneflow" (default is "middleburry").
         output_path (pathlib.Path): Path to save the extracted mesh (default is "mesh.ply").
         use_absolute_baseline (bool): If True, use the provided baseline as an absolute distance in world units (default is False).
@@ -94,6 +100,8 @@ def main(
         near=near,
         far=far,
         disparity_reprojection_threshold=disparity_reprojection_threshold,
+        alpha_threshold=alpha_threshold,
+        image_downsample_factor=image_downsample_factor,
         dlnr_backbone=dlnr_backbone,
         use_absolute_baseline=use_absolute_baseline,
         show_progress=True,

--- a/fvdb_reality_capture/tools/_common.py
+++ b/fvdb_reality_capture/tools/_common.py
@@ -1,0 +1,60 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import torch
+from fvdb.types import (
+    NumericMaxRank2,
+    NumericMaxRank3,
+    to_Mat33fBatch,
+    to_Mat44fBatch,
+    to_Vec2iBatch,
+)
+
+
+def validate_camera_matrices_and_image_sizes(
+    camera_to_world_matrices: NumericMaxRank3,
+    projection_matrices: NumericMaxRank3,
+    image_sizes: NumericMaxRank2,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Validate the shapes of the camera matrices and image sizes. This function converts input
+    tensor-like objects to torch.Tensors and checks their shapes.
+
+    The constraints are:
+    - camera_to_world_matrices must have shape (C, 4, 4) where C is the number of cameras.
+    - projection_matrices must have shape (C, 3, 3) where C is the number of cameras.
+    - image_sizes must have shape (C, 2) where C is the number of cameras.
+
+    Args:
+        camera_to_world_matrices (torch.Tensor): A (C, 4, 4)-shaped Tensor-like object containing camera to world
+            matrices where C is the number of camera views.
+        projection_matrices (torch.Tensor): A (C, 3, 3)-shaped Tensor-like object containing perspective projection matrices
+            where C is the number of camera views.
+        image_sizes (torch.Tensor): A (C, 2)-shaped Tensor-like object containing the width and height of each image.
+
+        Returns:
+            valid_camera_to_world_matrices (torch.Tensor): The validated camera to world matrices with shape (C, 4, 4).
+            valid_projection_matrices (torch.Tensor): The validated projection matrices with shape (C, 3, 3).
+            valid_image_sizes (torch.Tensor): The validated image sizes with shape (C, 2).
+    """
+    camera_to_world_matrices = to_Mat44fBatch(camera_to_world_matrices)
+
+    num_cameras = camera_to_world_matrices.shape[0]
+    if camera_to_world_matrices.shape != (num_cameras, 4, 4):
+        raise ValueError(
+            f"Expected camera_to_world_matrices to have shape (C, 4, 4) where C is the number of cameras, but got {camera_to_world_matrices.shape}"
+        )
+
+    projection_matrices = to_Mat33fBatch(projection_matrices)
+    if projection_matrices.shape != (num_cameras, 3, 3):
+        raise ValueError(
+            f"Expected projection_matrices to have shape (C, 3, 3) where C is the number of cameras, but got {projection_matrices.shape}"
+        )
+
+    image_sizes = to_Vec2iBatch(image_sizes)
+    if image_sizes.shape != (num_cameras, 2):
+        raise ValueError(
+            f"Expected image_sizes to have shape (C, 2) where C is the number of cameras, but got {image_sizes.shape}"
+        )
+
+    return camera_to_world_matrices, projection_matrices, image_sizes


### PR DESCRIPTION
This PR adds parameters for thresholding low opacity rendered pixels (which are usually in the background) as well as an image downsample factor (which can be needed for very large images). Tested locally on a few datasets. 