### PR TITLE
Fix tensorboard add_images

### DIFF
--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction_writer.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction_writer.py
@@ -520,7 +520,7 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
 
         if self._config.use_tensorboard and self._config.save_images_to_tensorboard and hasattr(self, "_tb_writer"):
             if hasattr(self, "_tb_writer") and self._tb_writer is not None:
-                self._tb_writer.add_images(image_name, image, global_step)
+                self._tb_writer.add_images(image_name, image.permute(0, 3, 1, 2).contiguous(), global_step)
 
     @torch.no_grad()
     def save_checkpoint(self, global_step: int, checkpoint_name: str, checkpoint: dict[str, Any]) -> None:


### PR DESCRIPTION
Fix `GaussianSplatReconstructionWriter.save_image` which needs to permute image axes before writing an image to Tensorboard

Signed-off-by: Jonathan Swartz <jonathan@jswartz.info>