### PR TITLE
Fix NameError: training_images not defined in run_gsplat_training.py

### DIFF
--- a/tests/benchmarks/comparative/benchmark_utils/run_gsplat_training.py
+++ b/tests/benchmarks/comparative/benchmark_utils/run_gsplat_training.py
@@ -172,7 +172,7 @@ def run_gsplat_training(
     logging.info(f"  sh_degree_interval_steps: {sh_degree_interval_steps}")
     logging.info(f"  reset_every_steps: {reset_every_steps}")
     logging.info(f"  refine_scale2d_stop_steps: {refine_scale2d_stop_steps}")
-    logging.info(f"  Training images: {training_images}")
+    logging.info(f"  Training images: {params.get('training_images', 'N/A')}")
     logging.info(f"  Total images: {params.get('total_images', 'N/A')}")
 
     data_base_path = run_config.get("paths", {}).get("data_base", "/workspace/data")

--- a/tests/benchmarks/test_comparison_benchmark.py
+++ b/tests/benchmarks/test_comparison_benchmark.py
@@ -23,6 +23,13 @@ def _load_comparison_benchmark_module():
     return module, comparative_dir
 
 
+def _get_build_gsplat_cli_args():
+    _load_comparison_benchmark_module()  # ensures sys.path includes comparative dir
+    from benchmark_utils.run_gsplat_training import build_gsplat_cli_args
+
+    return build_gsplat_cli_args
+
+
 def _write_minimal_report(report_path: Path, include_time_series: bool = False) -> None:
     metrics = {"psnr": 1.0, "ssim": 1.0, "final_gaussian_count": 1}
 
@@ -396,3 +403,63 @@ training_arguments:
     assert "test_commits" in report
     assert "repositories" in report["test_commits"]
     assert "fvdb_core" in report["test_commits"]["repositories"]
+
+
+# ---------------------------------------------------------------------------
+# build_gsplat_cli_args tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGsplatCliArgs:
+    @pytest.fixture(autouse=True)
+    def _load_func(self):
+        self.build_args = _get_build_gsplat_cli_args()
+
+    def test_empty_config_returns_empty_list(self):
+        assert self.build_args({}) == []
+        assert self.build_args({"training": {}}) == []
+        assert self.build_args({"training": {"config": {}}}) == []
+
+    def test_scalar_params_mapped(self):
+        opt_config = {"training": {"config": {"near_plane": 0.01, "far_plane": 1e10}}}
+        args = self.build_args(opt_config)
+        assert "--near_plane" in args
+        assert args[args.index("--near_plane") + 1] == "0.01"
+        assert "--far_plane" in args
+        assert args[args.index("--far_plane") + 1] == "10000000000.0"
+
+    def test_boolean_true_adds_flag(self):
+        opt_config = {"training": {"config": {"antialias": True}}}
+        args = self.build_args(opt_config)
+        assert "--antialiased" in args
+
+    def test_boolean_false_omits_flag(self):
+        opt_config = {"training": {"config": {"antialias": False, "random_bkgd": False}}}
+        args = self.build_args(opt_config)
+        assert args == []
+
+    def test_unmapped_params_ignored(self):
+        opt_config = {"training": {"config": {"unknown_param": 42, "near_plane": 0.5}}}
+        args = self.build_args(opt_config)
+        assert "--near_plane" in args
+        assert len(args) == 2  # flag + value, nothing for unknown_param
+
+    def test_mixed_types(self):
+        opt_config = {
+            "training": {
+                "config": {
+                    "near_plane": 0.01,
+                    "antialias": True,
+                    "random_bkgd": False,
+                    "sh_degree": 3,
+                    "optimize_camera_poses": True,
+                }
+            }
+        }
+        args = self.build_args(opt_config)
+        assert "--near_plane" in args
+        assert "--antialiased" in args
+        assert "--random_bkgd" not in args
+        assert "--sh_degree" in args
+        assert args[args.index("--sh_degree") + 1] == "3"
+        assert "--pose_opt" in args


### PR DESCRIPTION
## Summary

- Fix `NameError: name 'training_images' is not defined` in `run_gsplat_training.py` line 175, which broke nightly comparative benchmarks since PR #240
- The refactoring in #240 removed the local `training_images` variable but left a logging line referencing it; now reads from `params.get('training_images', 'N/A')` consistent with the adjacent `total_images` line
- Add unit tests for `build_gsplat_cli_args()` (new function from #240 that had no test coverage)

Fixes #246

## Test plan

- [x] `pytest tests/benchmarks/test_comparison_benchmark.py -v` -- all 14 tests pass (8 existing + 6 new)
- [x] `black --target-version=py311 --line-length=120` reports no changes needed

Made with [Cursor](https://cursor.com)