### PR TITLE
Fix nightly benchmark failures due to git clean of output file

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -325,7 +325,7 @@ jobs:
         run: |
           micromamba activate fvdb
           cd tests;
-          pytest benchmarks --benchmark-json benchmarks/output.json --ignore=benchmarks/test_benchmark_contract.py
+          pytest benchmarks/test_3dgs.py --benchmark-json benchmarks/output.json
 
       - name: Add commit metadata to benchmark results
         run: |
@@ -352,7 +352,8 @@ jobs:
           # Remove the locally modified benchmark_config.yaml to avoid conflicts when switching branches
           # This file is downloaded and modified by download_checkpoints_from_s3.py
           git checkout -- tests/benchmarks/benchmark_config.yaml || true
-          git clean -fd tests/benchmarks/ || true
+          # Clean up but exclude output.json which contains benchmark results
+          git clean -fd tests/benchmarks/ -e tests/benchmarks/output.json || true
 
       - name: Store benchmark result
         id: store-benchmark

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ _build
 docs/build
 *tmp*.py
 *.whl
-tests/benchmark/data
+tests/benchmarks/data
+tests/benchmarks/output.json
 releases/
 /data/
 /data/*

--- a/tests/benchmarks/test_3dgs.py
+++ b/tests/benchmarks/test_3dgs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
+import multiprocessing
 import os
 import pathlib
 import sys
@@ -12,6 +13,11 @@ import torch
 import torch.nn.functional as F
 import torch.utils.data
 import yaml
+
+# Set multiprocessing start method to 'spawn' to avoid fork() warnings with PyTorch
+# This must be done before any multiprocessing operations
+if multiprocessing.get_start_method(allow_none=True) != "spawn":
+    multiprocessing.set_start_method("spawn", force=True)
 
 from fvdb_reality_capture.radiance_fields import (
     GaussianSplatOptimizerMCMCConfig,


### PR DESCRIPTION
Previously I added a git clean step in the nightly benchmark workflow which unintentially deletes the output of the benchmark before uploading it.

This fixes that and also eliminates some deprecation warnings when running the benchmark.

Signed-off-by: Mark Harris <mharris@nvidia.com>