### PR TITLE
downsample and cache  SfM masks; use cached masks

### DIFF
--- a/fvdb_reality_capture/transforms/downsample_images.py
+++ b/fvdb_reality_capture/transforms/downsample_images.py
@@ -181,7 +181,6 @@ class DownsampleImages(BaseTransform):
                 if output_cache.has_file(cache_mask_filename):
                     mask_file_meta = output_cache.get_file_metadata(cache_mask_filename)
                     mask_path = str(mask_file_meta["path"])
-                    print("using cached mask", mask_path)
 
             new_image_metadata.append(
                 SfmPosedImageMetadata(


### PR DESCRIPTION
If there are masks in colmap database:

- if cache is empty (or number of images or masks changed), downsample and cache them alongside images (but with .png file type and cv2.INTER_NEAREST_EXACT interpolation)
- use cached masks in consequtive runs

Fixes #208 and #206