### PR TITLE
Adopt release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fvdb_reality_capture"
-version = "0.4.0"
+version = "0.5.0.dev0"
 description = "fVDB Reality Capture Toolbox."
 authors = [
     {name = "Francis Williams", email = "francis@fwilliams.info"},


### PR DESCRIPTION
## Adopt release v0.4.0

Merge release changes from `release/v0.4` into `main` via the
`adopt/v0.4` branch. The version in `pyproject.toml` has been set to
the current `main` development version to avoid conflicts.

**Tag:** `v0.4.0`

This PR replaces the original release PR (#266) which was
closed because `release/v0.4` intentionally carries a different version
string (`0.4.0`) than `main`.

### To merge

Merge this PR once CI passes. Use a **merge commit** (not squash) to preserve
the release branch history on `main`.