### PR TITLE
Remove 'viser' from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "torchvision",
     "tqdm",
     "tyro",
-    "viser",
     "usd-core",
     "msgpack",
     "types-usd",


### PR DESCRIPTION
Removed 'viser' from the dependencies list.