### PR TITLE
Fix nightly benchmark artifact download JSONDecodeError

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,6 +163,14 @@ jobs:
         if: steps.download_existing_wheel.outcome == 'success'
         run: echo "Artifact 'fvdb-wheel-${{ needs.get-fvdb-core-commit-hash.outputs.fvdb_core_commit_hash }}' exists. No need to rebuild."
 
+      - name: Upload downloaded fvdb wheel (make available to this run)
+        if: steps.download_existing_wheel.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fvdb-wheel-${{ needs.get-fvdb-core-commit-hash.outputs.fvdb_core_commit_hash }}
+          path: fvdb-core/dist/*.whl
+          retention-days: 30
+
       # TODO: DRY this up with an anchor
       - name: Clone fvdb-core
         if: steps.download_existing_wheel.outcome == 'failure'
@@ -288,14 +296,10 @@ jobs:
           environment-file: tests/benchmarks/comparative/docker/benchmark_environment.yml
 
       - name: Download fvdb-core wheel
-        uses: dawidd6/action-download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: fvdb-wheel-${{ needs.get-fvdb-core-commit-hash.outputs.fvdb_core_commit_hash }}
           path: ./dist
-          workflow: nightly.yml
-          workflow_conclusion: ""
-          search_artifacts: true
-          if_no_artifact_found: fail
 
       - name: Install fVDB and fvdb-reality-capture
         run: |
@@ -483,14 +487,10 @@ jobs:
           environment-file: tests/benchmarks/comparative/docker/benchmark_environment.yml
 
       - name: Download fvdb-core wheel
-        uses: dawidd6/action-download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: fvdb-wheel-${{ needs.get-fvdb-core-commit-hash.outputs.fvdb_core_commit_hash }}
           path: ./dist
-          workflow: nightly.yml
-          workflow_conclusion: ""
-          search_artifacts: true
-          if_no_artifact_found: fail
 
       - name: Install fVDB and fvdb-reality-capture
         run: |

--- a/tests/benchmarks/test_3dgs.py
+++ b/tests/benchmarks/test_3dgs.py
@@ -178,52 +178,53 @@ def create_benchmark_params():
     """Create benchmark parameters from YAML configuration."""
     original_cwd = pathlib.Path.cwd()
     try:
-        # Change to the directory of the current test file
+        # Change to the directory of the current test file so that relative paths
+        # in benchmark_config.yaml (e.g. ../../data, results/...) resolve correctly.
         test_file_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(test_file_dir)
         config = load_benchmark_config(config_path="benchmark_config.yaml")
+
+        params = []
+
+        data_base_path = config["paths"]["data_base"]
+
+        for dataset_config in config["datasets"]:
+            dataset_name = dataset_config["name"]
+            dataset_path = str(pathlib.Path(data_base_path) / dataset_config["path"])
+            run_path = dataset_config["run_directory"]
+
+            logger.info(f"Dataset: {dataset_name}")
+            logger.info(f"Dataset path: {dataset_path}")
+
+            if "checkpoint_paths" in dataset_config and dataset_config["checkpoint_paths"]:
+                checkpoint_paths = dataset_config["checkpoint_paths"]
+                logger.info(f"Checkpoint paths: {dataset_config['checkpoint_paths']}")
+            else:
+                raise ValueError(f"No checkpoint paths specified for dataset: {dataset_name}")
+
+            for checkpoint_path in checkpoint_paths:
+                checkpoint_id = f"{pathlib.Path(dataset_path).name}-{pathlib.Path(checkpoint_path).parent.name}"
+                missing_artifacts = []
+                if not pathlib.Path(dataset_path).exists():
+                    missing_artifacts.append(f"dataset '{dataset_path}'")
+                if not pathlib.Path(checkpoint_path).exists():
+                    missing_artifacts.append(f"checkpoint '{checkpoint_path}'")
+                if missing_artifacts:
+                    params.append(
+                        pytest.param(
+                            (dataset_path, run_path, checkpoint_path),
+                            id=checkpoint_id,
+                            marks=pytest.mark.skip(
+                                reason="Missing local benchmark artifacts: " + ", ".join(missing_artifacts)
+                            ),
+                        )
+                    )
+                else:
+                    params.append(pytest.param((dataset_path, run_path, checkpoint_path), id=checkpoint_id))
+
+        return params
     finally:
         os.chdir(original_cwd)
-
-    params = []
-
-    data_base_path = config["paths"]["data_base"]
-
-    for dataset_config in config["datasets"]:
-        dataset_name = dataset_config["name"]
-        dataset_path = str(pathlib.Path(data_base_path) / dataset_config["path"])
-        run_path = dataset_config["run_directory"]
-
-        logger.info(f"Dataset: {dataset_name}")
-        logger.info(f"Dataset path: {dataset_path}")
-
-        if "checkpoint_paths" in dataset_config and dataset_config["checkpoint_paths"]:
-            checkpoint_paths = dataset_config["checkpoint_paths"]
-            logger.info(f"Checkpoint paths: {dataset_config['checkpoint_paths']}")
-        else:
-            raise ValueError(f"No checkpoint paths specified for dataset: {dataset_name}")
-
-        for checkpoint_path in checkpoint_paths:
-            checkpoint_id = f"{pathlib.Path(dataset_path).name}-{pathlib.Path(checkpoint_path).parent.name}"
-            missing_artifacts = []
-            if not pathlib.Path(dataset_path).exists():
-                missing_artifacts.append(f"dataset '{dataset_path}'")
-            if not pathlib.Path(checkpoint_path).exists():
-                missing_artifacts.append(f"checkpoint '{checkpoint_path}'")
-            if missing_artifacts:
-                params.append(
-                    pytest.param(
-                        (dataset_path, run_path, checkpoint_path),
-                        id=checkpoint_id,
-                        marks=pytest.mark.skip(
-                            reason="Missing local benchmark artifacts: " + ", ".join(missing_artifacts)
-                        ),
-                    )
-                )
-            else:
-                params.append(pytest.param((dataset_path, run_path, checkpoint_path), id=checkpoint_id))
-
-    return params
 
 
 @pytest.fixture(

--- a/tests/benchmarks/test_benchmark_contract.py
+++ b/tests/benchmarks/test_benchmark_contract.py
@@ -68,6 +68,72 @@ def test_checkpoint_contract_accepts_mcmc_optimizer_config():
     contract.validate_checkpoint_contract(state)
 
 
+def test_create_benchmark_params_is_cwd_independent(tmp_path: pathlib.Path):
+    """Ensure create_benchmark_params() gives consistent results regardless of caller cwd.
+
+    Regression test for a bug where path existence checks ran after os.chdir()
+    restored the original cwd, making all benchmarks skip in CI.
+    """
+    import os
+
+    from .test_3dgs import create_benchmark_params, load_benchmark_config
+
+    # Create the benchmark artifacts that the config references, so the test
+    # can distinguish "found" from "not found" rather than trivially matching
+    # two identical all-skipped results.
+    benchmarks_dir = pathlib.Path(__file__).parent
+    original_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(benchmarks_dir)
+        config = load_benchmark_config()
+    finally:
+        os.chdir(original_cwd)
+
+    data_base = config["paths"]["data_base"]
+    created = []
+    for ds in config["datasets"]:
+        dp = benchmarks_dir / data_base / ds["path"]
+        dp.mkdir(parents=True, exist_ok=True)
+        created.append(dp)
+        for cp in ds.get("checkpoint_paths", []):
+            cp_path = benchmarks_dir / cp
+            cp_path.parent.mkdir(parents=True, exist_ok=True)
+            cp_path.touch(exist_ok=True)
+            created.append(cp_path)
+
+    try:
+        # Run from two different directories and compare
+        params_from_benchmarks_dir = create_benchmark_params()
+
+        os.chdir(tmp_path)
+        try:
+            params_from_tmp = create_benchmark_params()
+        finally:
+            os.chdir(original_cwd)
+
+        assert len(params_from_benchmarks_dir) == len(params_from_tmp)
+        for a, b in zip(params_from_benchmarks_dir, params_from_tmp):
+            assert a.values == b.values
+            a_marks = [m.mark for m in a.marks]
+            b_marks = [m.mark for m in b.marks]
+            assert a_marks == b_marks
+
+        # Verify the artifacts were actually found (not trivially all-skipped)
+        non_skipped = [p for p in params_from_benchmarks_dir if not p.marks]
+        assert len(non_skipped) > 0, "Expected some non-skipped params but all were skipped"
+    finally:
+        # Clean up created artifacts (in reverse to remove children before parents)
+        for p in reversed(created):
+            if p.is_file():
+                p.unlink()
+            elif p.is_dir():
+                # Only remove if we created it (empty)
+                try:
+                    p.rmdir()
+                except OSError:
+                    pass
+
+
 def test_benchmark_config_yaml_matches_contract():
     config_path = pathlib.Path(__file__).parent / "benchmark_config.yaml"
     config = contract.load_benchmark_yaml(str(config_path))


### PR DESCRIPTION
## Summary

- Re-upload downloaded fvdb-core wheel as a current-run artifact in the build job, so it's always available to downstream benchmark jobs
- Replace `dawidd6/action-download-artifact@v3` (cross-run search) with `actions/download-artifact@v4` (same-run) in both benchmark jobs
- Eliminates the `JSONDecodeError` caused by empty/non-JSON GitHub API responses during cross-run artifact search

Closes #277

## Test plan

- [x] Trigger a `workflow_dispatch` run of the nightly workflow on this branch
- [x] Verify the build job uploads the wheel artifact (whether freshly built or reused)
- [x] Verify both benchmark jobs successfully download the wheel from the current run

🤖 Generated with [Claude Code](https://claude.com/claude-code)