### PR TITLE
Fix nightly benchmark: update PyTorch 2.8->2.10 and CUDA 12.9->13.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -263,6 +263,7 @@ jobs:
       env:
         PYTHONPATH: ""
         CPM_SOURCE_CACHE: "/__w/cpm_cache"
+        CONDA_OVERRIDE_CUDA: "13.0"
       options: --rm
     defaults:
       run:
@@ -462,6 +463,7 @@ jobs:
       env:
         PYTHONPATH: ""
         CPM_SOURCE_CACHE: "/__w/cpm_cache"
+        CONDA_OVERRIDE_CUDA: "13.0"
       options: --rm --shm-size 16gb
     defaults:
       run:

--- a/tests/benchmarks/comparative/docker/Dockerfile
+++ b/tests/benchmarks/comparative/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM condaforge/miniforge3:24.11.3-2
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CONDA_AUTO_UPDATE_CONDA=false
-ENV CONDA_OVERRIDE_CUDA=12.9
+ENV CONDA_OVERRIDE_CUDA=13.0
 ENV PATH="/opt/conda/bin:$PATH"
 
 # Install system dependencies for building

--- a/tests/benchmarks/comparative/docker/benchmark_environment.yml
+++ b/tests/benchmarks/comparative/docker/benchmark_environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - cuda-cudart-dev
   - cuda-nvrtc-dev
   - cuda-nvtx-dev
-  - cuda-version=12.9
+  - cuda-version=13.0
   - cxx-compiler
   - gcc_linux-64=13
   - git
@@ -40,11 +40,11 @@ dependencies:
   - pkg-config
   - polyscope
   - psutil
-  - pybind11=2.13.6
+  - pybind11
   - py-opencv>=4.10[build=headless*]
   - pytest-benchmark
   - python=3.12
-  - pytorch-gpu=2.8.0
+  - pytorch-gpu=2.10.0
   - rich
   - scikit-build-core
   - scikit-learn
@@ -67,9 +67,9 @@ dependencies:
   - pip:
     - point-cloud-utils
     - pytest-markdown-docs
-    - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
-    - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
-    - https://nksr.s3.ap-northeast-1.amazonaws.com/dev-whls/pt28cu129/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
+    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
+    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
+    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
     - oiio-static-python
     - dlnr_lite
     - einops


### PR DESCRIPTION
## Summary

- The nightly benchmarks have been failing since March 11 because fvdb-core is now built with **PyTorch 2.10.0 / CUDA 13.0**, but the benchmark environment still used **PyTorch 2.8.0 / CUDA 12.9**. The compiled fvdb C++ extensions cannot load against the mismatched libtorch ABI, causing an import failure at the first step that runs Python code (`frgs download mipnerf360`).
- Updates `benchmark_environment.yml` to PyTorch 2.10.0 / CUDA 13.0 and points torchsparse, torchsparse_20, and torch_scatter wheel URLs at the `pt210cu130` builds on the fvdb-packages S3 bucket.
- Adds `CONDA_OVERRIDE_CUDA: "13.0"` to both benchmark job containers in `nightly.yml` so conda can resolve CUDA 13.0 packages inside the `aswf/ci-openvdb` container.
- Updates the comparative benchmark `Dockerfile` to match (`CONDA_OVERRIDE_CUDA=13.0`).

## Test plan

- [x] Trigger a manual workflow dispatch of the nightly benchmark targeting branch `mjh/fix-nightly-benchmark` to verify the unit benchmarks pass
- [x] Verify the comparative benchmarks also pass
- [x] Confirm all three wheel URLs are accessible (verified locally: all return HTTP 200)