### PR TITLE
Use actions/setup-python for validation containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -370,8 +370,15 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - name: Install Python and pip
-        run: apt update && apt install -y python3.12 python3-pip
+      - name: Install prerequisites
+        run: apt update && apt install -y git wget
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+        env:
+          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
@@ -426,8 +433,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Python and pip
-        run: apt update && apt install -y python3.12 python3-pip git
+      - name: Install prerequisites
+        run: apt update && apt install -y git wget
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+        env:
+          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
       - name: Download dist artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Use `actions/setup-python@v5` in smoke test and unit test validation
  containers instead of bare `apt install python3.12`. The `nvidia/cuda`
  Ubuntu 22.04 containers only have Python 3.10 in their default apt repos;
  Python 3.12 requires the deadsnakes PPA. This matches the approach used
  by the fvdb-core build and validation jobs.

## Test plan

- [ ] Trigger publish workflow via `workflow_dispatch` with `run_validation: true`;
  verify smoke test and unit test jobs pass