### PR TITLE
Add matplotlib to benchmark optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 benchmark = [
     "gitpython",
+    "matplotlib",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Add `matplotlib` to the `[project.optional-dependencies] benchmark` group in `pyproject.toml`
- The comparison benchmark tests (`test_comparison_benchmark.py`) and tools like `_tsdf_from_splats_dlnr.py` import `matplotlib.pyplot`, but it was not declared as a dependency

Fixes #255

## Test plan

```bash
pip install .[benchmark]
pip show matplotlib  # should be installed
cd tests && pytest -v benchmarks/test_comparison_benchmark.py
```