### PR TITLE
Fix incorrect camera matrices in scene normalization

### DIFF
--- a/fvdb_reality_capture/transforms/normalize_scene.py
+++ b/fvdb_reality_capture/transforms/normalize_scene.py
@@ -267,7 +267,7 @@ class NormalizeScene(BaseTransform):
         """
         if self._normalization_transform is None:
             points = input_scene.points
-            world_to_camera_matrices = input_scene.camera_to_world_matrices
+            world_to_camera_matrices = input_scene.world_to_camera_matrices
 
             if points is None or len(points) == 0:
                 self._logger.warning("No points found in the SfmScene.")


### PR DESCRIPTION
The scene normalization code incorrectly stores a local reference to `camera_to_world_matrices` instead of `world_to_camera_matrices` which leads to an incorrect inverted transform being passed to the similarity normalization leading to an incorrect scene scale.