### PR TITLE
Use uv for Python installation in publish.yml CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -448,12 +448,12 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Install prerequisites
+        run: dnf install -y git wget
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Install prerequisites
-        run: dnf install -y git wget
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86


### PR DESCRIPTION
Replace `actions/setup-python@v5` with `astral-sh/setup-uv` to manage Python installation and virtual environment setup.