### PR TITLE
Add event-driven issue triage labels workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,49 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+
+# ISSUES_PAT needs Organization > Members > Read to check fvdb-dev team
+# membership. GITHUB_TOKEN handles labeling via issues: write.
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    if: github.repository_owner == 'openvdb'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add triage label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "triage"
+
+      - name: Check team membership
+        id: membership
+        env:
+          GH_TOKEN: ${{ secrets.ISSUES_PAT }}
+        run: |
+          AUTHOR="${{ github.event.issue.user.login }}"
+          if gh api "orgs/openvdb/teams/fvdb-dev/memberships/$AUTHOR" \
+               --silent 2>/dev/null; then
+            echo "member=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "member=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add external label
+        if: steps.membership.outputs.member == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "external"


### PR DESCRIPTION
## Summary

- Add `issue-triage.yml` workflow that labels new/reopened issues with `triage`,
  and `external` if the author is not on the `fvdb-dev` team.

Companion to openvdb/fvdb-core#551.

## Test plan

- [x] Verified `ISSUES_PAT` secret is set and can read fvdb-dev team members