### PR TITLE
Add __version__ attribute to fvdb_reality_capture package

### DIFF
--- a/fvdb_reality_capture/__init__.py
+++ b/fvdb_reality_capture/__init__.py
@@ -2,10 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from importlib.metadata import PackageNotFoundError, version
+
 from . import dev, foundation_models, radiance_fields, sfm_scene, tools, transforms
 from .tools import download_example_data
 
+try:
+    __version__ = version("fvdb_reality_capture")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"
+
 __all__ = [
+    "__version__",
     "dev",
     "foundation_models",
     "radiance_fields",


### PR DESCRIPTION
## Summary

- Expose `__version__` via `importlib.metadata.version()` in `fvdb_reality_capture/__init__.py`
- Falls back to `"0.0.0.dev0"` for editable/uninstalled development installs
- Exported in `__all__` for discoverability

Fixes #254

## Test plan

```python
import fvdb_reality_capture
print(fvdb_reality_capture.__version__)  # e.g. "0.3.1"
```

- Verify `__version__` matches `pyproject.toml` version when installed via `pip install .`
- Verify fallback `"0.0.0.dev0"` when running from source without installing