### PR TITLE
Fix performance regression in Gaussian splat loss computation

### DIFF
--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -1161,7 +1161,7 @@ class GaussianSplatReconstruction:
                         colors.permute(0, 3, 1, 2).contiguous(),
                         pixels.permute(0, 3, 1, 2).contiguous(),
                     )
-                    loss = torch.lerp(l1loss, ssimloss, self.config.ssim_lambda)
+                    loss = torch.lerp(l1loss, ssimloss, self.config.ssim_lambda)  # type: ignore
 
                     # Rgularize opacity to ensure Gaussian's don't become too opaque
                     if self.config.opacity_reg > 0.0:


### PR DESCRIPTION
Calling `torch.Tensor([self.config.ssim_lambda]).to(ssimloss)` leads to an unnecessary allocation of a torch.Tensor followed by a cudaMemcpy. Instead, it can just be passed as a parameter directly and PyTorch will use the Scalar interpolation parameter overload of the operator.