### PR TITLE
Fix crash when accumulated_gradient_step_counts is None during refinement

### DIFF
--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer.py
@@ -835,6 +835,22 @@ class GaussianSplatOptimizer(BaseGaussianSplatOptimizer):
         # We use the average norm of the gradients of the projected Gaussians with respect to the
         # loss (accumulated since the last refinement step) to decide which Gaussians to duplicate or split.
 
+        # Guard against None gradient accumulation tensors. This can happen when a projection method
+        # (e.g., Unscented Transform for OpenCV camera models) does not accumulate 2D mean gradients.
+        if (
+            self._model.accumulated_gradient_step_counts is None
+            or self._model.accumulated_mean_2d_gradient_norms is None
+        ):
+            self._logger.warning(
+                "Gradient accumulation data is unavailable (accumulated_gradient_step_counts or "
+                "accumulated_mean_2d_gradient_norms is None). This is expected when using a projection "
+                "method that does not support gradient accumulation (e.g., Unscented Transform for "
+                "OpenCV camera models). Skipping Gaussian insertion for this refinement step."
+            )
+            device = self._model.means.device
+            N = self._model.num_gaussians
+            return torch.zeros(N, dtype=torch.bool, device=device), torch.zeros(N, dtype=torch.bool, device=device)
+
         # model.accumulated_gradient_step_counts is the number of times a Gaussian has been projected
         # to an image (i.e. included in the loss gradient computation)
         # model.accumulated_mean_2d_gradient_norms is the sum of norms of the gradients of the

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer.py
@@ -841,15 +841,20 @@ class GaussianSplatOptimizer(BaseGaussianSplatOptimizer):
             self._model.accumulated_gradient_step_counts is None
             or self._model.accumulated_mean_2d_gradient_norms is None
         ):
-            self._logger.warning(
-                "Gradient accumulation data is unavailable (accumulated_gradient_step_counts or "
-                "accumulated_mean_2d_gradient_norms is None). This is expected when using a projection "
-                "method that does not support gradient accumulation (e.g., Unscented Transform for "
-                "OpenCV camera models). Skipping Gaussian insertion for this refinement step."
-            )
+            if not getattr(self, "_warned_missing_gradient_accumulation", False):
+                self._logger.warning(
+                    "Gradient accumulation data is unavailable (accumulated_gradient_step_counts or "
+                    "accumulated_mean_2d_gradient_norms is None). This is expected when using a projection "
+                    "method that does not support gradient accumulation (e.g., Unscented Transform for "
+                    "OpenCV camera models). Skipping Gaussian insertion for this refinement step."
+                )
+                self._warned_missing_gradient_accumulation = True
             device = self._model.means.device
             N = self._model.num_gaussians
-            return torch.zeros(N, dtype=torch.bool, device=device), torch.zeros(N, dtype=torch.bool, device=device)
+            return (
+                torch.zeros(N, dtype=torch.bool, device=device),
+                torch.zeros(N, dtype=torch.bool, device=device),
+            )
 
         # model.accumulated_gradient_step_counts is the number of times a Gaussian has been projected
         # to an image (i.e. included in the loss gradient computation)

--- a/tests/unit/test_gaussian_splat_optimizer.py
+++ b/tests/unit/test_gaussian_splat_optimizer.py
@@ -116,6 +116,34 @@ class GaussianSplatOptimizerRefinementTests(GettysburgGaussianSplatTestCase, uni
             loss.backward()
             self.optimizer.step()
 
+    def test_refinement_with_none_gradient_accumulation(self):
+        """Regression test for issue #279: refine() must not crash when gradient accumulation state is None.
+
+        When the Unscented Transform projection path is used (e.g., for OpenCV camera models),
+        fvdb-core does not initialize accumulated_gradient_step_counts or
+        accumulated_mean_2d_gradient_norms. Calling set_state() also resets them to None.
+        The optimizer must handle this gracefully by skipping insertion (duplication/splitting).
+        """
+        model = self.model
+        optimizer = self.optimizer
+
+        # Simulate the UT projection path: set_state() resets gradient tensors to None
+        model.set_state(
+            means=model.means,
+            quats=model.quats,
+            log_scales=model.log_scales,
+            logit_opacities=model.logit_opacities,
+            sh0=model.sh0,
+            shN=model.shN,
+        )
+        self.assertIsNone(model.accumulated_gradient_step_counts)
+        self.assertIsNone(model.accumulated_mean_2d_gradient_norms)
+
+        # refine() should not crash — it should skip insertion and return zero counts
+        refine_stats = optimizer.refine(zero_gradients=True)
+        self.assertEqual(refine_stats["num_duplicated"], 0)
+        self.assertEqual(refine_stats["num_split"], 0)
+
     def test_refinement_no_op(self):
         model = self.model
         optimizer = self.optimizer

--- a/tests/unit/test_gaussian_splat_optimizer.py
+++ b/tests/unit/test_gaussian_splat_optimizer.py
@@ -128,14 +128,15 @@ class GaussianSplatOptimizerRefinementTests(GettysburgGaussianSplatTestCase, uni
         optimizer = self.optimizer
 
         # Simulate the UT projection path: set_state() resets gradient tensors to None
-        model.set_state(
-            means=model.means,
-            quats=model.quats,
-            log_scales=model.log_scales,
-            logit_opacities=model.logit_opacities,
-            sh0=model.sh0,
-            shN=model.shN,
-        )
+        with torch.no_grad():
+            model.set_state(
+                means=model.means,
+                quats=model.quats,
+                log_scales=model.log_scales,
+                logit_opacities=model.logit_opacities,
+                sh0=model.sh0,
+                shN=model.shN,
+            )
         self.assertIsNone(model.accumulated_gradient_step_counts)
         self.assertIsNone(model.accumulated_mean_2d_gradient_norms)
 


### PR DESCRIPTION
## Summary
- Add defensive None guard in `_compute_insertion_masks` to handle the case where gradient accumulation tensors are `None` (e.g., when using the Unscented Transform projection path for OpenCV camera models)
- Add regression test that reproduces the exact `AttributeError` from issue #279

## Root Cause

When COLMAP datasets use non-pinhole camera models (SIMPLE_RADIAL, RADIAL, OPENCV), fvdb maps them to `CameraModel.OPENCV_RADTAN_5`, which forces the UT projection path in fvdb-core. The UT path does not initialize `accumulated_gradient_step_counts` or `accumulated_mean_2d_gradient_norms`, leaving them as `None`. At the first refinement step, `_compute_insertion_masks()` crashes calling `.clamp_min(1)` on `None`.

The companion fvdb-core fix is at harrism/fvdb-core#1 — these two fixes are independent and can be merged in any order.

## Behavioral impact

When the UT projection path is used, no Gaussians will be duplicated or split during refinement (since no gradient data is available to make that decision). Deletion still works. Training converges, just without adaptive densification — a reasonable degradation until fvdb-core adds gradient accumulation to the UT kernel.

Closes #279

## Test plan
- [x] New test `test_refinement_with_none_gradient_accumulation` reproduces the crash (red before fix, green after)
- [x] All 9 optimizer tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)