### PR TITLE
Fix incorrect cache path when resuming from checkpoint

### DIFF
--- a/fvdb_reality_capture/sfm_scene/sfm_scene.py
+++ b/fvdb_reality_capture/sfm_scene/sfm_scene.py
@@ -248,7 +248,7 @@ class SfmScene:
             "transformation_matrix": (
                 self._transformation_matrix.tolist() if self._transformation_matrix is not None else None
             ),
-            "cache_path": self._cache.cache_root_path.absolute().as_posix(),
+            "cache_path": self._cache.db_path.parent.absolute().as_posix(),
             "cache_name": self._cache.cache_name,
             "cache_description": self._cache.cache_description,
         }


### PR DESCRIPTION
When starting a reconstruction from scratch, `get_cache` is called with the `db_path.parent` (i.e. `_cache`) and `cache_root_path = db.path.parent + ('/cache_1')` resolves to `_cache/cache_1` under which the downsampled images and their associated file lock are stored. However, when resuming from a checkpoint, `get_cache` is incorrectly called with the `cache_root_path` which leads to a new subdirectory being created underneath the `cache_1` subdirectory resulting in a path similar to `_cache/cache_1/cache_1`. This directory nesting becomes deeper each time you resume from a checkpoint ultimately resulting in a path similar to `_cache/cache_1/cache_1/cache_1/cache_1/cache_1/cache_1`.