### PR TITLE
Configuration for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-fvdb.ai/reality-capture

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,9 @@ author = "Contributors to the OpenVDB Project"
 # Updated automatically by fvdb-core's devtools/update-doc-versions.sh during release.
 fvdb_core_stable_version = "0.4.0"
 
+version = fvdb_core_stable_version
+release = fvdb_core_stable_version
+
 rst_prolog = f"""\
 .. |fvdb_core_version_pt210_cu128| replace:: {fvdb_core_stable_version}+pt210.cu128
 .. |fvdb_core_version_pt210_cu130| replace:: {fvdb_core_stable_version}+pt210.cu130
@@ -68,6 +71,31 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "wip"]
 
 autodoc_default_options = {"undoc-members": "forward, extra_repr"}
 
+# Mock compiled / GPU / heavy dependencies so Sphinx can introspect the
+# Python API on build hosts that lack CUDA (e.g. Read the Docs).
+autodoc_mock_imports = [
+    "_fvdb_cpp",
+    "boto3",
+    "botocore",
+    "cv2",
+    "dlnr_lite",
+    "fvdb",
+    "msgpack",
+    "numpy",
+    "point_cloud_utils",
+    "pxr",
+    "pye57",
+    "pyproj",
+    "requests",
+    "sam2",
+    "scipy",
+    "skimage",
+    "torch",
+    "torchvision",
+    "tqdm",
+    "tyro",
+]
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -76,13 +104,20 @@ autodoc_default_options = {"undoc-members": "forward, extra_repr"}
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {"analytics_id": "G-60P7VJJ09C"}  # Google Analytics ID
 
+html_context = {
+    "display_github": True,
+    "github_user": "openvdb",
+    "github_repo": "fvdb-reality-capture",
+    "github_version": "main",
+    "conf_py_path": "/docs/",
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = [
     "tutorials/radiance_field_and_mesh_reconstruction_files",
     "tutorials/sensor_data_loading_and_manipulation_files",
-    "CNAME",
     "_static",
 ]
 html_css_files = [
@@ -92,9 +127,6 @@ html_css_files = [
 myst_heading_anchors = 3
 
 # -- Custom hooks ------------------------------------------------------------
-
-print("SYS EXECUTABLE", sys.executable)
-print("SYS PATH", sys.path)
 
 
 def process_signature(app, what, name, obj, options, signature, return_annotation):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=7.0.0
+sphinx-rtd-theme
+myst-parser
+linkify-it-py


### PR DESCRIPTION
This pull request introduces configuration and documentation improvements to support building the documentation with Read the Docs.

**Read the Docs integration and documentation build improvements:**

* Added a `.readthedocs.yaml` configuration file to enable building documentation on Read the Docs using Ubuntu 24.04 and Python 3.12, and to specify Sphinx and Python requirements.
* Created `docs/requirements.txt` to list Sphinx and related documentation dependencies, ensuring consistent builds locally and on Read the Docs.

**Sphinx configuration enhancements:**

* Updated `docs/conf.py` to set `version` and `release` dynamically from the stable version, and added `autodoc_mock_imports` to mock heavy or unavailable dependencies (e.g., CUDA, compiled modules) so Sphinx can generate API docs even if those dependencies are not present. [[1]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R26-R28) [[2]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R74-R98)
* Added `html_context` to `docs/conf.py` to enable GitHub integration in the generated docs, and removed `CNAME` from `html_static_path` because we no longer use the fvdb.ai domain.
* Cleaned up debug print statements from `docs/conf.py` for a cleaner build process.

**Other documentation cleanup:**

* Removed the custom domain configuration from `docs/CNAME`, we don't use the fvdb.ai domain any longer.