### PR TITLE
Harden issue-triage workflow membership check

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -38,7 +38,7 @@ jobs:
           AUTHOR="${{ github.event.issue.user.login }}"
           RESPONSE=$( (gh api "orgs/openvdb/teams/fvdb-dev/memberships/$AUTHOR" \
             -i --silent 2>&1 || true) )
-          HTTP_CODE=$(printf '%s\n' "$RESPONSE" | grep -m1 '^HTTP/' | awk '{print $2}')
+          HTTP_CODE=$(printf '%s\n' "$RESPONSE" | grep -m1 '^HTTP/' | awk '{print $2}' || true)
           case "$HTTP_CODE" in
             200) echo "member=true"  >> "$GITHUB_OUTPUT" ;;
             404) echo "member=false" >> "$GITHUB_OUTPUT" ;;


### PR DESCRIPTION
## Summary

- Validate `ISSUES_PAT` is configured before calling the GitHub API
- Parse the HTTP status code robustly (grep for `^HTTP/` line instead of
  assuming it is the first line of output)
- Distinguish 404 (not a member) from auth/config errors (fail the workflow)
- Guard all pipelines against `set -e` / `pipefail` so expected non-zero
  exits don't terminate the step prematurely
- Surface the raw API response on unexpected failures for easier debugging

Companion to openvdb/fvdb-core#551.

## Test plan

- Verified `ISSUES_PAT` secret is set and can read fvdb-dev team members