### PR TITLE
Fix typo in sensor data loading tutorial

### DIFF
--- a/docs/tutorials/sensor_data_loading_and_manipulation.md
+++ b/docs/tutorials/sensor_data_loading_and_manipulation.md
@@ -673,7 +673,7 @@ plot_three_images_with_bbox(tx_scene, "Three images from a normalized, downsampl
 
 
 
-**⚠️ Caveat about transform oder ⚠️**
+**⚠️ Caveat about transform order ⚠️**
 One caveat about composing transforms is that for some transforms, *order matters*. For example, when you crop a scene, the image masks are pre-computed as part of the transformation. If you normalize the scene after cropping, your images and bounding boxes won't match as expected. This is expected behavior. We are working on solutions to configure this behavior in an upcoming release.
 
 Here we show an example where we crop the scene, which caches image masks, and then normalize the scene. Note how the plotted bounding boxes don't align with the image mask.

--- a/notebooks/sensor_data_loading_and_manipulation.ipynb
+++ b/notebooks/sensor_data_loading_and_manipulation.ipynb
@@ -947,7 +947,7 @@
    "id": "c61c1e98",
    "metadata": {},
    "source": [
-    "**⚠️ Caveat about transform oder ⚠️**\n",
+    "**⚠️ Caveat about transform order ⚠️**\n",
     "One caveat about composing transforms is that for some transforms, *order matters*. For example, when you crop a scene, the image masks are pre-computed as part of the transformation. If you normalize the scene after cropping, your images and bounding boxes won't match as expected. This is expected behavior. We are working on solutions to configure this behavior in an upcoming release.\n",
     "\n",
     "Here we show an example where we crop the scene, which caches image masks, and then normalize the scene. Note how the plotted bounding boxes don't align with the image mask."


### PR DESCRIPTION
- "oder" -> "order"
