### PR TITLE
Release publishing: PyPI + S3 production

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
       - 'release/v[0-9]*'
   workflow_dispatch:
     inputs:
+      branch:
+        description: "Branch to build"
+        required: true
+        default: "main"
       publish_target:
         description: "Publish target: testpypi | s3 | release | none"
         required: false
@@ -86,6 +90,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
@@ -483,6 +488,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86


### PR DESCRIPTION
Decouple PyPI and S3 publish targets so both run on release. Previously a release tag only published to PyPI; now it uploads sdist and wheel to production PyPI and additionally uploads the wheel to the S3 simple/ production index.

Add independent routing flags (pypi, s3, is_release) to replace the single mutually-exclusive s3 flag. Add "release" as a workflow_dispatch publish_target option so the release flow can be re-triggered manually if it fails. Gate the .post version suffix to TestPyPI-only publishes. S3 uploads are now wheel-only since sdists live on PyPI.