### PR TITLE
Fix for nightly job being triggered in forked repos

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   # Get current commit hash of fvdb-core main and store in a variable
   get-fvdb-core-commit-hash:
+    if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Get fvdb-core commit hash
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Fix fork repositories running the 'get-fvdb-core-commit-hash' job nightly even though downstream jobs don't run; they have an appropriate conditional