### PR TITLE
Fix restarting from checkpoint for reconstruction

### DIFF
--- a/fvdb_reality_capture/cli/frgs/_resume.py
+++ b/fvdb_reality_capture/cli/frgs/_resume.py
@@ -86,7 +86,7 @@ class Resume(BaseCommand):
         logger = logging.getLogger(__name__)
 
         logger.info(f"Loading checkpoint at {self.checkpoint_path}")
-        checkpoint_state = torch.load(self.checkpoint_path, map_location=self.device)
+        checkpoint_state = torch.load(self.checkpoint_path, map_location=self.device, weights_only=False)
 
         writer = GaussianSplatReconstructionWriter(
             run_name=self.run_name, save_path=self.io.log_path, config=self.io, exist_ok=False


### PR DESCRIPTION
Our checkpoints require `weights_only=False`. Otherwise they fail with:

```
2025-10-23 12:21:19,315 - fvdb_reality_capture.cli.frgs._resume - INFO - Loading checkpoint at frgs_logs/run_2025-10-22-23-40-48/checkpoints/00055500/reconstruct_ckpt.pt
Traceback (most recent call last):
  File "/home/mcong/venv/bin/frgs", line 7, in <module>
    sys.exit(frgs())
  File "/home/mcong/fvdb-reality-capture/fvdb_reality_capture/cli/frgs/__init__.py", line 25, in frgs
    cmd.execute()
  File "/home/mcong/fvdb-reality-capture/fvdb_reality_capture/cli/frgs/_resume.py", line 89, in execute
    checkpoint_state = torch.load(self.checkpoint_path, map_location=self.device)
  File "/home/mcong/venv/lib/python3.10/site-packages/torch/serialization.py", line 1531, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL numpy._core.multiarray.scalar was not an allowed global by default. Please use `torch.serialization.add_safe_globals([numpy._core.multiarray.scalar])` or the `torch.serialization.safe_globals([numpy._core.multiarray.scalar])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
```