### PR TITLE
Add cross-library TSDF / ESDF / Occupancy benchmark drivers

### DIFF
--- a/tests/benchmarks/tsdf_fusion/README.md
+++ b/tests/benchmarks/tsdf_fusion/README.md
@@ -1,0 +1,51 @@
+<!--
+  Copyright Contributors to the OpenVDB Project
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# TSDF / ESDF / Occupancy cross-library benchmarks
+
+Benchmark drivers comparing fvdb against external sparse-voxel
+libraries (nvblox, VDBFusion, Open3D) on real and synthetic RGB-D /
+LiDAR workloads.
+
+The drivers live in [`cross_library/`](cross_library/) and are
+organised by dataset and workload:
+
+| Driver                          | Dataset            | Workload                                        |
+|---------------------------------|--------------------|-------------------------------------------------|
+| `bench_open3d_vs_fvdb.py`       | Synthetic sphere   | TSDF, fvdb vs Open3D                            |
+| `bench_replica_full.py`         | Replica            | TSDF + ESDF, multi-scene, full frame rate       |
+| `bench_esdf_replica.py`         | Replica            | ESDF scale sweep                                |
+| `bench_kitti.py`                | KITTI Odometry     | LiDAR TSDF                                      |
+| `bench_esdf_kitti.py`           | KITTI Odometry     | LiDAR ESDF                                      |
+| `bench_occupancy_kitti.py`      | KITTI Odometry     | LiDAR occupancy                                 |
+| `bench_decay_kitti.py`          | KITTI Odometry     | Dynamic-scene decay-and-prune                   |
+| `bench_mai_city.py`             | Mai City (LiDAR)   | LiDAR TSDF, fvdb vs VDBFusion vs nvblox         |
+| `bench_seven_scenes.py`         | 7-Scenes (RGB-D)   | TSDF, long-trajectory                           |
+| `bench_esdf_vs_nvblox.py`       | Mai City           | ESDF, fvdb vs nvblox                            |
+| `bench_occupancy_vs_nvblox.py`  | Mai City           | Occupancy, fvdb vs nvblox                       |
+
+Supporting modules in the same directory:
+
+- `kitti_loader.py`, `replica_loader.py`, `mai_city_loader.py`,
+  `seven_scenes_loader.py` — minimal dataset loaders that yield
+  per-frame `(intrinsics, cam-to-world, depth_or_points)` tuples.
+- `download_kitti.py`, `download_replica.py`,
+  `download_replica_zip.py` — resumable, parallel-stream downloaders
+  for the public dataset archives.
+- `nvblox_runner.py` — Python wrapper around the nvblox CLI that
+  matches the cross-library interface used by the bench drivers.
+- `install_nvblox.sh`, `install_vdbfusion.sh` — reproducible install
+  recipes for the two C++ comparison libraries; each builds against
+  the fvdb conda env's TBB / Blosc / Boost.
+
+Each bench script accepts `--help` for its full argument surface and
+typically writes a JSON results file alongside printed per-frame
+summaries.
+
+## Data
+
+Datasets are not vendored. Place them under
+[`data/`](data/) (gitignored) and point each bench driver at the
+appropriate subdirectory via its `--data-root` (or equivalent) flag.

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_decay_kitti.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_decay_kitti.py
@@ -1,0 +1,165 @@
+"""Decay-and-prune experiment on KITTI seq 00.
+
+Single-number measurement of dynamic-scene decay's effect on persistent
+voxel count, on a real-sensor LiDAR sequence with moving objects (cars,
+cyclists, pedestrians on the road).
+
+Two parallel runs:
+  - "no_decay":  integrate first N frames in chunks; record voxel count
+                  at each checkpoint.
+  - "with_decay": integrate the same N frames in the same chunks; after
+                  each chunk, apply decay-and-prune to the weight
+                  sidecar (γ, threshold) and re-bind tsdf to the new
+                  pruned grid.
+
+Output: voxel count over time for both runs, plus the final reduction
+ratio. The "single number" the paper cites is V_with_decay / V_no_decay
+at the end of the integration window.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from fvdb import Grid
+from kitti_loader import load_kitti_scene
+
+
+def integrate_chunk(g, tsdf, weights, scene, chunk_start, chunk_end,
+                    truncation, sensor_origins_gpu):
+    chunk_pts = [
+        torch.from_numpy(scene.points_per_frame[i]).cuda()
+        for i in range(chunk_start, chunk_end)
+    ]
+    chunk_origins = sensor_origins_gpu[chunk_start:chunk_end]
+    g, tsdf, weights = g.integrate_tsdf_from_points_frames(
+        truncation_distance=truncation,
+        points_per_frame=chunk_pts,
+        sensor_origins=chunk_origins,
+        tsdf=tsdf, weights=weights,
+        carve_free_space=True,
+    )
+    del chunk_pts
+    return g, tsdf, weights
+
+
+def run(scene, voxel_size, truncation, n_frames, chunk_frames,
+        with_decay, decay_factor, prune_threshold):
+    torch.cuda.empty_cache()
+    g = Grid.from_dense(
+        dense_dims=[10, 10, 10], ijk_min=[-5, -5, -5],
+        voxel_size=voxel_size, origin=[0, 0, 0], device="cuda",
+    )
+    tsdf = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    weights = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    torch.cuda.reset_peak_memory_stats()
+
+    sensor_origins_gpu = torch.from_numpy(scene.sensor_origins).cuda()
+
+    timeline = []
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for chunk_start in range(0, n_frames, chunk_frames):
+        chunk_end = min(chunk_start + chunk_frames, n_frames)
+        g, tsdf, weights = integrate_chunk(
+            g, tsdf, weights, scene, chunk_start, chunk_end,
+            truncation, sensor_origins_gpu,
+        )
+        if with_decay:
+            # Decay weights and prune the grid; tsdf rides along as an extra.
+            g, weights, [tsdf] = g.decay_and_prune(
+                weights,
+                decay_factor=decay_factor,
+                prune_threshold=prune_threshold,
+                extra_sidecars=[tsdf],
+            )
+        torch.cuda.synchronize()
+        timeline.append({
+            "frames_integrated": chunk_end,
+            "n_voxels": int(g.num_voxels),
+        })
+
+    wall_s = time.perf_counter() - t0
+    peak_gb = torch.cuda.max_memory_allocated() / 1e9
+    return {
+        "ok": True,
+        "with_decay": with_decay,
+        "decay_factor": decay_factor if with_decay else None,
+        "prune_threshold": prune_threshold if with_decay else None,
+        "n_frames_integrated": n_frames,
+        "chunk_frames": chunk_frames,
+        "final_voxels": int(g.num_voxels),
+        "peak_gb": peak_gb,
+        "wall_s": wall_s,
+        "timeline": timeline,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--sequence", default="00")
+    ap.add_argument("--n-frames", type=int, default=500)
+    ap.add_argument("--voxel-size", type=float, default=0.1)  # 10 cm
+    ap.add_argument("--truncation", type=float, default=0.3)  # 3 * voxel
+    ap.add_argument("--chunk-frames", type=int, default=25)
+    ap.add_argument("--decay-factor", type=float, default=0.5)
+    ap.add_argument("--prune-threshold", type=float, default=0.05)
+    ap.add_argument("--json-out", type=Path, required=True)
+    args = ap.parse_args()
+
+    print(f"Loading KITTI seq {args.sequence}, first {args.n_frames} frames...",
+          flush=True)
+    scene = load_kitti_scene(args.root, sequence=args.sequence,
+                              max_frames=args.n_frames)
+    print(f"  loaded {scene.n_frames} frames, {scene.total_points:,} points",
+          flush=True)
+
+    print(f"\nRun 1/2: WITHOUT decay (baseline)", flush=True)
+    no_decay = run(scene, args.voxel_size, args.truncation,
+                    args.n_frames, args.chunk_frames,
+                    with_decay=False,
+                    decay_factor=1.0, prune_threshold=0.0)
+    print(f"  final voxels: {no_decay['final_voxels']:,}", flush=True)
+
+    print(f"\nRun 2/2: WITH decay (γ={args.decay_factor}, "
+          f"threshold={args.prune_threshold} per chunk of "
+          f"{args.chunk_frames} frames)", flush=True)
+    with_decay = run(scene, args.voxel_size, args.truncation,
+                      args.n_frames, args.chunk_frames,
+                      with_decay=True,
+                      decay_factor=args.decay_factor,
+                      prune_threshold=args.prune_threshold)
+    print(f"  final voxels: {with_decay['final_voxels']:,}", flush=True)
+
+    reduction = (1 - with_decay["final_voxels"]
+                  / no_decay["final_voxels"]) * 100
+    print(f"\nReduction in persistent voxel count: {reduction:.1f}%",
+          flush=True)
+
+    out = {
+        "args": vars(args) | {"json_out": str(args.json_out)},
+        "scene": {
+            "dataset": "kitti",
+            "sequence": args.sequence,
+            "n_frames": scene.n_frames,
+            "total_points": int(scene.total_points),
+        },
+        "results": {
+            "no_decay": no_decay,
+            "with_decay": with_decay,
+            "reduction_percent": reduction,
+        },
+    }
+    with open(args.json_out, "w") as f:
+        json.dump(out, f, indent=2)
+    print(f"\nWrote {args.json_out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_esdf_kitti.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_esdf_kitti.py
@@ -1,0 +1,124 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+KITTI Odometry counterpart to `bench_esdf_vs_nvblox.py`.
+
+Reuses the per-config ESDF runner from `bench_esdf_vs_nvblox.py`
+(loader-agnostic — it only depends on the duck-typed scene
+interface satisfied by both `MaiCityScene` and `KittiScene`),
+sweeps over multiple sequences and multiple voxel sizes, and
+writes a combined JSON suitable for paper-table generation.
+
+Default voxel sweep aligns with the LiDAR ESDF table in
+`PAPER_SECTION.md` §3.4. Default sequences are the standard
+NICE-SLAM trio (00, 02, 05).
+
+Usage:
+
+    cd fvdb-reality-capture/tests/benchmarks/tsdf_fusion/cross_library
+    CUDA_VISIBLE_DEVICES=1 PYTORCH_ALLOC_CONF=expandable_segments:True \\
+    /home/fwilliams/bin/miniconda3/envs/fvdb/bin/python \\
+        bench_esdf_kitti.py \\
+        --root .../data/KITTI \\
+        --sequences 00 02 05 \\
+        --n-frames 100 \\
+        --voxel-sizes-m 0.2 0.1 0.05 0.03 0.02 \\
+        --json-out ./results/kitti_esdf.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from kitti_loader import load_kitti_scene  # noqa: E402
+from bench_esdf_vs_nvblox import (  # noqa: E402
+    _format_scale_table,
+    _run_one_config,
+)
+
+
+# Mai City evidence: nvblox ESDF OOMs at 2 cm. KITTI has more frames
+# per sequence -> denser working set -> nvblox will OOM at least as
+# early. Skip the cells we know will fail to save wall time.
+_KNOWN_OOM_NVBLOX = lambda vs: vs <= 0.02   # 2 cm and below
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", required=True,
+                    help="Path to KITTI root (contains dataset/sequences/...)")
+    ap.add_argument("--sequences", nargs="+", default=["00", "02", "05"])
+    ap.add_argument("--n-frames", type=int, default=100,
+                    help="frames per sequence used to build TSDF before "
+                         "ESDF timing (default 100, matching Mai City)")
+    ap.add_argument("--voxel-sizes-m", type=float, nargs="+",
+                    default=[0.2, 0.1, 0.05, 0.03, 0.02])
+    ap.add_argument("--trunc-voxel-multiplier", type=float, default=3.0)
+    ap.add_argument("--max-distance-voxel-multiplier", type=float, default=10.0)
+    ap.add_argument("--esdf-warm-calls", type=int, default=5)
+    ap.add_argument("--skip-known-oom", action="store_true", default=True)
+    ap.add_argument("--no-skip-known-oom", dest="skip_known_oom",
+                    action="store_false")
+    ap.add_argument("--skip-nvblox", action="store_true",
+                    help="skip nvblox at every voxel (fvdb-only run)")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    all_results: list[dict[str, Any]] = []
+    t_start = time.time()
+
+    for seq in args.sequences:
+        print(f"\n##### KITTI seq={seq!r} #####")
+        scene = load_kitti_scene(
+            root_dir=args.root, sequence=seq,
+            max_frames=args.n_frames,
+        )
+        print(f"[load] done. {scene.n_frames} frames, "
+              f"{scene.total_points / 1e6:.2f} M points total")
+
+        for vs in args.voxel_sizes_m:
+            cfg_skip_nvblox = args.skip_nvblox or (
+                args.skip_known_oom and _KNOWN_OOM_NVBLOX(vs))
+            r = _run_one_config(
+                scene,
+                voxel_size=float(vs),
+                truncation=float(vs) * args.trunc_voxel_multiplier,
+                max_distance=float(vs) * args.max_distance_voxel_multiplier,
+                esdf_warm_calls=args.esdf_warm_calls,
+                skip_nvblox=cfg_skip_nvblox,
+            )
+            r["sequence"] = seq
+            r["dataset"] = "kitti"
+            all_results.append(r)
+            if args.json_out is not None:
+                args.json_out.parent.mkdir(parents=True, exist_ok=True)
+                with args.json_out.open("w") as f:
+                    json.dump({
+                        "config": {
+                            "sequences": args.sequences,
+                            "n_frames": args.n_frames,
+                            "esdf_warm_calls": args.esdf_warm_calls,
+                            "trunc_voxel_multiplier":
+                                args.trunc_voxel_multiplier,
+                            "max_distance_voxel_multiplier":
+                                args.max_distance_voxel_multiplier,
+                        },
+                        "results": all_results,
+                    }, f, indent=2)
+
+    print("")
+    print(_format_scale_table(all_results))
+    print(f"\n##### Total wall time: {(time.time() - t_start) / 60:.1f} min #####")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_esdf_replica.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_esdf_replica.py
@@ -1,0 +1,382 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+ESDF cross-library comparison on Replica depth data (NICE-SLAM format).
+
+Direct depth-TSDF counterpart to `bench_esdf_vs_nvblox.py` (which is
+Mai City LiDAR-only). Both systems integrate the same N Replica depth
+frames into a TSDF, then the ESDF compute step is timed in isolation:
+
+  - fvdb: `Grid.integrate_tsdf_frames(..)` -> `Grid.compute_esdf(..)`
+          (cold) / `Grid.compute_esdf_incremental(..)` (warm).
+  - nvblox: subprocess `run_depth` in the CUDA-12.4 env -> time
+            `Mapper.update_esdf(..)` cold + warm.
+
+Scope: single Replica scene (default room0), 200-frame stride-10
+subset matching the existing `bench_open3d_vs_fvdb.py` convention.
+The timings are the ESDF step cost; TSDF fusion is reported but
+not the headline number.
+
+Typical invocation for the paper's Replica ESDF row:
+
+    CUDA_VISIBLE_DEVICES=1 PYTORCH_ALLOC_CONF=expandable_segments:True \\
+    /home/fwilliams/bin/miniconda3/envs/fvdb/bin/python \\
+        bench_esdf_replica.py \\
+        --scene ../../data/Replica/room0 \\
+        --n-frames 200 --stride 10 \\
+        --voxel-sizes-m 0.02 0.01 0.005 0.003 \\
+        --trunc-voxel-multiplier 3 --max-distance-voxel-multiplier 10 \\
+        --json-out ./results/esdf_replica_room0.json
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import numpy as np
+import torch
+
+import fvdb
+
+from replica_loader import load_replica_scene
+
+
+NVBLOX_ENV_PYTHON = "/home/fwilliams/bin/miniconda3/envs/nvblox/bin/python"
+
+
+def _build_fvdb_seed_grid(voxel_size: float, device: str = "cuda"):
+    """Metadata-only seed grid for fvdb's `integrate_tsdf_frames` —
+    1 voxel so it establishes the voxel_size / origin convention, and
+    the integrator grows it via shell dilation per frame."""
+    g = fvdb.Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+    )
+    tsdf = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
+    w    = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
+    return g, tsdf, w
+
+
+def _run_fvdb(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    max_distance: float,
+    esdf_warm_calls: int,
+) -> dict[str, Any]:
+    """Build a TSDF from Replica depth frames, then time compute_esdf
+    (cold) + compute_esdf_incremental (warm). Mirrors the Mai City
+    driver's fvdb path."""
+    device = "cuda"
+
+    # Push the depth + pose arrays to GPU. Replica's depth_images at
+    # 1200x680 x 200 frames = ~650 MB as fp32 — fits comfortably.
+    K_t = torch.from_numpy(scene.K).to(device=device, dtype=torch.float32)
+    cam_to_world = torch.from_numpy(scene.cam_to_world).to(
+        device=device, dtype=torch.float32)
+    depth_images = torch.from_numpy(scene.depth_images).to(
+        device=device, dtype=torch.float32)
+    N = scene.n_frames
+    K_per_frame = K_t.unsqueeze(0).expand(N, 3, 3).contiguous()
+
+    seed_grid, tsdf_init, w_init = _build_fvdb_seed_grid(voxel_size, device)
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    tsdf_grid, tsdf, w = seed_grid.integrate_tsdf_frames(
+        truncation_distance=truncation,
+        projection_matrices=K_per_frame,
+        cam_to_world_matrices=cam_to_world,
+        tsdf=tsdf_init,
+        weights=w_init,
+        depth_images=depth_images,
+    )
+    torch.cuda.synchronize()
+    tsdf_s = time.perf_counter() - t0
+
+    n_voxels = int(tsdf_grid.num_voxels)
+    n_leaves = int(tsdf_grid.num_leaf_nodes)
+
+    # Cold one-shot.
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    esdf_grid, esdf = tsdf_grid.compute_esdf(
+        tsdf, w,
+        truncation_distance=truncation,
+        max_distance=max_distance,
+        use_vbm=True,
+    )
+    torch.cuda.synchronize()
+    esdf_cold_ms = (time.perf_counter() - t0) * 1000.0
+    esdf_n_voxels = int(esdf_grid.num_voxels)
+
+    # Warm incremental calls.
+    warm_samples = []
+    prev_grid, prev_esdf = esdf_grid, esdf
+    for _ in range(esdf_warm_calls):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        new_grid, new_esdf = tsdf_grid.compute_esdf_incremental(
+            tsdf, w, prev_grid, prev_esdf,
+            truncation_distance=truncation,
+            max_distance=max_distance,
+            use_vbm=True,
+        )
+        torch.cuda.synchronize()
+        warm_samples.append((time.perf_counter() - t0) * 1000.0)
+        prev_grid, prev_esdf = new_grid, new_esdf
+
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    return {
+        "system": "fvdb",
+        "tsdf_fuse_s": tsdf_s,
+        "tsdf_n_voxels": n_voxels,
+        "tsdf_n_leaves": n_leaves,
+        "esdf_n_voxels": esdf_n_voxels,
+        "esdf_cold_ms": esdf_cold_ms,
+        "esdf_warm_ms_min": min(warm_samples) if warm_samples else -1.0,
+        "esdf_warm_ms_median": (statistics.median(warm_samples)
+                                 if warm_samples else -1.0),
+        "esdf_warm_ms_max": max(warm_samples) if warm_samples else -1.0,
+        "esdf_warm_calls": len(warm_samples),
+        "peak_torch_gb": peak_torch_gb,
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "max_distance_m": max_distance,
+        "n_frames": scene.n_frames,
+    }
+
+
+def _run_nvblox(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    max_distance: float,
+    esdf_warm_calls: int,
+) -> dict[str, Any]:
+    """Run nvblox depth-TSDF + ESDF via the subprocess runner."""
+    runner = str(Path(__file__).resolve().parent / "nvblox_runner.py")
+
+    with tempfile.TemporaryDirectory(prefix="nvblox_esdf_replica_") as tmp:
+        depth_npz = os.path.join(tmp, "replica_depth.npz")
+        np.savez(
+            depth_npz,
+            depth_images=scene.depth_images.astype(np.float32),
+            cam_to_world=scene.cam_to_world.astype(np.float32),
+            K=scene.K.astype(np.float32),
+        )
+
+        spec = {
+            "workload": "depth",
+            "voxel_size_m": voxel_size,
+            "truncation_distance_m": truncation,
+            "depth_npz": depth_npz,
+            "warmup_frames": 2,
+            "with_esdf": True,
+            "esdf_warm_calls": esdf_warm_calls,
+        }
+        spec_path = os.path.join(tmp, "spec.json")
+        out_path  = os.path.join(tmp, "result.json")
+        with open(spec_path, "w") as f:
+            json.dump(spec, f)
+
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = env.get("CUDA_VISIBLE_DEVICES", "1")
+        proc = subprocess.run(
+            [NVBLOX_ENV_PYTHON, runner, "--spec", spec_path, "--output", out_path],
+            env=env, capture_output=True, text=True, timeout=3600,
+        )
+        if not os.path.exists(out_path):
+            return {"system": "nvblox", "ok": False,
+                    "failure": f"no output. stderr tail: {proc.stderr[-500:]!r}"}
+        with open(out_path, "r") as f:
+            result = json.load(f)
+
+    result["system"] = "nvblox"
+    result["voxel_size_m"] = voxel_size
+    result["truncation_m"] = truncation
+    result["max_distance_m"] = max_distance
+    return result
+
+
+def _run_one_config(
+    scene, voxel_size: float, truncation: float, max_distance: float,
+    esdf_warm_calls: int, skip_nvblox: bool,
+) -> dict[str, Any]:
+    print(f"\n[config] voxel={voxel_size}  trunc={truncation}  max_dist={max_distance}")
+    result: dict[str, Any] = {
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "max_distance_m": max_distance,
+    }
+
+    torch.cuda.reset_peak_memory_stats()
+    try:
+        result["fvdb"] = _run_fvdb(scene, voxel_size, truncation,
+                                   max_distance, esdf_warm_calls)
+        result["fvdb"]["ok"] = True
+        r = result["fvdb"]
+        print(f"  fvdb: TSDF {r['tsdf_n_voxels']:,} vx, "
+              f"ESDF {r['esdf_n_voxels']:,} vx, "
+              f"cold {r['esdf_cold_ms']:.1f} ms, "
+              f"warm {r['esdf_warm_ms_median']:.1f} ms, "
+              f"peak_gb {r['peak_torch_gb']:.2f}")
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  fvdb: OOM - {e}")
+        result["fvdb"] = {"ok": False, "failure": f"OOM: {e}"}
+        torch.cuda.empty_cache(); gc.collect()
+    except Exception as e:  # noqa: BLE001
+        print(f"  fvdb: failed ({type(e).__name__}: {e})")
+        result["fvdb"] = {"ok": False, "failure": f"{type(e).__name__}: {e}"}
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    if skip_nvblox:
+        result["nvblox"] = {"ok": False, "failure": "skipped"}
+    else:
+        try:
+            nvblox_result = _run_nvblox(scene, voxel_size, truncation,
+                                        max_distance, esdf_warm_calls)
+            result["nvblox"] = nvblox_result
+            if nvblox_result.get("ok", False):
+                print(f"  nvblox: approx_vx {nvblox_result['n_voxels']:,}, "
+                      f"cold {nvblox_result['esdf_cold_ms']:.1f} ms, "
+                      f"warm {nvblox_result['esdf_warm_ms_median']:.2f} ms, "
+                      f"gpu_gb {nvblox_result.get('gpu_used_gb', -1):.2f}")
+            else:
+                print(f"  nvblox: FAILED {nvblox_result.get('failure', '?')}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  nvblox: driver error ({type(e).__name__}: {e})")
+            result["nvblox"] = {"ok": False,
+                                "failure": f"driver: {type(e).__name__}: {e}"}
+
+    return result
+
+
+def _format_scale_table(results: list[dict[str, Any]]) -> str:
+    """Render the scale-ceiling summary table as a printable string.
+
+    `cold_x` > 1 means nvblox wins; < 1 means fvdb wins; `fvdb∞`
+    means nvblox OOM'd while fvdb ran."""
+    lines = []
+    lines.append("=== ESDF Scale Ceiling (Replica depth) ===")
+    lines.append(f"{'voxel':>6}  {'fvdb_ESDF_vx':>12}  {'fvdb_cold_ms':>13}  "
+                 f"{'fvdb_warm_ms':>13}  {'fvdb_gb':>7}  "
+                 f"{'nvblox_cold_ms':>14}  {'nvblox_gb':>9}  {'cold_x':>8}")
+    for r in results:
+        vs = r["voxel_size_m"]
+        fv = r.get("fvdb", {})
+        nv = r.get("nvblox", {})
+        if fv.get("ok"):
+            fv_str = (f"{fv['esdf_n_voxels']:>12,}  "
+                      f"{fv['esdf_cold_ms']:>13.1f}  "
+                      f"{fv['esdf_warm_ms_median']:>13.1f}  "
+                      f"{fv['peak_torch_gb']:>7.2f}")
+        else:
+            fv_str = f"{'OOM':>12}  {'--':>13}  {'--':>13}  {'--':>7}"
+        if nv.get("ok"):
+            nv_cold = nv.get("esdf_cold_ms", -1)
+            nv_gb = nv.get("gpu_used_gb", -1)
+            if fv.get("ok") and nv_cold > 0 and fv["esdf_cold_ms"] > 0:
+                cold_x = f"{fv['esdf_cold_ms'] / nv_cold:.2f}x"
+            else:
+                cold_x = "--"
+            nv_str = f"{nv_cold:>14.1f}  {nv_gb:>9.2f}  {cold_x:>8}"
+        else:
+            fail = nv.get("failure", "")
+            fail_str = str(fail)
+            looks_oom = ("OOM" in fail_str.upper()
+                         or "OutOfMemory" in fail_str
+                         or "cudaMalloc" in fail_str
+                         or "bad_alloc" in fail_str
+                         or "out of memory" in fail_str.lower())
+            if looks_oom:
+                nv_str = f"{'OOM':>14}  {'--':>9}  {'fvdb∞':>8}"
+            elif "skipped" in fail_str.lower():
+                nv_str = f"{'skip':>14}  {'--':>9}  {'--':>8}"
+            else:
+                nv_str = f"{'FAIL':>14}  {'--':>9}  {'--':>8}"
+        lines.append(f"{vs:>6.3f}  {fv_str}  {nv_str}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scene", required=True,
+                    help="Path to a Replica scene directory (e.g., .../Replica/room0)")
+    ap.add_argument("--n-frames", type=int, default=200)
+    ap.add_argument("--stride", type=int, default=10)
+    ap.add_argument("--voxel-sizes-m", type=float, nargs="+", required=True)
+    ap.add_argument("--trunc-voxel-multiplier", type=float, default=3.0)
+    ap.add_argument("--max-distance-voxel-multiplier", type=float, default=10.0)
+    ap.add_argument("--esdf-warm-calls", type=int, default=5)
+    ap.add_argument("--skip-nvblox", action="store_true")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    configs = [{
+        "voxel_size": float(vs),
+        "truncation":  float(vs) * args.trunc_voxel_multiplier,
+        "max_distance": float(vs) * args.max_distance_voxel_multiplier,
+    } for vs in args.voxel_sizes_m]
+
+    print(f"[load] Replica scene={args.scene}  n_frames={args.n_frames}  "
+          f"stride={args.stride}")
+    scene = load_replica_scene(
+        scene_dir=args.scene,
+        max_frames=args.n_frames,
+        stride=args.stride,
+    )
+    print(f"[load] done. {scene.n_frames} frames @ "
+          f"{scene.depth_images.shape[1]}x{scene.depth_images.shape[2]} depth")
+
+    results: list[dict[str, Any]] = []
+    for cfg in configs:
+        results.append(_run_one_config(
+            scene,
+            voxel_size=cfg["voxel_size"],
+            truncation=cfg["truncation"],
+            max_distance=cfg["max_distance"],
+            esdf_warm_calls=args.esdf_warm_calls,
+            skip_nvblox=args.skip_nvblox,
+        ))
+
+    print("")
+    print(_format_scale_table(results))
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.json_out.open("w") as f:
+            json.dump({
+                "config": {
+                    "scene": args.scene,
+                    "n_frames": args.n_frames,
+                    "stride": args.stride,
+                    "esdf_warm_calls": args.esdf_warm_calls,
+                    "trunc_voxel_multiplier": args.trunc_voxel_multiplier,
+                    "max_distance_voxel_multiplier":
+                        args.max_distance_voxel_multiplier,
+                },
+                "results": results,
+            }, f, indent=2)
+        print(f"\nWrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_esdf_vs_nvblox.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_esdf_vs_nvblox.py
@@ -1,0 +1,494 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+ESDF cross-library comparison: fvdb `Grid.compute_esdf` vs nvblox's
+`Mapper.update_esdf`, both fed the same TSDF fused from Mai City LiDAR.
+
+Setup. The paper needs a head-to-head number for the ESDF step itself
+(post-TSDF wavefront / block-allocator update). The comparison is:
+
+  1. Load N frames of Mai City seq00 LiDAR sweeps.
+  2. In fvdb: call `Grid.integrate_tsdf_from_points_frames` to build
+     the TSDF. Then time `Grid.compute_esdf(...)` for M warmup + K
+     timed iterations, report median + min.
+  3. In nvblox (subprocess, CUDA-12.4 env): feed the same LiDAR
+     sweeps through `Mapper.add_depth_frame`, then time
+     `Mapper.update_esdf(...)` for the same M + K schedule.
+  4. Print a comparison table + write machine-readable JSON.
+
+Notes:
+
+  - The two ESDF implementations compute SAME-shape output (per-voxel
+    world-unit signed distance with `|d| <= max_distance`), but on
+    different underlying topologies (fvdb: narrow-band index grid;
+    nvblox: block-hashed allocator with padded 8^3 blocks). Direct
+    numerical comparison of per-voxel values isn't meaningful because
+    the voxel sets differ. We only compare timings.
+  - Mai City at 20 cm voxels is a sweet-spot: both systems complete
+    the TSDF fusion well within GPU memory, and the ESDF step has
+    enough voxel volume (~7 M fvdb, ~13 M nvblox per earlier bench
+    numbers) for the timing delta to be meaningful.
+  - We deliberately keep the frame count small (100 frames default)
+    so TSDF fusion finishes in a few seconds and we're timing the
+    ESDF step in isolation, not the fusion wall-clock.
+
+Usage:
+
+    cd fvdb-reality-capture/tests/benchmarks/tsdf_fusion/cross_library
+    CUDA_VISIBLE_DEVICES=1 PYTORCH_ALLOC_CONF=expandable_segments:True \\
+    /home/fwilliams/bin/miniconda3/envs/fvdb/bin/python \\
+        bench_esdf_vs_nvblox.py \\
+        --root ../../data/mai_city/mai_city \\
+        --sequence 00 --n-frames 100 \\
+        --voxel-size 0.2 --truncation 0.6 --max-distance 2.0 \\
+        --json-out ./results/esdf_vs_nvblox_mai_city.json
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import numpy as np
+import torch
+
+import fvdb
+
+from mai_city_loader import load_mai_city_scene
+
+
+NVBLOX_ENV_PYTHON = "/home/fwilliams/bin/miniconda3/envs/nvblox/bin/python"
+
+
+def _run_fvdb(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    max_distance: float,
+    esdf_warm_calls: int,
+) -> dict[str, Any]:
+    """Build a TSDF from the scene via `integrate_tsdf_from_points_frames`,
+    then time both one-shot `compute_esdf` (cold) and
+    `compute_esdf_incremental` (warm) so we can compare apples-to-
+    apples against nvblox's stateful `update_esdf`.
+
+    Measurement protocol mirrors the nvblox runner:
+
+      - `esdf_cold_ms`: single call to `compute_esdf` on the final
+        TSDF (always "cold" in fvdb's stateless world).
+      - `esdf_warm_ms_*`: `esdf_warm_calls` calls to
+        `compute_esdf_incremental` feeding back the previous frame's
+        output. This is fvdb's equivalent of nvblox's
+        "no-dirty-blocks" fast path: idempotent warm-starts on an
+        unchanged TSDF.
+    """
+    device = "cuda"
+
+    points_torch = [
+        torch.from_numpy(p).to(device=device, dtype=torch.float32)
+        for p in scene.points_per_frame
+    ]
+    sensor_origins_t = torch.from_numpy(scene.sensor_origins).to(
+        device=device, dtype=torch.float32)
+
+    seed_grid = fvdb.Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+    )
+    tsdf_init = torch.zeros(seed_grid.num_voxels, device=device, dtype=torch.float32)
+    w_init = torch.zeros(seed_grid.num_voxels, device=device, dtype=torch.float32)
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    tsdf_grid, tsdf, w = seed_grid.integrate_tsdf_from_points_frames(
+        truncation_distance=truncation,
+        points_per_frame=points_torch,
+        sensor_origins=sensor_origins_t,
+        tsdf=tsdf_init,
+        weights=w_init,
+        carve_free_space=True,
+    )
+    torch.cuda.synchronize()
+    tsdf_s = time.perf_counter() - t0
+
+    n_voxels = int(tsdf_grid.num_voxels)
+    n_leaves = int(tsdf_grid.num_leaf_nodes)
+
+    # Cold: a single one-shot `compute_esdf` after TSDF fuse.
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    esdf_grid, esdf = tsdf_grid.compute_esdf(
+        tsdf, w, truncation_distance=truncation,
+        max_distance=max_distance, use_vbm=True,
+    )
+    torch.cuda.synchronize()
+    esdf_cold_ms = (time.perf_counter() - t0) * 1000.0
+
+    esdf_n_voxels = int(esdf_grid.num_voxels)
+
+    # Warm (no dirty mask): repeated `compute_esdf_incremental`
+    # calls feeding the previous result back. Monotone-min is
+    # idempotent at fixed point; cost is dominated by
+    # dilate+merge+inject+seed+short-circuited-sweep = ~20-30 ms.
+    warm_samples = []
+    prev_grid = esdf_grid
+    prev_esdf = esdf
+    for _ in range(esdf_warm_calls):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        new_grid, new_esdf = tsdf_grid.compute_esdf_incremental(
+            tsdf, w, prev_grid, prev_esdf,
+            truncation_distance=truncation,
+            max_distance=max_distance, use_vbm=True,
+        )
+        torch.cuda.synchronize()
+        warm_samples.append((time.perf_counter() - t0) * 1000.0)
+        prev_grid, prev_esdf = new_grid, new_esdf
+
+    # Warm (dirty-mask short-circuit): an all-false dirty mask
+    # triggers the Python-level cache-hit path in
+    # `compute_esdf_incremental`, which returns the previous
+    # (grid, esdf) directly without entering C++. This is the
+    # apples-to-apples equivalent of nvblox's "no dirty blocks"
+    # cache hit.
+    dirty_all_false = torch.zeros(tsdf_grid.num_voxels, device=device,
+                                   dtype=torch.bool)
+    # Warmup.
+    for _ in range(2):
+        _ = tsdf_grid.compute_esdf_incremental(
+            tsdf, w, esdf_grid, esdf,
+            truncation_distance=truncation,
+            max_distance=max_distance, use_vbm=True,
+            dirty_mask=dirty_all_false,
+        )
+    warm_dirty_samples = []
+    for _ in range(max(esdf_warm_calls, 10)):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        _ = tsdf_grid.compute_esdf_incremental(
+            tsdf, w, esdf_grid, esdf,
+            truncation_distance=truncation,
+            max_distance=max_distance, use_vbm=True,
+            dirty_mask=dirty_all_false,
+        )
+        torch.cuda.synchronize()
+        warm_dirty_samples.append((time.perf_counter() - t0) * 1000.0)
+
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    return {
+        "system": "fvdb",
+        "tsdf_fuse_s": tsdf_s,
+        "tsdf_n_voxels": n_voxels,
+        "tsdf_n_leaves": n_leaves,
+        "esdf_n_voxels": esdf_n_voxels,
+        "esdf_cold_ms": esdf_cold_ms,
+        "esdf_warm_ms_min": min(warm_samples) if warm_samples else -1.0,
+        "esdf_warm_ms_median": (statistics.median(warm_samples)
+                                 if warm_samples else -1.0),
+        "esdf_warm_ms_max": max(warm_samples) if warm_samples else -1.0,
+        "esdf_warm_calls": len(warm_samples),
+        "esdf_warm_dirty_ms_min": (min(warm_dirty_samples)
+                                    if warm_dirty_samples else -1.0),
+        "esdf_warm_dirty_ms_median": (statistics.median(warm_dirty_samples)
+                                       if warm_dirty_samples else -1.0),
+        "peak_torch_gb": peak_torch_gb,
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "max_distance_m": max_distance,
+        "n_frames": scene.n_frames,
+    }
+
+
+def _run_nvblox(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    max_distance: float,
+    esdf_warm_calls: int,
+    num_azimuth: int = 1800,
+    num_elevation: int = 64,
+    vertical_fov_rad: float = 0.4712,
+) -> dict[str, Any]:
+    """Run nvblox ESDF via the dedicated-env subprocess."""
+    runner = str(Path(__file__).resolve().parent / "nvblox_runner.py")
+
+    with tempfile.TemporaryDirectory(prefix="nvblox_esdf_") as tmp:
+        # Mirror bench_mai_city's npz packaging so the nvblox subprocess
+        # can load the sweeps zero-copy.
+        pts_concat = np.concatenate(scene.points_per_frame, axis=0).astype(np.float32)
+        offsets = np.zeros(scene.n_frames + 1, dtype=np.int64)
+        offsets[1:] = np.cumsum([p.shape[0] for p in scene.points_per_frame])
+
+        npz_path = os.path.join(tmp, "mai_city_sweeps.npz")
+        np.savez(
+            npz_path,
+            points_per_frame_concat=pts_concat,
+            points_per_frame_offsets=offsets,
+            sensor_origins=scene.sensor_origins.astype(np.float32),
+            cam_to_world=scene.cam_to_world.astype(np.float32),
+        )
+
+        spec = {
+            "workload": "lidar",
+            "voxel_size_m": voxel_size,
+            "truncation_distance_m": truncation,
+            "lidar_num_azimuth": num_azimuth,
+            "lidar_num_elevation": num_elevation,
+            "lidar_vertical_fov_rad": vertical_fov_rad,
+            "lidar_min_valid_range_m": 1.0,
+            "lidar_sweeps_npz": npz_path,
+            "warmup_frames": 2,
+            "with_esdf": True,
+            "esdf_warm_calls": esdf_warm_calls,
+        }
+        spec_path = os.path.join(tmp, "spec.json")
+        out_path  = os.path.join(tmp, "result.json")
+        with open(spec_path, "w") as f:
+            json.dump(spec, f)
+
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = env.get("CUDA_VISIBLE_DEVICES", "1")
+        proc = subprocess.run(
+            [NVBLOX_ENV_PYTHON, runner, "--spec", spec_path, "--output", out_path],
+            env=env, capture_output=True, text=True, timeout=3600,
+        )
+        if not os.path.exists(out_path):
+            return {"system": "nvblox", "ok": False,
+                    "failure": f"no output. stderr tail: {proc.stderr[-500:]!r}"}
+        with open(out_path, "r") as f:
+            result = json.load(f)
+
+    result["system"] = "nvblox"
+    result["voxel_size_m"] = voxel_size
+    result["truncation_m"] = truncation
+    result["max_distance_m"] = max_distance
+    return result
+
+
+def _run_one_config(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    max_distance: float,
+    esdf_warm_calls: int,
+    skip_nvblox: bool,
+) -> dict[str, Any]:
+    """Run one (voxel_size, truncation, max_distance) config across
+    both systems. Isolated per-config so OOM in one system doesn't
+    cascade: wraps fvdb in try/except for
+    `torch.cuda.OutOfMemoryError`, and frees intermediate state
+    between configs so fine-voxel runs don't inherit fragmentation
+    from coarse ones."""
+    print(f"\n[config] voxel={voxel_size}  trunc={truncation}  "
+          f"max_dist={max_distance}")
+    result: dict[str, Any] = {
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "max_distance_m": max_distance,
+    }
+
+    # fvdb run (in-process). Catch OOM; reset allocator state.
+    torch.cuda.reset_peak_memory_stats()
+    try:
+        result["fvdb"] = _run_fvdb(
+            scene, voxel_size, truncation, max_distance, esdf_warm_calls,
+        )
+        result["fvdb"]["ok"] = True
+        r = result["fvdb"]
+        print(f"  fvdb: TSDF {r['tsdf_n_voxels']:,} vx, "
+              f"ESDF {r['esdf_n_voxels']:,} vx, "
+              f"cold {r['esdf_cold_ms']:.1f} ms, "
+              f"warm {r['esdf_warm_ms_median']:.1f} ms, "
+              f"peak_gb {r['peak_torch_gb']:.2f}")
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  fvdb: OOM at voxel_size={voxel_size} - {e}")
+        result["fvdb"] = {"ok": False, "failure": f"OOM: {e}"}
+        # Drain torch's allocator so later configs don't inherit
+        # fragmentation; gc.collect to release any stale Python refs.
+        torch.cuda.empty_cache()
+        gc.collect()
+    except Exception as e:  # noqa: BLE001
+        print(f"  fvdb: failed ({type(e).__name__}: {e})")
+        result["fvdb"] = {"ok": False,
+                          "failure": f"{type(e).__name__}: {e}"}
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    # nvblox run (subprocess, so its own OOM doesn't affect us).
+    if skip_nvblox:
+        result["nvblox"] = {"ok": False, "failure": "skipped"}
+    else:
+        try:
+            nvblox_result = _run_nvblox(
+                scene, voxel_size, truncation, max_distance, esdf_warm_calls,
+            )
+            result["nvblox"] = nvblox_result
+            if nvblox_result.get("ok", False):
+                print(f"  nvblox: approx_vx {nvblox_result['n_voxels']:,}, "
+                      f"cold {nvblox_result['esdf_cold_ms']:.1f} ms, "
+                      f"warm {nvblox_result['esdf_warm_ms_median']:.2f} ms, "
+                      f"gpu_gb {nvblox_result.get('gpu_used_gb', -1):.2f}")
+            else:
+                print(f"  nvblox: FAILED {nvblox_result.get('failure', '?')}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  nvblox: driver error ({type(e).__name__}: {e})")
+            result["nvblox"] = {"ok": False,
+                                "failure": f"driver: {type(e).__name__}: {e}"}
+
+    return result
+
+
+def _format_scale_table(results: list[dict[str, Any]]) -> str:
+    """Render the scale-ceiling summary table as a printable string.
+
+    `cold_x` column: how many times slower fvdb's cold ESDF is than
+    nvblox's. Values > 1 mean nvblox wins; values < 1 mean fvdb
+    wins; `∞` means nvblox OOM'd."""
+    lines = []
+    lines.append("=== ESDF Scale Ceiling (Mai City) ===")
+    lines.append(f"{'voxel':>6}  {'fvdb_ESDF_vx':>12}  {'fvdb_cold_ms':>13}  "
+                 f"{'fvdb_warm_ms':>13}  {'fvdb_dirty_ms':>14}  {'fvdb_gb':>7}  "
+                 f"{'nvblox_cold_ms':>14}  {'nvblox_gb':>9}  {'cold_x':>8}")
+    for r in results:
+        vs = r["voxel_size_m"]
+        fv = r.get("fvdb", {})
+        nv = r.get("nvblox", {})
+        if fv.get("ok"):
+            dirty_ms = fv.get("esdf_warm_dirty_ms_median", -1.0)
+            dirty_str = f"{dirty_ms * 1000:14.0f}μs" if dirty_ms > 0 and dirty_ms < 1.0 \
+                else f"{dirty_ms:>14.2f}"
+            fv_str = (f"{fv['esdf_n_voxels']:>12,}  "
+                      f"{fv['esdf_cold_ms']:>13.1f}  "
+                      f"{fv['esdf_warm_ms_median']:>13.1f}  "
+                      f"{dirty_str}  "
+                      f"{fv['peak_torch_gb']:>7.2f}")
+        else:
+            fv_str = f"{'OOM':>12}  {'--':>13}  {'--':>13}  {'--':>14}  {'--':>7}"
+        if nv.get("ok"):
+            nv_cold = nv.get("esdf_cold_ms", -1)
+            nv_gb = nv.get("gpu_used_gb", -1)
+            if fv.get("ok") and nv_cold > 0 and fv["esdf_cold_ms"] > 0:
+                # cold_x = fvdb_cold / nvblox_cold; >1 means nvblox wins
+                cold_x = f"{fv['esdf_cold_ms'] / nv_cold:.2f}x"
+            else:
+                cold_x = "--"
+            nv_str = f"{nv_cold:>14.1f}  {nv_gb:>9.2f}  {cold_x:>8}"
+        else:
+            fail = nv.get("failure", "")
+            fail_str = str(fail)
+            looks_oom = ("OOM" in fail_str.upper()
+                         or "OutOfMemory" in fail_str
+                         or "cudaMalloc" in fail_str
+                         or "bad_alloc" in fail_str
+                         or "out of memory" in fail_str.lower())
+            if looks_oom:
+                nv_str = f"{'OOM':>14}  {'--':>9}  {'fvdb∞':>8}"
+            elif "skipped" in fail_str.lower():
+                nv_str = f"{'skip':>14}  {'--':>9}  {'--':>8}"
+            else:
+                nv_str = f"{'FAIL':>14}  {'--':>9}  {'--':>8}"
+        lines.append(f"{vs:>6.3f}  {fv_str}  {nv_str}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True,
+                    help="Path to Mai City root (contains bin/sequences/.../velodyne)")
+    ap.add_argument("--sequence", default="00")
+    ap.add_argument("--n-frames", type=int, default=100)
+    # Single-config mode (backwards compatible):
+    ap.add_argument("--voxel-size", type=float, default=None)
+    ap.add_argument("--truncation", type=float, default=None)
+    ap.add_argument("--max-distance", type=float, default=None)
+    # Scale-sweep mode (preferred for the paper's scale-ceiling figure):
+    ap.add_argument("--voxel-sizes-m", type=float, nargs="+", default=None,
+                    help="Sweep over a list of voxel sizes. Truncation and "
+                         "max_distance default to fixed multiples (3x and "
+                         "10x) of each voxel size.")
+    ap.add_argument("--trunc-voxel-multiplier", type=float, default=3.0,
+                    help="In sweep mode: truncation = this × voxel_size")
+    ap.add_argument("--max-distance-voxel-multiplier", type=float, default=10.0,
+                    help="In sweep mode: max_distance = this × voxel_size")
+    ap.add_argument("--esdf-warm-calls", type=int, default=5,
+                    help="Number of warm (idempotent) ESDF calls to time "
+                         "after the cold (first) call.")
+    ap.add_argument("--skip-nvblox", action="store_true")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    # Build the list of configs to run.
+    if args.voxel_sizes_m is not None:
+        configs = []
+        for vs in args.voxel_sizes_m:
+            configs.append({
+                "voxel_size": float(vs),
+                "truncation":  float(vs) * args.trunc_voxel_multiplier,
+                "max_distance": float(vs) * args.max_distance_voxel_multiplier,
+            })
+    else:
+        # Single-config back-compat.
+        if args.voxel_size is None or args.truncation is None or args.max_distance is None:
+            raise SystemExit("Either --voxel-sizes-m or all of --voxel-size "
+                             "/ --truncation / --max-distance must be set")
+        configs = [{
+            "voxel_size": args.voxel_size,
+            "truncation": args.truncation,
+            "max_distance": args.max_distance,
+        }]
+
+    print(f"[load] Mai City seq={args.sequence} n_frames={args.n_frames}")
+    scene = load_mai_city_scene(
+        root_dir=args.root, sequence=args.sequence,
+        max_frames=args.n_frames,
+    )
+    print(f"[load] done. {scene.n_frames} frames, "
+          f"{scene.total_points / 1e6:.2f} M points total")
+
+    results: list[dict[str, Any]] = []
+    for cfg in configs:
+        results.append(_run_one_config(
+            scene,
+            voxel_size=cfg["voxel_size"],
+            truncation=cfg["truncation"],
+            max_distance=cfg["max_distance"],
+            esdf_warm_calls=args.esdf_warm_calls,
+            skip_nvblox=args.skip_nvblox,
+        ))
+
+    print("")
+    print(_format_scale_table(results))
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.json_out.open("w") as f:
+            json.dump({
+                "config": {
+                    "sequence": args.sequence,
+                    "n_frames": args.n_frames,
+                    "esdf_warm_calls": args.esdf_warm_calls,
+                    "trunc_voxel_multiplier": args.trunc_voxel_multiplier,
+                    "max_distance_voxel_multiplier": args.max_distance_voxel_multiplier,
+                },
+                "results": results,
+            }, f, indent=2)
+        print(f"\nWrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_kitti.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_kitti.py
@@ -1,0 +1,263 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Long-trajectory LiDAR TSDF benchmark on KITTI Odometry (real-sensor
+HDL-64).
+
+Counterpart to `bench_mai_city.py`. KITTI replaces the synthetic
+Mai City sweeps with real Velodyne data: longer trajectories
+(seq 00 = 4541 frames over 3.7 km), real noise, real moving cars
+in scene. The integrate path is unchanged
+(`Grid.integrate_tsdf_from_points_frames`); the value of running
+this is to validate that the Mai City speed/scale claims hold on
+real-sensor data.
+
+Reuses `run_fvdb`, `run_nvblox`, `run_vdbfusion` from
+`bench_mai_city.py` since those functions are loader-agnostic
+(they only depend on the duck-typed scene interface satisfied by
+both `MaiCityScene` and `KittiScene`).
+
+Usage:
+
+    python bench_kitti.py \\
+        --root .../data/KITTI \\
+        --sequences 00 02 05 \\
+        --voxel-sizes 0.4 0.2 0.1 0.05 0.03 0.02 \\
+        --systems fvdb nvblox \\
+        --skip-known-oom \\
+        --json-out kitti_tsdf.json
+"""
+
+from __future__ import annotations
+
+import os
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from kitti_loader import load_kitti_scene  # noqa: E402
+from bench_mai_city import run_nvblox, run_vdbfusion  # noqa: E402
+
+
+def run_fvdb_chunked(scene, voxel_size: float, truncation: float,
+                     carve_free_space: bool = True,
+                     chunk_frames: int = 200) -> Dict[str, Any]:
+    """Chunked fvdb LiDAR TSDF for long trajectories.
+
+    The unchunked `bench_mai_city.run_fvdb` pre-loads ALL frames'
+    point clouds onto the GPU before the timed window. For KITTI's
+    4541-frame sequence 00 (~549 M points x 12 B = 6.6 GB just
+    for points), this triggers an OOM in nanoVDB's allocator before
+    the integrate kernel even starts.
+
+    This variant streams frames in chunks: at each step it loads
+    `chunk_frames` worth of point clouds to GPU, runs one
+    `integrate_tsdf_from_points_frames` over the chunk (which
+    grows the persistent grid), then frees the chunk's CUDA
+    tensors. Throughput is essentially identical to the one-shot
+    path (the C++ kernel doesn't care about call boundaries) but
+    peak memory is bounded by `chunk_frames * avg_points * 12 B`
+    instead of `total_points * 12 B`.
+
+    Memory accounting note: `peak_gb` is the post-fusion CUDA
+    high-water mark (so it includes the final grid + sidecars),
+    which is what the paper cares about. The transient point-
+    upload spike per chunk is bounded.
+    """
+    import gc
+    from fvdb import Grid
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    N = scene.n_frames
+    g = Grid.from_dense(
+        dense_dims=[10, 10, 10], ijk_min=[-5, -5, -5],
+        voxel_size=voxel_size, origin=[0, 0, 0], device="cuda",
+    )
+    tsdf = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    weights = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+
+    # Warmup on first 2 frames (matches bench_mai_city.run_fvdb).
+    for i in range(min(2, N)):
+        pts = torch.from_numpy(scene.points_per_frame[i]).cuda()
+        origin = torch.from_numpy(scene.sensor_origins[i]).cuda()
+        g, tsdf, weights = g.integrate_tsdf_from_points(
+            truncation_distance=truncation,
+            points=pts, sensor_origin=origin,
+            tsdf=tsdf, weights=weights,
+            carve_free_space=carve_free_space,
+        )
+    torch.cuda.synchronize()
+
+    # Fresh state for the timed run.
+    g = Grid.from_dense(
+        dense_dims=[10, 10, 10], ijk_min=[-5, -5, -5],
+        voxel_size=voxel_size, origin=[0, 0, 0], device="cuda",
+    )
+    tsdf = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    weights = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    torch.cuda.reset_peak_memory_stats()
+
+    sensor_origins_full = torch.from_numpy(scene.sensor_origins).cuda()
+
+    try:
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for chunk_start in range(0, N, chunk_frames):
+            chunk_end = min(chunk_start + chunk_frames, N)
+            chunk_pts = [
+                torch.from_numpy(scene.points_per_frame[i]).cuda()
+                for i in range(chunk_start, chunk_end)
+            ]
+            chunk_origins = sensor_origins_full[chunk_start:chunk_end]
+            g, tsdf, weights = g.integrate_tsdf_from_points_frames(
+                truncation_distance=truncation,
+                points_per_frame=chunk_pts,
+                sensor_origins=chunk_origins,
+                tsdf=tsdf, weights=weights,
+                carve_free_space=carve_free_space,
+            )
+            del chunk_pts
+        torch.cuda.synchronize()
+    except torch.cuda.OutOfMemoryError as e:
+        return {"system": "fvdb", "ok": False,
+                "failure": f"torch OOM: {str(e).splitlines()[0][:140]}"}
+    except RuntimeError as e:
+        msg = str(e)
+        if "out of memory" in msg.lower() or "CUDA error 2" in msg:
+            return {"system": "fvdb", "ok": False,
+                    "failure": f"runtime OOM: {msg.splitlines()[0][:140]}"}
+        return {"system": "fvdb", "ok": False,
+                "failure": f"runtime: {msg.splitlines()[0][:140]}"}
+
+    ms_per_f = (time.perf_counter() - t0) * 1000 / N
+    peak_gb = torch.cuda.max_memory_allocated() / 1e9
+    return {
+        "system": "fvdb", "ok": True,
+        "ms_per_f": ms_per_f, "peak_gb": peak_gb,
+        "n_voxels": int(g.num_voxels), "n_frames": N,
+        "chunk_frames": chunk_frames,
+    }
+
+
+# Mai City evidence (700-frame seq00) shows nvblox OOMs at 5 cm and
+# below for LiDAR TSDF. KITTI has 6.5x more frames per sequence, so
+# nvblox will OOM at LEAST as early. Skipping known-OOM cells saves
+# ~30% wall time without losing paper-relevant data (we just record
+# them as "skipped: known OOM from Mai City").
+_KNOWN_OOM_NVBLOX = {
+    "tsdf": lambda vs: vs <= 0.05,    # 5 cm and below
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--root", required=True,
+                   help="path to extracted KITTI/ (the dir containing dataset/)")
+    p.add_argument("--sequences", nargs="+", default=["00", "02", "05"],
+                   help="KITTI sequences (00..10 are training; 11..21 lack poses)")
+    p.add_argument("--n-frames", type=int, default=0,
+                   help="cap on frames per sequence (0 = all). "
+                        "Useful for smoke tests.")
+    p.add_argument("--voxel-sizes", nargs="+", type=float,
+                   default=[0.4, 0.2, 0.1, 0.05, 0.03, 0.02],
+                   help="voxel sizes in metres.")
+    p.add_argument("--truncation-multiplier", type=float, default=3.0)
+    p.add_argument("--carve-free-space", action="store_true", default=True)
+    p.add_argument("--no-carve-free-space", dest="carve_free_space",
+                   action="store_false")
+    p.add_argument("--systems", nargs="+",
+                   default=["fvdb", "nvblox"],
+                   choices=["fvdb", "fvdb_per_frame", "vdbfusion", "nvblox"])
+    p.add_argument("--skip-known-oom", action="store_true", default=True,
+                   help="skip nvblox at voxels Mai City showed OOM (default on)")
+    p.add_argument("--no-skip-known-oom", dest="skip_known_oom",
+                   action="store_false")
+    p.add_argument("--chunk-frames", type=int, default=200,
+                   help="frames per fvdb integrate call. Bounds peak GPU "
+                        "memory for the input point upload at ~chunk_frames "
+                        "* avg_pts * 12 B. Default 200 -> ~290 MB transient "
+                        "for KITTI (vs ~6.6 GB if all 4541 frames pre-loaded).")
+    p.add_argument("--json-out", type=str, default=None)
+    args = p.parse_args()
+
+    max_frames = None if args.n_frames <= 0 else args.n_frames
+
+    all_results: List[Dict[str, Any]] = []
+    t_start = time.time()
+
+    for seq in args.sequences:
+        print(f"\n##### KITTI seq={seq!r} #####", flush=True)
+        scene = load_kitti_scene(args.root, sequence=seq, max_frames=max_frames)
+        traj_len = float(np.linalg.norm(
+            np.diff(scene.sensor_origins, axis=0), axis=1).sum())
+        print(f"Loaded: {scene.n_frames} frames, "
+              f"{scene.total_points:,} total points, "
+              f"avg {scene.total_points // max(scene.n_frames, 1):,} pts/frame, "
+              f"trajectory length {traj_len:.1f} m", flush=True)
+
+        for vs in args.voxel_sizes:
+            trunc = vs * args.truncation_multiplier
+            print(f"\n=== seq={seq} voxel={vs*100:.1f}cm trunc={trunc*100:.1f}cm ===",
+                  flush=True)
+            for system in args.systems:
+                t0 = time.time()
+                if (args.skip_known_oom and system == "nvblox"
+                        and _KNOWN_OOM_NVBLOX["tsdf"](vs)):
+                    r = {"system": "nvblox", "ok": False,
+                         "failure": "skipped: known OOM at this voxel from "
+                                    "Mai City evidence",
+                         "skipped": True}
+                elif system == "fvdb":
+                    r = run_fvdb_chunked(
+                        scene, vs, trunc,
+                        carve_free_space=args.carve_free_space,
+                        chunk_frames=args.chunk_frames)
+                elif system == "vdbfusion":
+                    r = run_vdbfusion(scene, vs, trunc)
+                elif system == "nvblox":
+                    r = run_nvblox(scene, vs, trunc)
+                else:
+                    continue
+                r["voxel_size"] = vs
+                r["sequence"] = seq
+                r["dataset"] = "kitti"
+                r["wall_s"] = time.time() - t0
+                all_results.append(r)
+                if r.get("ok"):
+                    extra = (f"  peak={r.get('peak_gb', 0):.2f} GB"
+                             f"  voxels={r.get('n_voxels', 0):,}")
+                    print(f"  {system:15s} OK  {r['ms_per_f']:7.2f} ms/f"
+                          f"  ({r['wall_s']:.1f} s wall){extra}",
+                          flush=True)
+                elif r.get("skipped"):
+                    print(f"  {system:15s} SKIP  {r.get('failure','')[:80]}",
+                          flush=True)
+                else:
+                    print(f"  {system:15s} FAIL  ({r['wall_s']:.1f} s wall) "
+                          f"{r.get('failure','?')[:120]}",
+                          flush=True)
+                # Drain torch's allocator between systems so a fail
+                # doesn't poison the next attempt.
+                torch.cuda.empty_cache()
+            if args.json_out:
+                with open(args.json_out, "w") as f:
+                    json.dump({"results": all_results, "args": vars(args)},
+                              f, indent=2)
+
+    print(f"\n##### Total wall time: {(time.time() - t_start) / 60:.1f} min #####",
+          flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_mai_city.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_mai_city.py
@@ -1,0 +1,449 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Long-trajectory LiDAR TSDF-fusion benchmark on Mai City (synthetic
+Velodyne HDL-64).
+
+Mai City sequence 00 is a 700 m synthetic drive at 10 m/s with 700
+Velodyne-style sweeps (~130 K points each after the opening few
+frames). Complements the depth-TSDF benches
+(`bench_open3d_vs_fvdb.py` on Replica, `bench_seven_scenes.py` on
+7-Scenes) by exercising the LiDAR integrate path
+(`Grid.integrate_tsdf_from_points`) on an unbounded-surface
+trajectory.
+
+Runs the following systems (each optional via --systems):
+  - `fvdb`:           current per-frame-looped `integrate_tsdf_from_points`
+                       (the implementation that ships today).
+  - `fvdb_composed`:  explicit `FVDB_TSDF_COMPOSED=1` ablation (same
+                       path, but opts out of any future persistent-state
+                       changes so the baseline is reproducible).
+  - `vdbfusion`:      PRBonn VDBFusion CPU/OpenVDB baseline. Disabled
+                       by default because `pip install vdbfusion`
+                       currently fails due to the vendored
+                       blosc-1.x + zlib-1.2.8 not compiling with
+                       modern gcc (missing `#include <unistd.h>` for
+                       `lseek`/`read`/`write`/`close`); the fix
+                       requires either a Docker image or patched
+                       third-party sources. See `install_vdbfusion.sh`
+                       in this directory for the working recipe.
+
+Usage:
+
+    python bench_mai_city.py \\
+        --root .../data/mai_city/mai_city \\
+        --sequence 00 \\
+        --n-frames 700 \\
+        --voxel-sizes 0.2 0.1 0.05 \\
+        --json-out results.json
+"""
+
+from __future__ import annotations
+
+import os
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import argparse
+import gc
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from mai_city_loader import load_mai_city_scene  # noqa: E402
+
+
+def run_fvdb(scene, voxel_size: float, truncation: float,
+             carve_free_space: bool = True,
+             batched: bool = True) -> Dict[str, Any]:
+    """Run fvdb's LiDAR TSDF on a Mai City sweep sequence.
+
+    Two paths:
+      - `batched=True` (default): `Grid.integrate_tsdf_from_points_frames`
+        runs the whole N-sweep loop in C++, avoiding the per-frame
+        Python <-> C++ dispatch + JaggedTensor rewrap cost. Shipped
+        in the batched N-frame path. Output matches the per-frame loop
+        within a 10-ULP tolerance (atomic-add reorder in the ray-walk
+        kernel is NOT bit-deterministic even for two back-to-back
+        sequential runs, so the batched path's agreement floor is
+        just that atomic-noise floor).
+      - `batched=False`: Python `for` loop over `integrate_tsdf_from_points`,
+        matching the per-frame loop. Useful as
+        an ablation baseline to quantify the Python-dispatch overhead.
+    """
+    from fvdb import Grid
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    N = scene.n_frames
+    # Start from a tiny dense seed grid rather than truly empty --
+    # `integrate_tsdf_from_points` requires a non-empty initial
+    # GridBatch (there's an "empty grid handle" runtime check in the
+    # C++ path). 10^3 voxels at any origin costs essentially nothing.
+    g = Grid.from_dense(
+        dense_dims=[10, 10, 10], ijk_min=[-5, -5, -5],
+        voxel_size=voxel_size, origin=[0, 0, 0], device="cuda",
+    )
+    tsdf = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    weights = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+
+    # Warmup 2 frames (matches the pattern in bench_seven_scenes).
+    for i in range(min(2, N)):
+        pts = torch.from_numpy(scene.points_per_frame[i]).cuda()
+        origin = torch.from_numpy(scene.sensor_origins[i]).cuda()
+        g, tsdf, weights = g.integrate_tsdf_from_points(
+            truncation_distance=truncation,
+            points=pts, sensor_origin=origin,
+            tsdf=tsdf, weights=weights,
+            carve_free_space=carve_free_space,
+        )
+    torch.cuda.synchronize()
+
+    # Fresh state for timed run.
+    g = Grid.from_dense(
+        dense_dims=[10, 10, 10], ijk_min=[-5, -5, -5],
+        voxel_size=voxel_size, origin=[0, 0, 0], device="cuda",
+    )
+    tsdf = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    weights = torch.zeros(g.num_voxels, device="cuda", dtype=torch.float32)
+    torch.cuda.reset_peak_memory_stats()
+
+    try:
+        if batched:
+            # Batched N-frame path: one C++ call for all N frames.
+            # Pre-load all points to GPU OUTSIDE the timed window --
+            # the point-transfer step isn't the thing the batched path is
+            # optimizing, and a real streaming pipeline would overlap
+            # it with the integrate kernels anyway. We measure the
+            # integrate-only cost for a fair comparison against
+            # `fvdb_per_frame`.
+            pts_per_frame = [
+                torch.from_numpy(p).cuda() for p in scene.points_per_frame
+            ]
+            origins = torch.from_numpy(scene.sensor_origins).cuda()
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            g, tsdf, weights = g.integrate_tsdf_from_points_frames(
+                truncation_distance=truncation,
+                points_per_frame=pts_per_frame,
+                sensor_origins=origins,
+                tsdf=tsdf, weights=weights,
+                carve_free_space=carve_free_space,
+            )
+            torch.cuda.synchronize()
+        else:
+            # Ablation baseline: Python per-frame loop. For symmetry,
+            # also pre-load all points outside the timing window --
+            # otherwise the per-frame path would get "credit" for the
+            # H->D copy being interleaved with compute.
+            pts_per_frame_cu = [
+                torch.from_numpy(p).cuda() for p in scene.points_per_frame
+            ]
+            origins = torch.from_numpy(scene.sensor_origins).cuda()
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            for i in range(N):
+                g, tsdf, weights = g.integrate_tsdf_from_points(
+                    truncation_distance=truncation,
+                    points=pts_per_frame_cu[i],
+                    sensor_origin=origins[i],
+                    tsdf=tsdf, weights=weights,
+                    carve_free_space=carve_free_space,
+                )
+            torch.cuda.synchronize()
+    except torch.cuda.OutOfMemoryError as e:
+        return {"system": "fvdb", "ok": False,
+                "failure": f"OOM: {str(e).splitlines()[0][:100]}"}
+    except RuntimeError as e:
+        return {"system": "fvdb", "ok": False,
+                "failure": f"runtime: {str(e).splitlines()[0][:140]}"}
+
+    ms_per_f = (time.perf_counter() - t0) * 1000 / N
+    peak_gb = torch.cuda.max_memory_allocated() / 1e9
+    return {
+        "system": "fvdb" if batched else "fvdb_per_frame",
+        "ok": True,
+        "ms_per_f": ms_per_f,
+        "peak_gb": peak_gb,
+        "n_voxels": int(g.num_voxels),
+        "n_frames": N,
+    }
+
+
+def run_nvblox(scene, voxel_size: float, truncation: float,
+               nvblox_env_python: str = "/home/fwilliams/bin/miniconda3/envs/nvblox/bin/python",
+               num_azimuth: int = 1800, num_elevation: int = 64,
+               vertical_fov_rad: float = 0.4712,  # ~27 deg for HDL-64
+               **_ignored) -> Dict[str, Any]:
+    """Run NVIDIA nvblox's LiDAR TSDF integrator on a Mai City sweep
+    sequence by spawning a subprocess into the `nvblox` conda env.
+
+    nvblox needs CUDA 12 + torch<=2.9.1 (its wheel targets those); our
+    fvdb env has CUDA 13 + torch 2.10. Rather than downgrading our
+    env, we build a dedicated `nvblox` conda env (see
+    `install_nvblox.sh`, to be written) and call it out-of-process.
+    The subprocess pattern also keeps nvblox's CUDA context fully
+    isolated from our process -- no risk of the two libraries fighting
+    over GPU memory or CUDA streams.
+
+    nvblox represents LiDAR input as a (num_elevation, num_azimuth)
+    spherical range image. The runner script converts our raw 3D
+    Mai City points -> sensor frame -> range image internally. We
+    use HDL-64 defaults matching the Mai City dataset.
+    """
+    import os, subprocess, tempfile
+
+    if not os.path.exists(nvblox_env_python):
+        return {"system": "nvblox", "ok": False,
+                "failure": f"nvblox env python not found: {nvblox_env_python}"}
+
+    runner = str(Path(__file__).resolve().parent / "nvblox_runner.py")
+    if not os.path.exists(runner):
+        return {"system": "nvblox", "ok": False,
+                "failure": f"nvblox_runner.py missing: {runner}"}
+
+    # Stash points + poses into an npz so the subprocess can load
+    # them zero-copy (JSON-encoding N x ~100k points is too slow).
+    with tempfile.TemporaryDirectory(prefix="nvblox_bench_") as tmp:
+        # Concatenate all frames' points + build offsets for O(1)
+        # slicing on the nvblox side.
+        pts_concat = np.concatenate(scene.points_per_frame, axis=0).astype(np.float32)
+        offsets = np.zeros(scene.n_frames + 1, dtype=np.int64)
+        offsets[1:] = np.cumsum([p.shape[0] for p in scene.points_per_frame])
+
+        npz_path = os.path.join(tmp, "mai_city_sweeps.npz")
+        np.savez(
+            npz_path,
+            points_per_frame_concat=pts_concat,
+            points_per_frame_offsets=offsets,
+            sensor_origins=scene.sensor_origins.astype(np.float32),
+            cam_to_world=scene.cam_to_world.astype(np.float32),
+        )
+
+        spec = {
+            "workload": "lidar",
+            "voxel_size_m": voxel_size,
+            "truncation_distance_m": truncation,
+            "lidar_num_azimuth": num_azimuth,
+            "lidar_num_elevation": num_elevation,
+            "lidar_vertical_fov_rad": vertical_fov_rad,
+            "lidar_min_valid_range_m": 1.0,
+            "lidar_sweeps_npz": npz_path,
+            "warmup_frames": 2,
+        }
+        spec_path = os.path.join(tmp, "spec.json")
+        out_path = os.path.join(tmp, "result.json")
+        with open(spec_path, "w") as f:
+            json.dump(spec, f)
+
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = env.get("CUDA_VISIBLE_DEVICES", "1")
+        try:
+            proc = subprocess.run(
+                [nvblox_env_python, runner, "--spec", spec_path,
+                 "--output", out_path],
+                env=env, capture_output=True, text=True,
+                timeout=3600,  # 1h cap; way above expected runtime
+            )
+        except subprocess.TimeoutExpired as e:
+            return {"system": "nvblox", "ok": False,
+                    "failure": f"subprocess timeout: {e}"}
+
+        if not os.path.exists(out_path):
+            return {"system": "nvblox", "ok": False,
+                    "failure": f"nvblox runner did not produce output. "
+                               f"stderr tail: {proc.stderr[-500:]!r}"}
+        with open(out_path, "r") as f:
+            result = json.load(f)
+
+    # Normalise keys to match fvdb/vdbfusion output schema. Prefer
+    # `gpu_used_gb` (CUDA driver-reported aggregate used memory)
+    # over the RSS delta for a GPU library -- RSS only captures
+    # pinned-host allocations which vastly under-represent nvblox's
+    # actual footprint.
+    if result.get("gpu_used_gb", -1) > 0:
+        result.setdefault("peak_gb", result["gpu_used_gb"])
+    else:
+        result.setdefault("peak_gb", result.get("peak_rss_delta_gb", 0.0))
+    result["system"] = "nvblox"
+    if not result.get("ok"):
+        # Surface a short failure string to the driver's print loop.
+        return {"system": "nvblox", "ok": False,
+                "failure": result.get("failure", "unknown") +
+                           (f" (stderr tail: {proc.stderr[-300:]!r})"
+                            if proc.stderr else "")}
+    return result
+
+
+def run_vdbfusion(scene, voxel_size: float, truncation: float,
+                  carve_free_space: bool = True,
+                  **_ignored) -> Dict[str, Any]:
+    """Run PRBonn VDBFusion CPU TSDF integrator (multi-threaded OpenVDB).
+
+    VDBFusion's API: construct a `VDBVolume(voxel_size, sdf_trunc,
+    space_carving)`, call `integrate(points, origin)` per sweep,
+    then `extract_triangle_mesh()` at the end. Runs on CPU with
+    TBB parallelism; this is exactly the baseline the paper wants
+    to anchor against for LiDAR TSDF.
+
+    Install notes: `pip install vdbfusion` fails on modern gcc
+    because of vendored blosc-1.x + zlib-1.2.8 toolchain issues.
+    A working recipe is to clone OpenVDB 12 from source, build it
+    against the fvdb conda env's TBB / Blosc / Boost, and rebuild
+    the VDBFusion wheel with `CMAKE_MODULE_PATH` pointing at the
+    OpenVDB prefix. See the helper script `install_vdbfusion.sh`
+    next to this file for the steps.
+    """
+    try:
+        import vdbfusion
+    except ImportError as e:
+        return {
+            "system": "vdbfusion", "ok": False,
+            "failure": f"vdbfusion not installed: {e}",
+        }
+    import gc
+    gc.collect()
+
+    # Warmup on first two frames so the OpenVDB thread pool + grid
+    # allocator are hot (matches the fvdb harness's 2-frame warmup).
+    vol = vdbfusion.VDBVolume(
+        voxel_size=voxel_size, sdf_trunc=truncation,
+        space_carving=carve_free_space,
+    )
+    for i in range(min(2, scene.n_frames)):
+        vol.integrate(
+            scene.points_per_frame[i].astype(np.float64, copy=False),
+            scene.sensor_origins[i].astype(np.float64, copy=False),
+        )
+    del vol
+    gc.collect()
+
+    # Fresh instance for the timed run.
+    vol = vdbfusion.VDBVolume(
+        voxel_size=voxel_size, sdf_trunc=truncation,
+        space_carving=carve_free_space,
+    )
+    # CPU workload — use wall-clock via perf_counter. We don't have
+    # GPU memory stats for CPU libraries; report peak RSS via
+    # `resource` instead so the comparison table has *some* memory
+    # number for both sides.
+    import resource
+    base_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    t0 = time.perf_counter()
+    try:
+        for i in range(scene.n_frames):
+            vol.integrate(
+                scene.points_per_frame[i].astype(np.float64, copy=False),
+                scene.sensor_origins[i].astype(np.float64, copy=False),
+            )
+    except Exception as e:  # noqa: BLE001
+        return {"system": "vdbfusion", "ok": False,
+                "failure": f"runtime: {str(e).splitlines()[0][:140]}"}
+    wall_s = time.perf_counter() - t0
+    ms_per_f = wall_s * 1000 / scene.n_frames
+
+    # Voxel count: `vol.tsdf.activeVoxelCount()` would be the natural
+    # API but the Python binding doesn't expose it directly; instead
+    # run a mesh extract (which iterates the active set) and report
+    # the vertex count as a proxy for surface complexity. Timing is
+    # already captured above so this doesn't skew ms/f.
+    try:
+        verts, tris = vol.extract_triangle_mesh(min_weight=0.1)
+        n_verts = int(verts.shape[0])
+        n_tris = int(tris.shape[0])
+    except Exception as e:  # noqa: BLE001
+        n_verts = n_tris = -1
+        print(f"    warning: VDBFusion mesh extract failed: {e}")
+
+    peak_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return {
+        "system": "vdbfusion", "ok": True,
+        "ms_per_f": ms_per_f,
+        "wall_s": wall_s,
+        # CPU RSS delta in "GB" so the column visually lines up with
+        # fvdb's GPU peak. Apples-to-oranges (host vs device mem), but
+        # order-of-magnitude is what the paper table cares about.
+        "peak_gb": max(0.0, (peak_rss_kb - base_rss_kb) / 1e6),
+        "peak_rss_gb": peak_rss_kb / 1e6,
+        "n_frames": scene.n_frames,
+        "n_voxels": n_verts,  # approximation via mesh vertex count
+        "n_mesh_verts": n_verts,
+        "n_mesh_tris": n_tris,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--root", required=True,
+                   help="path to extracted mai_city/ (the dir containing bin/)")
+    p.add_argument("--sequence", default="00",
+                   help="Mai City sequence: 00 (700m drive), 01, or 02")
+    p.add_argument("--n-frames", type=int, default=700,
+                   help="frame cap (0 or negative uses all frames)")
+    p.add_argument("--voxel-sizes", nargs="+", type=float,
+                   default=[0.2, 0.1, 0.05],
+                   help="voxel sizes in metres. Outdoor LiDAR TSDF "
+                        "defaults: 20 cm (fast), 10 cm (balanced), "
+                        "5 cm (detailed).")
+    p.add_argument("--truncation-multiplier", type=float, default=3.0)
+    p.add_argument("--carve-free-space", action="store_true", default=True,
+                   help="VDBFusion-compatible free-space carving. Default on.")
+    p.add_argument("--no-carve-free-space", dest="carve_free_space",
+                   action="store_false")
+    p.add_argument("--systems", nargs="+",
+                   default=["fvdb", "vdbfusion"],
+                   choices=["fvdb", "fvdb_per_frame", "vdbfusion", "nvblox"])
+    p.add_argument("--json-out", type=str, default=None)
+    args = p.parse_args()
+
+    max_frames = None if args.n_frames <= 0 else args.n_frames
+    scene = load_mai_city_scene(
+        args.root, sequence=args.sequence, max_frames=max_frames,
+    )
+    traj_len = float(np.linalg.norm(
+        np.diff(scene.sensor_origins, axis=0), axis=1).sum())
+    print(f"Loaded Mai City seq={args.sequence!r}: "
+          f"{scene.n_frames} frames, {scene.total_points:,} total points, "
+          f"trajectory length {traj_len:.1f} m")
+
+    results: List[Dict[str, Any]] = []
+    for vs in args.voxel_sizes:
+        trunc = vs * args.truncation_multiplier
+        print(f"\n=== voxel_size={vs*100:.1f}cm  trunc={trunc*100:.1f}cm ===")
+        for system in args.systems:
+            if system == "fvdb":
+                r = run_fvdb(scene, vs, trunc,
+                             carve_free_space=args.carve_free_space,
+                             batched=True)
+            elif system == "fvdb_per_frame":
+                r = run_fvdb(scene, vs, trunc,
+                             carve_free_space=args.carve_free_space,
+                             batched=False)
+            elif system == "vdbfusion":
+                r = run_vdbfusion(scene, vs, trunc)
+            elif system == "nvblox":
+                r = run_nvblox(scene, vs, trunc)
+            else:
+                continue
+            r["voxel_size"] = vs
+            results.append(r)
+            if r.get("ok"):
+                extra = (f"  peak={r.get('peak_gb', 0):.2f} GB  "
+                         f"voxels={r.get('n_voxels', 0):,}")
+                print(f"  {system:15s} OK  {r['ms_per_f']:7.2f} ms/f{extra}")
+            else:
+                print(f"  {system:15s} FAIL  {r.get('failure','?')[:140]}")
+        if args.json_out:
+            with open(args.json_out, "w") as f:
+                json.dump({"results": results, "args": vars(args)},
+                          f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_occupancy_kitti.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_occupancy_kitti.py
@@ -1,0 +1,106 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+KITTI Odometry counterpart to `bench_occupancy_vs_nvblox.py`.
+
+Reuses the per-config occupancy runner from
+`bench_occupancy_vs_nvblox.py` (loader-agnostic), sweeps over
+multiple sequences and multiple voxel sizes, and writes a combined
+JSON.
+
+Default voxel sweep aligns with the occupancy table in
+`PAPER_SECTION.md` §3.5. Default sequences are the standard
+NICE-SLAM trio (00, 02, 05).
+
+Usage:
+
+    cd fvdb-reality-capture/tests/benchmarks/tsdf_fusion/cross_library
+    CUDA_VISIBLE_DEVICES=1 PYTORCH_ALLOC_CONF=expandable_segments:True \\
+    /home/fwilliams/bin/miniconda3/envs/fvdb/bin/python \\
+        bench_occupancy_kitti.py \\
+        --root .../data/KITTI \\
+        --sequences 00 02 05 \\
+        --n-frames 100 \\
+        --voxel-sizes-m 0.2 0.1 0.05 0.03 0.02 0.015 \\
+        --json-out ./results/kitti_occupancy.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from kitti_loader import load_kitti_scene  # noqa: E402
+from bench_occupancy_vs_nvblox import (  # noqa: E402
+    _format_scale_table,
+    _run_one_config,
+)
+
+
+# Mai City evidence: nvblox occupancy never OOMs through 1.5 cm
+# (the table in §3.5 has a value at every voxel). So no skip rule.
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", required=True,
+                    help="Path to KITTI root (contains dataset/sequences/...)")
+    ap.add_argument("--sequences", nargs="+", default=["00", "02", "05"])
+    ap.add_argument("--n-frames", type=int, default=100)
+    ap.add_argument("--voxel-sizes-m", type=float, nargs="+",
+                    default=[0.2, 0.1, 0.05, 0.03, 0.02, 0.015])
+    ap.add_argument("--trunc-voxel-multiplier", type=float, default=3.0)
+    ap.add_argument("--skip-nvblox", action="store_true")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    all_results: list[dict[str, Any]] = []
+    t_start = time.time()
+
+    for seq in args.sequences:
+        print(f"\n##### KITTI seq={seq!r} #####")
+        scene = load_kitti_scene(
+            root_dir=args.root, sequence=seq,
+            max_frames=args.n_frames,
+        )
+        print(f"[load] done. {scene.n_frames} frames, "
+              f"{scene.total_points / 1e6:.2f} M points total")
+
+        for vs in args.voxel_sizes_m:
+            r = _run_one_config(
+                scene,
+                voxel_size=float(vs),
+                truncation=float(vs) * args.trunc_voxel_multiplier,
+                skip_nvblox=args.skip_nvblox,
+            )
+            r["sequence"] = seq
+            r["dataset"] = "kitti"
+            all_results.append(r)
+            if args.json_out is not None:
+                args.json_out.parent.mkdir(parents=True, exist_ok=True)
+                with args.json_out.open("w") as f:
+                    json.dump({
+                        "config": {
+                            "sequences": args.sequences,
+                            "n_frames": args.n_frames,
+                            "trunc_voxel_multiplier":
+                                args.trunc_voxel_multiplier,
+                        },
+                        "results": all_results,
+                    }, f, indent=2)
+
+    print("")
+    print(_format_scale_table(all_results))
+    print(f"\n##### Total wall time: {(time.time() - t_start) / 60:.1f} min #####")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_occupancy_vs_nvblox.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_occupancy_vs_nvblox.py
@@ -1,0 +1,330 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Occupancy mapping cross-library comparison on Mai City LiDAR.
+
+fvdb `Grid.integrate_occupancy_from_points_frames` vs nvblox
+`ProjectiveIntegratorType.OCCUPANCY`. Both systems consume the same N
+Mai City LiDAR sweeps and produce a per-voxel log-odds occupancy
+representation; this driver measures end-to-end fusion time
+(TSDF-equivalent role in nvblox's integrator) and scale ceiling.
+
+This is the paper's fifth application of the topology-op vocabulary,
+and closes the nvblox feature-parity gap. See session notes for the
+primitive-matrix update.
+
+Scope: Mai City LiDAR (the only sensor modality with a working
+nvblox-side LiDAR occupancy path). 100 frames default, scale-sweep
+mode matching `bench_esdf_vs_nvblox.py`.
+
+Usage:
+
+    cd fvdb-reality-capture/tests/benchmarks/tsdf_fusion/cross_library
+    CUDA_VISIBLE_DEVICES=1 PYTORCH_ALLOC_CONF=expandable_segments:True \\
+    /home/fwilliams/bin/miniconda3/envs/fvdb/bin/python \\
+        bench_occupancy_vs_nvblox.py \\
+        --root ../../data/mai_city/mai_city \\
+        --sequence 00 --n-frames 100 \\
+        --voxel-sizes-m 0.2 0.1 0.05 0.03 0.02 \\
+        --trunc-voxel-multiplier 3 \\
+        --json-out ./results/scale_ceiling_mai_city.json
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import numpy as np
+import torch
+
+import fvdb
+
+from mai_city_loader import load_mai_city_scene
+
+
+NVBLOX_ENV_PYTHON = "/home/fwilliams/bin/miniconda3/envs/nvblox/bin/python"
+
+
+def _run_fvdb(
+    scene,
+    voxel_size: float,
+    truncation: float,
+) -> dict[str, Any]:
+    """Build a log-odds occupancy map from the scene via
+    `integrate_occupancy_from_points_frames`. Measures fusion wall-
+    clock (per-frame amortised) and peak GPU memory."""
+    device = "cuda"
+
+    points_torch = [
+        torch.from_numpy(p).to(device=device, dtype=torch.float32)
+        for p in scene.points_per_frame
+    ]
+    sensor_origins_t = torch.from_numpy(scene.sensor_origins).to(
+        device=device, dtype=torch.float32)
+
+    seed_grid = fvdb.Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+    )
+    log_odds_init = torch.zeros(
+        seed_grid.num_voxels, device=device, dtype=torch.float32)
+
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    out_grid, out_log_odds = seed_grid.integrate_occupancy_from_points_frames(
+        truncation_distance=truncation,
+        points_per_frame=points_torch,
+        sensor_origins=sensor_origins_t,
+        log_odds=log_odds_init,
+    )
+    torch.cuda.synchronize()
+    fuse_s = time.perf_counter() - t0
+    ms_per_f = fuse_s * 1000 / scene.n_frames
+
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    # A bit of distributional info on the final log-odds: how many
+    # voxels are "confidently occupied" (log_odds > 2) vs
+    # "confidently free" (log_odds < -2). Useful sanity for the
+    # paper's "fvdb produces an actually-usable occupancy volume".
+    lo = out_log_odds
+    n_occupied = int((lo > 2.0).sum().item())
+    n_free     = int((lo < -2.0).sum().item())
+    n_unknown  = int((lo.abs() <= 2.0).sum().item())
+
+    return {
+        "system": "fvdb",
+        "fuse_s": fuse_s,
+        "ms_per_f": ms_per_f,
+        "n_voxels": int(out_grid.num_voxels),
+        "n_leaves": int(out_grid.num_leaf_nodes),
+        "n_occupied_voxels": n_occupied,
+        "n_free_voxels": n_free,
+        "n_unknown_voxels": n_unknown,
+        "log_odds_min": float(lo.min().item()),
+        "log_odds_max": float(lo.max().item()),
+        "peak_torch_gb": peak_torch_gb,
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "n_frames": scene.n_frames,
+    }
+
+
+def _run_nvblox(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    num_azimuth: int = 1800,
+    num_elevation: int = 64,
+    vertical_fov_rad: float = 0.4712,
+) -> dict[str, Any]:
+    """Run nvblox occupancy integrator (LiDAR) via the dedicated-env
+    subprocess."""
+    runner = str(Path(__file__).resolve().parent / "nvblox_runner.py")
+
+    with tempfile.TemporaryDirectory(prefix="nvblox_occ_") as tmp:
+        pts_concat = np.concatenate(scene.points_per_frame, axis=0).astype(np.float32)
+        offsets = np.zeros(scene.n_frames + 1, dtype=np.int64)
+        offsets[1:] = np.cumsum([p.shape[0] for p in scene.points_per_frame])
+
+        npz_path = os.path.join(tmp, "mai_city_sweeps.npz")
+        np.savez(
+            npz_path,
+            points_per_frame_concat=pts_concat,
+            points_per_frame_offsets=offsets,
+            sensor_origins=scene.sensor_origins.astype(np.float32),
+            cam_to_world=scene.cam_to_world.astype(np.float32),
+        )
+
+        spec = {
+            "workload": "lidar_occupancy",
+            "voxel_size_m": voxel_size,
+            "truncation_distance_m": truncation,
+            "lidar_num_azimuth": num_azimuth,
+            "lidar_num_elevation": num_elevation,
+            "lidar_vertical_fov_rad": vertical_fov_rad,
+            "lidar_min_valid_range_m": 1.0,
+            "lidar_sweeps_npz": npz_path,
+            "warmup_frames": 2,
+        }
+        spec_path = os.path.join(tmp, "spec.json")
+        out_path  = os.path.join(tmp, "result.json")
+        with open(spec_path, "w") as f:
+            json.dump(spec, f)
+
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = env.get("CUDA_VISIBLE_DEVICES", "1")
+        proc = subprocess.run(
+            [NVBLOX_ENV_PYTHON, runner, "--spec", spec_path, "--output", out_path],
+            env=env, capture_output=True, text=True, timeout=3600,
+        )
+        if not os.path.exists(out_path):
+            return {"system": "nvblox", "ok": False,
+                    "failure": f"no output. stderr tail: {proc.stderr[-500:]!r}"}
+        with open(out_path, "r") as f:
+            result = json.load(f)
+
+    result["system"] = "nvblox"
+    result["voxel_size_m"] = voxel_size
+    result["truncation_m"] = truncation
+    return result
+
+
+def _run_one_config(
+    scene, voxel_size: float, truncation: float, skip_nvblox: bool,
+) -> dict[str, Any]:
+    print(f"\n[config] voxel={voxel_size}  trunc={truncation}")
+    result: dict[str, Any] = {
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+    }
+    try:
+        result["fvdb"] = _run_fvdb(scene, voxel_size, truncation)
+        result["fvdb"]["ok"] = True
+        r = result["fvdb"]
+        print(f"  fvdb: fuse {r['fuse_s']:.2f} s  ({r['ms_per_f']:.1f} ms/f)  "
+              f"voxels {r['n_voxels']:,}  leaves {r['n_leaves']:,}  "
+              f"peak_gb {r['peak_torch_gb']:.2f}  "
+              f"occ {r['n_occupied_voxels']:,} / "
+              f"free {r['n_free_voxels']:,} / unknown {r['n_unknown_voxels']:,}")
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  fvdb: OOM - {e}")
+        result["fvdb"] = {"ok": False, "failure": f"OOM: {e}"}
+        torch.cuda.empty_cache(); gc.collect()
+    except Exception as e:  # noqa: BLE001
+        print(f"  fvdb: failed ({type(e).__name__}: {e})")
+        result["fvdb"] = {"ok": False, "failure": f"{type(e).__name__}: {e}"}
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    if skip_nvblox:
+        result["nvblox"] = {"ok": False, "failure": "skipped"}
+    else:
+        try:
+            nvblox_result = _run_nvblox(scene, voxel_size, truncation)
+            result["nvblox"] = nvblox_result
+            if nvblox_result.get("ok", False):
+                print(f"  nvblox: fuse {nvblox_result['wall_s']:.2f} s  "
+                      f"({nvblox_result['ms_per_f']:.1f} ms/f)  "
+                      f"approx_vx {nvblox_result['n_voxels']:,}  "
+                      f"blocks {nvblox_result['n_blocks']:,}  "
+                      f"gpu_gb {nvblox_result.get('gpu_used_gb', -1):.2f}")
+            else:
+                print(f"  nvblox: FAILED {nvblox_result.get('failure', '?')}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  nvblox: driver error ({type(e).__name__}: {e})")
+            result["nvblox"] = {"ok": False,
+                                "failure": f"driver: {type(e).__name__}: {e}"}
+
+    return result
+
+
+def _format_scale_table(results: list[dict[str, Any]]) -> str:
+    """Render the scale-ceiling summary table. `ratio` = fvdb_ms_per_f
+    / nvblox_ms_per_f; >1 means nvblox wins, <1 means fvdb wins,
+    `fvdb∞` means nvblox OOM/FAILed while fvdb succeeded."""
+    lines = []
+    lines.append("=== Occupancy Scale Ceiling (Mai City) ===")
+    lines.append(f"{'voxel':>6}  {'fvdb_voxels':>12}  {'fvdb_ms/f':>10}  "
+                 f"{'fvdb_gb':>7}  {'nvblox_ms/f':>12}  {'nvblox_gb':>9}  "
+                 f"{'ratio':>8}")
+    for r in results:
+        vs = r["voxel_size_m"]
+        fv = r.get("fvdb", {})
+        nv = r.get("nvblox", {})
+        if fv.get("ok"):
+            fv_str = (f"{fv['n_voxels']:>12,}  "
+                      f"{fv['ms_per_f']:>10.1f}  "
+                      f"{fv['peak_torch_gb']:>7.2f}")
+        else:
+            fv_str = f"{'OOM':>12}  {'--':>10}  {'--':>7}"
+        if nv.get("ok"):
+            nv_ms = nv.get("ms_per_f", -1)
+            nv_gb = nv.get("gpu_used_gb", -1)
+            if fv.get("ok") and nv_ms > 0 and fv["ms_per_f"] > 0:
+                ratio = f"{fv['ms_per_f'] / nv_ms:.2f}x"
+            else:
+                ratio = "--"
+            nv_str = f"{nv_ms:>12.1f}  {nv_gb:>9.2f}  {ratio:>8}"
+        else:
+            fail = str(nv.get("failure", ""))
+            looks_oom = ("OOM" in fail.upper()
+                         or "OutOfMemory" in fail
+                         or "cudaMalloc" in fail
+                         or "out of memory" in fail.lower())
+            if looks_oom:
+                nv_str = f"{'OOM':>12}  {'--':>9}  {'fvdb∞':>8}"
+            elif "skipped" in fail.lower():
+                nv_str = f"{'skip':>12}  {'--':>9}  {'--':>8}"
+            else:
+                nv_str = f"{'FAIL':>12}  {'--':>9}  {'--':>8}"
+        lines.append(f"{vs:>6.3f}  {fv_str}  {nv_str}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True,
+                    help="Path to Mai City root (contains bin/sequences/.../velodyne)")
+    ap.add_argument("--sequence", default="00")
+    ap.add_argument("--n-frames", type=int, default=100)
+    ap.add_argument("--voxel-sizes-m", type=float, nargs="+", required=True)
+    ap.add_argument("--trunc-voxel-multiplier", type=float, default=3.0)
+    ap.add_argument("--skip-nvblox", action="store_true")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    configs = [{
+        "voxel_size": float(vs),
+        "truncation":  float(vs) * args.trunc_voxel_multiplier,
+    } for vs in args.voxel_sizes_m]
+
+    print(f"[load] Mai City seq={args.sequence}  n_frames={args.n_frames}")
+    scene = load_mai_city_scene(
+        root_dir=args.root, sequence=args.sequence,
+        max_frames=args.n_frames,
+    )
+    print(f"[load] done. {scene.n_frames} frames, "
+          f"{scene.total_points / 1e6:.2f} M points total")
+
+    results: list[dict[str, Any]] = []
+    for cfg in configs:
+        results.append(_run_one_config(
+            scene, voxel_size=cfg["voxel_size"],
+            truncation=cfg["truncation"], skip_nvblox=args.skip_nvblox,
+        ))
+
+    print("")
+    print(_format_scale_table(results))
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.json_out.open("w") as f:
+            json.dump({
+                "config": {
+                    "sequence": args.sequence,
+                    "n_frames": args.n_frames,
+                    "trunc_voxel_multiplier": args.trunc_voxel_multiplier,
+                },
+                "results": results,
+            }, f, indent=2)
+        print(f"\nWrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_open3d_vs_fvdb.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_open3d_vs_fvdb.py
@@ -1,0 +1,1059 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+fvdb vs Open3D smoke comparison on a synthetic RGB-D sphere scene.
+
+Workload: N views of a unit-radius-ish sphere rendered from random
+camera poses via analytical ray-sphere intersection. No external
+dataset download; runs in a few seconds.
+
+Measures for each library:
+  - Wall-clock: per-frame integration time, mesh extraction time.
+  - Peak memory: GPU (fvdb) or host (Open3D, CPU).
+  - Mesh size: vertex count, triangle count.
+  - Reconstruction quality: symmetric Chamfer-L1 vs GT sphere surface
+    (uniform-sampled), F-score at tau = voxel_size.
+
+Useful as a head-to-head smoke test that doesn't require the nvblox
+or VDBFusion Docker infrastructure.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Default to PyTorch's expandable-segments allocator *before* importing
+# torch, since the allocator config is read at first CUDA initialization
+# and setting it later has no effect. At Replica-scale (N=200 frames,
+# 1200x680) the TSDF truncation-shell build fragments enough of the
+# default caching allocator that fvdb can OOM on office0 / room1 even
+# though <10 GB is genuinely live; `expandable_segments=True` lets torch
+# grow existing blocks instead of reserving new ones, reclaiming the
+# ~10-15 GB of fragmented "reserved but unallocated" space and unblocking
+# N=200 on every Replica scene we benchmark. Overridable via the env var.
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import argparse
+import dataclasses
+import gc
+import math
+import resource
+import time
+from typing import Dict, List, Tuple
+
+import numpy as np
+import open3d as o3d
+import torch
+
+import fvdb
+from fvdb import Grid, JaggedTensor
+
+try:
+    from .replica_loader import load_replica_scene, ReplicaScene
+except ImportError:
+    # Allow running as a script from the parent dir.
+    import sys as _sys
+    _sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from replica_loader import load_replica_scene, ReplicaScene  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Scene generation
+# ---------------------------------------------------------------------------
+
+
+def _look_at(eye: np.ndarray, target: np.ndarray, up_world: np.ndarray) -> np.ndarray:
+    """Return a cam->world 4x4 matrix placing the camera at `eye` looking at `target`."""
+    forward = target - eye
+    forward = forward / np.linalg.norm(forward)
+    right = np.cross(forward, up_world)
+    right = right / (np.linalg.norm(right) + 1e-12)
+    up = np.cross(right, forward)
+    # OpenCV camera convention: +x right, +y down, +z forward.
+    R = np.stack([right, -up, forward], axis=1)
+    cam_to_world = np.eye(4)
+    cam_to_world[:3, :3] = R
+    cam_to_world[:3, 3] = eye
+    return cam_to_world
+
+
+def _render_sphere_depth(
+    sphere_center: np.ndarray,
+    sphere_radius: float,
+    cam_to_world: np.ndarray,
+    K: np.ndarray,
+    W: int,
+    H: int,
+    max_depth: float,
+) -> np.ndarray:
+    """Analytical ray-sphere depth renderer.
+
+    Returns a (H, W) float32 depth image. Pixels that miss the sphere
+    get 0 (no-measurement convention used by both libraries).
+    """
+    # Build per-pixel ray directions in camera space (OpenCV: +z forward).
+    fx = K[0, 0]
+    fy = K[1, 1]
+    cx = K[0, 2]
+    cy = K[1, 2]
+    uu, vv = np.meshgrid(np.arange(W), np.arange(H))
+    x = (uu - cx) / fx
+    y = (vv - cy) / fy
+    z = np.ones_like(x)
+    dirs_cam = np.stack([x, y, z], axis=-1).reshape(-1, 3)
+    dirs_cam = dirs_cam / np.linalg.norm(dirs_cam, axis=1, keepdims=True)
+
+    # Transform to world.
+    R = cam_to_world[:3, :3]
+    origin = cam_to_world[:3, 3]
+    dirs_world = dirs_cam @ R.T
+
+    # Ray-sphere intersection. (O + t*d - c) · (O + t*d - c) = r^2
+    oc = origin - sphere_center
+    b = 2.0 * (dirs_world @ oc)
+    c = oc @ oc - sphere_radius * sphere_radius
+    disc = b * b - 4.0 * c
+    hit = disc >= 0.0
+    disc_clamped = np.where(hit, disc, 0.0)
+    t = (-b - np.sqrt(disc_clamped)) / 2.0
+    depth_cam = t * dirs_cam[:, 2]  # depth (z) along camera forward
+    depth_cam = np.where((t > 0) & hit & (depth_cam < max_depth), depth_cam, 0.0)
+    return depth_cam.reshape(H, W).astype(np.float32)
+
+
+@dataclasses.dataclass
+class SyntheticScene:
+    depth_images: np.ndarray  # [N, H, W] float32, 0 = miss
+    cam_to_world: np.ndarray  # [N, 4, 4] float32
+    K: np.ndarray  # [3, 3] float32 (shared intrinsics)
+    sphere_center: np.ndarray  # [3] float32
+    sphere_radius: float
+
+
+def make_sphere_scene(
+    n_frames: int = 16,
+    W: int = 320,
+    H: int = 240,
+    sphere_radius: float = 0.5,
+    sphere_center: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    cam_radius: float = 1.5,
+    max_depth: float = 5.0,
+    fov_deg: float = 60.0,
+    seed: int = 0,
+) -> SyntheticScene:
+    rng = np.random.default_rng(seed)
+    sphere_center_np = np.asarray(sphere_center, dtype=np.float32)
+
+    # Fibonacci-lattice cameras on a sphere around the target.
+    idx = np.arange(n_frames) + 0.5
+    phi = idx * math.pi * (3.0 - math.sqrt(5.0))
+    cos_theta = 1.0 - 2.0 * idx / n_frames
+    sin_theta = np.sqrt(np.clip(1.0 - cos_theta * cos_theta, 0.0, 1.0))
+    cams = np.stack(
+        [
+            cam_radius * np.cos(phi) * sin_theta,
+            cam_radius * np.sin(phi) * sin_theta,
+            cam_radius * cos_theta,
+        ],
+        axis=1,
+    ).astype(np.float32)
+    # Jitter the cameras slightly to avoid perfect symmetry masking bugs.
+    cams += 0.02 * rng.standard_normal(cams.shape).astype(np.float32)
+
+    up_world = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+    cam_to_worlds = np.stack(
+        [_look_at(eye, sphere_center_np, up_world) for eye in cams], axis=0
+    ).astype(np.float32)
+
+    # Shared intrinsics.
+    fx = fy = (W / 2.0) / math.tan(math.radians(fov_deg) / 2.0)
+    K = np.array([[fx, 0, W / 2.0], [0, fy, H / 2.0], [0, 0, 1]], dtype=np.float32)
+
+    depth_images = np.stack(
+        [
+            _render_sphere_depth(
+                sphere_center_np, sphere_radius, c2w, K, W, H, max_depth
+            )
+            for c2w in cam_to_worlds
+        ],
+        axis=0,
+    )
+
+    return SyntheticScene(
+        depth_images=depth_images,
+        cam_to_world=cam_to_worlds,
+        K=K,
+        sphere_center=sphere_center_np,
+        sphere_radius=sphere_radius,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-library integration
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class RunResult:
+    library: str
+    integrate_s: float
+    mesh_extract_s: float
+    mesh_V: int
+    mesh_F: int
+    mesh_verts: np.ndarray  # [V, 3] float32 in world space
+    peak_gpu_mb: float
+    peak_host_mb: float
+
+
+def _peak_host_mb() -> float:
+    """Coarse peak host-memory sample via RUSAGE_SELF.ru_maxrss (KiB on Linux).
+
+    Only meaningful as a *delta* across a library call — the process
+    baseline includes libtorch + CUDA runtime, which is constant and
+    dominates the absolute value.
+    """
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+
+
+def _estimate_scene_bbox(scene) -> tuple[np.ndarray, np.ndarray]:
+    """Return world-space ``(min_xyz, max_xyz)`` enclosing all
+    sensor positions + a simple depth-extent margin.
+
+    This sizes the initial dense bounding-box grid for fvdb without
+    requiring the caller to hand-tune `grid_extent` per scene. For
+    the synthetic sphere we'd happily use a fixed `[-1.5, 1.5]^3`;
+    for Replica rooms we need something scene-dependent.
+    """
+    centres = scene.cam_to_world[:, :3, 3]
+    bbox_min = centres.min(axis=0).astype(np.float32)
+    bbox_max = centres.max(axis=0).astype(np.float32)
+    # Expand by the p95 of observed depth so any ray endpoint lands
+    # inside the initial grid. 99th percentile would be more
+    # conservative but spikes from stray pixels blow up the extent.
+    valid = scene.depth_images[scene.depth_images > 0]
+    margin = float(np.percentile(valid, 95)) if valid.size else 1.0
+    bbox_min = bbox_min - margin
+    bbox_max = bbox_max + margin
+    return bbox_min, bbox_max
+
+
+def integrate_fvdb(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    device: str = "cuda",
+    grid_extent: float | None = None,
+    mode: str = "per_frame",
+    start_empty: bool = False,
+) -> RunResult:
+    """Integrate all frames into a TSDF volume.
+
+    `mode`:
+      - "per_frame": loop N calls to `Grid.integrate_tsdf` (rebuilds
+        topology per frame). Legacy / naive path.
+      - "frames":    one call to `Grid.integrate_tsdf_frames` (builds
+        topology once over all frames). (one-shot N-frame topology).
+
+    `grid_extent` / `start_empty`:
+      - start_empty=True: initial grid is a minimal 1x1x1 (same as
+        the LiDAR integrator's convention) — the integrate call's
+        union-topology build grows it to cover the scene. Required
+        for room-scale scenes where a dense bbox would OOM.
+      - grid_extent=float: half-extent of a unit-box dense grid at
+        origin (legacy, kept for the synthetic sphere smoke).
+      - grid_extent=None: auto-estimate dense bbox from scene sensor
+        positions + depth p95.
+    """
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device=device)
+    gc.collect()
+    host_before = _peak_host_mb()
+
+    if start_empty:
+        # 1x1x1 minimal grid at origin — metadata (voxel_size, origin)
+        # carries through to the union grid; no up-front dense allocation.
+        grid = Grid.from_dense(
+            dense_dims=[1, 1, 1],
+            ijk_min=[0, 0, 0],
+            voxel_size=voxel_size,
+            origin=[0, 0, 0],
+            device=device,
+        )
+    else:
+        if grid_extent is None:
+            bbox_min_np, bbox_max_np = _estimate_scene_bbox(scene)
+        else:
+            bbox_min_np = np.array([-grid_extent] * 3, np.float32)
+            bbox_max_np = np.array([grid_extent] * 3, np.float32)
+
+        side_xyz = np.ceil((bbox_max_np - bbox_min_np) / voxel_size).astype(np.int64)
+        side_xyz = np.maximum(side_xyz, 1)
+        ijk_min = np.floor(bbox_min_np / voxel_size).astype(np.int64)
+        grid = Grid.from_dense(
+            dense_dims=[int(side_xyz[0]), int(side_xyz[1]), int(side_xyz[2])],
+            ijk_min=[int(ijk_min[0]), int(ijk_min[1]), int(ijk_min[2])],
+            voxel_size=voxel_size,
+            origin=[0, 0, 0],
+            device=device,
+        )
+    tsdf = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+    weights = torch.zeros(grid.num_voxels, device=device, dtype=torch.float32)
+
+    # Pre-upload camera matrices + depth (warm the caches before timing).
+    K = torch.from_numpy(scene.K).to(device)
+    cam_to_world = torch.from_numpy(scene.cam_to_world).to(device)
+    depth_images = torch.from_numpy(scene.depth_images).to(device)
+    torch.cuda.synchronize()
+
+    N = scene.depth_images.shape[0]
+    K_per_frame = K.unsqueeze(0).expand(N, 3, 3).contiguous()
+
+    t0 = time.perf_counter()
+    if mode == "frames":
+        grid, tsdf, weights = grid.integrate_tsdf_frames(
+            truncation_distance=truncation,
+            projection_matrices=K_per_frame,
+            cam_to_world_matrices=cam_to_world,
+            tsdf=tsdf,
+            weights=weights,
+            depth_images=depth_images,
+        )
+    elif mode == "per_frame":
+        for f in range(N):
+            grid, tsdf, weights = grid.integrate_tsdf(
+                truncation_distance=truncation,
+                projection_matrices=K.unsqueeze(0),
+                cam_to_world_matrices=cam_to_world[f : f + 1],
+                tsdf=tsdf,
+                weights=weights,
+                depth_images=depth_images[f : f + 1],
+            )
+    else:
+        raise ValueError(f"unknown mode {mode!r}; expected 'per_frame' or 'frames'")
+    torch.cuda.synchronize()
+    integrate_s = time.perf_counter() - t0
+
+    # Mesh extraction should only run on observed voxels — otherwise MC
+    # finds a spurious zero-crossing at the boundary between the
+    # truncation band's `-1` values and the unobserved-voxel default of
+    # 0. Prune the grid to `weights > 0` (the same pattern as the LiDAR
+    # integrator's sphere-reconstruction test).
+    observed_mask = weights > 0
+    pruned_grid = grid.pruned_grid(observed_mask)
+    pruned_tsdf = tsdf[observed_mask]
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    v, f, _ = pruned_grid.marching_cubes(pruned_tsdf, 0.0)
+    torch.cuda.synchronize()
+    mesh_extract_s = time.perf_counter() - t0
+
+    peak_gpu_mb = torch.cuda.max_memory_allocated(device=device) / (1024 * 1024)
+
+    verts_np = v.detach().cpu().numpy()
+    return RunResult(
+        library=f"fvdb_{mode}",
+        integrate_s=integrate_s,
+        mesh_extract_s=mesh_extract_s,
+        mesh_V=v.shape[0],
+        mesh_F=f.shape[0],
+        mesh_verts=verts_np,
+        peak_gpu_mb=peak_gpu_mb,
+        peak_host_mb=_peak_host_mb() - host_before,
+    )
+
+
+def integrate_open3d_cuda(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    device: str = "cuda",
+    block_resolution: int = 16,
+    block_count: int = 100_000,
+) -> RunResult:
+    """Integrate via Open3D's `t.geometry.VoxelBlockGrid` (GPU).
+
+    This is Open3D's "tensor" TSDF backend — CUDA-native, the
+    canonical comparison for fvdb's GPU path (vs `ScalableTSDFVolume`
+    which is CPU-only and therefore an unfair column on its own).
+    Matches NICE-SLAM / Co-SLAM / ESLAM's Open3D-based baselines.
+    """
+    import open3d as o3d
+    import open3d.core as o3c
+
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device=device)
+    gc.collect()
+    host_before = _peak_host_mb()
+
+    o3d_device = o3c.Device("CUDA:0")
+
+    # trunc_voxel_multiplier = truncation / voxel_size; Open3D expects
+    # it as an integer-ish float (default 8 -> 8 * voxel_size truncation).
+    trunc_mul = float(truncation / voxel_size)
+
+    vbg = o3d.t.geometry.VoxelBlockGrid(
+        attr_names=("tsdf", "weight"),
+        attr_dtypes=(o3c.float32, o3c.float32),
+        attr_channels=((1,), (1,)),
+        voxel_size=voxel_size,
+        block_resolution=block_resolution,
+        block_count=block_count,
+        device=o3d_device,
+    )
+
+    K_o3d = o3c.Tensor(
+        np.asarray(scene.K, dtype=np.float64),
+        o3c.float64, device=o3c.Device("CPU:0"),
+    )
+
+    # Warm-up: Open3D's first CUDA invocation eats ~hundreds of ms of
+    # JIT; amortize it outside the timed region so per-frame numbers
+    # are steady-state.
+    warm_depth = o3d.t.geometry.Image(
+        o3c.Tensor(scene.depth_images[0:1].astype(np.float32).squeeze(0),
+                   o3c.float32, o3d_device)
+    )
+    warm_ext = o3c.Tensor(
+        np.linalg.inv(scene.cam_to_world[0]).astype(np.float64),
+        o3c.float64, device=o3c.Device("CPU:0"),
+    )
+    _ = vbg.compute_unique_block_coordinates(
+        warm_depth, K_o3d, warm_ext, depth_scale=1.0, depth_max=10.0)
+    # Reset the vbg after warmup (empty it so the timed run starts
+    # from the same state as fvdb: no pre-allocated data).
+    vbg = o3d.t.geometry.VoxelBlockGrid(
+        attr_names=("tsdf", "weight"),
+        attr_dtypes=(o3c.float32, o3c.float32),
+        attr_channels=((1,), (1,)),
+        voxel_size=voxel_size,
+        block_resolution=block_resolution,
+        block_count=block_count,
+        device=o3d_device,
+    )
+
+    N = scene.depth_images.shape[0]
+    # Precompute extrinsics (world-to-cam inverse of cam_to_world).
+    extrinsics = np.linalg.inv(scene.cam_to_world)
+
+    # Stage depth onto device once so we're timing TSDF integration,
+    # not host->device DMA. (fvdb does the same staging before its
+    # timed region.)
+    depth_staging = []
+    for i in range(N):
+        d = o3c.Tensor(scene.depth_images[i].astype(np.float32),
+                       o3c.float32, o3d_device)
+        depth_staging.append(o3d.t.geometry.Image(d))
+
+    extrinsic_staging = [
+        o3c.Tensor(extrinsics[i].astype(np.float64),
+                   o3c.float64, device=o3c.Device("CPU:0"))
+        for i in range(N)
+    ]
+
+    o3c.cuda.synchronize()
+    t0 = time.perf_counter()
+    for i in range(N):
+        depth_i = depth_staging[i]
+        ext_i = extrinsic_staging[i]
+        frustum = vbg.compute_unique_block_coordinates(
+            depth_i, K_o3d, ext_i,
+            depth_scale=1.0, depth_max=10.0,
+            trunc_voxel_multiplier=trunc_mul,
+        )
+        vbg.integrate(
+            frustum, depth_i, K_o3d, ext_i,
+            depth_scale=1.0, depth_max=10.0,
+            trunc_voxel_multiplier=trunc_mul,
+        )
+    o3c.cuda.synchronize()
+    integrate_s = time.perf_counter() - t0
+
+    o3c.cuda.synchronize()
+    t0 = time.perf_counter()
+    try:
+        mesh = vbg.extract_triangle_mesh()
+        o3c.cuda.synchronize()
+        mesh_extract_s = time.perf_counter() - t0
+        verts = mesh.vertex.positions.cpu().numpy().astype(np.float32)
+        tris = mesh.triangle.indices.cpu().numpy().astype(np.int64)
+    except RuntimeError as e:
+        # Open3D's VBG.extract_triangle_mesh asserts on SetVertexColors
+        # shape when the grid is empty / too-tiny to have extracted any
+        # verts. Tolerate that in the warmup / degenerate-scene case.
+        o3c.cuda.synchronize()
+        mesh_extract_s = time.perf_counter() - t0
+        verts = np.empty((0, 3), np.float32)
+        tris = np.empty((0, 3), np.int64)
+
+    peak_gpu_mb = torch.cuda.max_memory_allocated(device=device) / (1024 * 1024)
+    return RunResult(
+        library="open3d_cuda",
+        integrate_s=integrate_s,
+        mesh_extract_s=mesh_extract_s,
+        mesh_V=verts.shape[0],
+        mesh_F=tris.shape[0],
+        mesh_verts=verts,
+        peak_gpu_mb=peak_gpu_mb,
+        peak_host_mb=_peak_host_mb() - host_before,
+    )
+
+
+def integrate_open3d(
+    scene: SyntheticScene,
+    voxel_size: float,
+    truncation: float,
+) -> RunResult:
+    """Integrate via Open3D's ScalableTSDFVolume (CPU)."""
+    gc.collect()
+    host_before = _peak_host_mb()
+
+    volume = o3d.pipelines.integration.ScalableTSDFVolume(
+        voxel_length=voxel_size,
+        sdf_trunc=truncation,
+        color_type=o3d.pipelines.integration.TSDFVolumeColorType.NoColor,
+    )
+
+    W = scene.depth_images.shape[2]
+    H = scene.depth_images.shape[1]
+    intrinsics = o3d.camera.PinholeCameraIntrinsic(
+        W, H,
+        fx=float(scene.K[0, 0]),
+        fy=float(scene.K[1, 1]),
+        cx=float(scene.K[0, 2]),
+        cy=float(scene.K[1, 2]),
+    )
+
+    t0 = time.perf_counter()
+    for f in range(scene.depth_images.shape[0]):
+        depth = o3d.geometry.Image(scene.depth_images[f])
+        # Dummy colour so the RGBDImage constructor is happy.
+        dummy_color = o3d.geometry.Image(
+            np.zeros((H, W, 3), dtype=np.uint8)
+        )
+        # `depth_trunc` is the "beyond this range, treat as no measurement"
+        # cap — not the TSDF truncation-band width. Set it well past our
+        # scene extent so no pixels are silently dropped (fvdb's
+        # integrate_tsdf doesn't have an equivalent parameter, so it
+        # integrates every non-zero pixel).
+        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            dummy_color,
+            depth,
+            depth_scale=1.0,
+            depth_trunc=1e6,
+            convert_rgb_to_intensity=False,
+        )
+        # Open3D wants world->cam (extrinsic), not cam->world.
+        extrinsic = np.linalg.inv(scene.cam_to_world[f])
+        volume.integrate(rgbd, intrinsics, extrinsic)
+    integrate_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    mesh = volume.extract_triangle_mesh()
+    mesh_extract_s = time.perf_counter() - t0
+
+    verts = np.asarray(mesh.vertices, dtype=np.float32)
+    tris = np.asarray(mesh.triangles, dtype=np.int64)
+
+    return RunResult(
+        library="open3d",
+        integrate_s=integrate_s,
+        mesh_extract_s=mesh_extract_s,
+        mesh_V=verts.shape[0],
+        mesh_F=tris.shape[0],
+        mesh_verts=verts,
+        peak_gpu_mb=0.0,
+        peak_host_mb=_peak_host_mb() - host_before,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quality metrics vs GT sphere
+# ---------------------------------------------------------------------------
+
+
+def _sample_sphere_surface(
+    n_points: int, center: np.ndarray, radius: float, rng: np.random.Generator
+) -> np.ndarray:
+    """Uniform-area sample n_points on a sphere surface."""
+    phi = rng.uniform(0, 2 * math.pi, n_points)
+    cos_theta = rng.uniform(-1, 1, n_points)
+    sin_theta = np.sqrt(1.0 - cos_theta * cos_theta)
+    pts = np.stack(
+        [
+            radius * np.cos(phi) * sin_theta,
+            radius * np.sin(phi) * sin_theta,
+            radius * cos_theta,
+        ],
+        axis=1,
+    ).astype(np.float32)
+    pts += center
+    return pts
+
+
+def _chunked_nn_distances(
+    points_a: torch.Tensor, points_b: torch.Tensor, chunk: int = 4096
+) -> torch.Tensor:
+    """For each point in `points_a`, return min L2 distance to `points_b`.
+
+    Chunked to avoid an `|A|*|B|` pairwise matrix blowing up memory on
+    Replica-scale meshes (hundreds-of-thousands of verts x sampled-GT).
+    """
+    out = torch.empty(points_a.shape[0], device=points_a.device)
+    for s in range(0, points_a.shape[0], chunk):
+        e = min(s + chunk, points_a.shape[0])
+        dmat = torch.cdist(points_a[s:e], points_b)
+        out[s:e] = dmat.min(dim=1).values
+    return out
+
+
+def _compute_chamfer_f_score(
+    mesh_verts_np: np.ndarray,
+    gt_np: np.ndarray,
+    f_score_tau: float,
+    device: str,
+) -> Dict[str, float]:
+    if mesh_verts_np.shape[0] == 0 or gt_np.shape[0] == 0:
+        return {
+            "chamfer_l1": float("nan"),
+            "f_score": float("nan"),
+            "precision": float("nan"),
+            "recall": float("nan"),
+        }
+    mesh_t = torch.from_numpy(mesh_verts_np).to(device)
+    gt_t = torch.from_numpy(gt_np).to(device)
+    d_m_to_gt = _chunked_nn_distances(mesh_t, gt_t)
+    d_gt_to_m = _chunked_nn_distances(gt_t, mesh_t)
+    chamfer_l1 = (d_m_to_gt.mean().item() + d_gt_to_m.mean().item()) * 0.5
+    prec = (d_m_to_gt < f_score_tau).float().mean().item()
+    recall = (d_gt_to_m < f_score_tau).float().mean().item()
+    f_score = 2 * prec * recall / (prec + recall + 1e-12)
+    return {
+        "chamfer_l1": chamfer_l1,
+        "f_score": f_score,
+        "precision": prec,
+        "recall": recall,
+    }
+
+
+def mesh_quality_vs_gt_mesh(
+    mesh_verts: np.ndarray,
+    gt_mesh_path: str,
+    n_gt_samples: int = 200_000,
+    f_score_tau: float = 0.02,
+    device: str = "cuda",
+) -> Dict[str, float]:
+    """Symmetric Chamfer-L1 + F-score vs a GT mesh `.ply`, point-sampled."""
+    import open3d as o3d
+
+    gt_mesh = o3d.io.read_triangle_mesh(gt_mesh_path)
+    if len(gt_mesh.triangles) == 0:
+        raise ValueError(f"GT mesh at {gt_mesh_path!r} has no triangles")
+    # Uniform surface-area sampling for GT — this is the canonical
+    # protocol used by NICE-SLAM / Co-SLAM / ESLAM / GO-Surf etc.
+    gt_pcd = gt_mesh.sample_points_uniformly(n_gt_samples, seed=0)
+    gt_np = np.asarray(gt_pcd.points, dtype=np.float32)
+    return _compute_chamfer_f_score(mesh_verts, gt_np, f_score_tau, device)
+
+
+def mesh_quality_vs_gt(
+    mesh_verts: np.ndarray,
+    scene: SyntheticScene,
+    n_gt_samples: int = 20_000,
+    f_score_tau: float = 0.02,
+    device: str = "cuda",
+) -> Dict[str, float]:
+    """Symmetric Chamfer-L1 + F-score vs uniformly-sampled GT sphere points.
+
+    Operates on GPU via torch.cdist for speed.
+    """
+    if mesh_verts.shape[0] == 0:
+        return {"chamfer_l1": float("nan"), "f_score_tau": float("nan")}
+
+    rng = np.random.default_rng(0)
+    gt = _sample_sphere_surface(n_gt_samples, scene.sphere_center, scene.sphere_radius, rng)
+
+    mesh_t = torch.from_numpy(mesh_verts).to(device)
+    gt_t = torch.from_numpy(gt).to(device)
+
+    # Chunked cdist to avoid V * G memory blow-up.
+    chunk = 4096
+    d_m_to_gt = torch.empty(mesh_t.shape[0], device=device)
+    d_gt_to_m = torch.empty(gt_t.shape[0], device=device)
+    for s in range(0, mesh_t.shape[0], chunk):
+        e = min(s + chunk, mesh_t.shape[0])
+        dmat = torch.cdist(mesh_t[s:e], gt_t)
+        d_m_to_gt[s:e] = dmat.min(dim=1).values
+    for s in range(0, gt_t.shape[0], chunk):
+        e = min(s + chunk, gt_t.shape[0])
+        dmat = torch.cdist(gt_t[s:e], mesh_t)
+        d_gt_to_m[s:e] = dmat.min(dim=1).values
+
+    chamfer_l1 = (d_m_to_gt.mean().item() + d_gt_to_m.mean().item()) * 0.5
+
+    prec = (d_m_to_gt < f_score_tau).float().mean().item()
+    recall = (d_gt_to_m < f_score_tau).float().mean().item()
+    f_score = 2 * prec * recall / (prec + recall + 1e-12)
+
+    return {
+        "chamfer_l1": chamfer_l1,
+        "f_score": f_score,
+        "precision": prec,
+        "recall": recall,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    # Scene selection.
+    p.add_argument(
+        "--scene",
+        type=str,
+        default=None,
+        help=(
+            "Path to a NICE-SLAM Replica scene root (containing `results/` "
+            "and `traj.txt`). If omitted, a synthetic sphere scene is used."
+        ),
+    )
+    p.add_argument(
+        "--gt-mesh",
+        type=str,
+        default=None,
+        help=(
+            "Path to the scene's GT mesh `.ply` (Replica ships these under "
+            "the original Replica-Dataset tree, e.g. `room_0/mesh.ply`). "
+            "If provided, mesh quality vs this mesh is reported. If omitted "
+            "on a Replica scene, quality metrics are skipped."
+        ),
+    )
+    # Synthetic-only args (ignored when --scene is given).
+    p.add_argument("--n-frames", type=int, default=16)
+    p.add_argument("--W", type=int, default=320)
+    p.add_argument("--H", type=int, default=240)
+    # Replica-only args.
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=1,
+        help="Replica scene: keep every Nth frame (1 = all).",
+    )
+    p.add_argument(
+        "--max-frames",
+        type=int,
+        default=None,
+        help="Replica scene: cap the number of frames after stride.",
+    )
+    p.add_argument(
+        "--depth-downsample",
+        type=int,
+        default=1,
+        help="Replica scene: spatially downsample depth by this factor (1200/680 "
+             "-> 600/340 at 2, 300/170 at 4). Intrinsics are scaled accordingly. "
+             "Useful for avoiding OOM in fvdb's one-shot topology build at high "
+             "frame counts (the N-frames union ingests frames*H*W points).",
+    )
+    # Reconstruction config.
+    p.add_argument("--voxel-size", type=float, default=0.02)
+    p.add_argument("--truncation", type=float, default=0.06)
+    p.add_argument("--device", type=str, default="cuda")
+    p.add_argument(
+        "--f-score-tau",
+        type=float,
+        default=None,
+        help="F-score threshold; defaults to voxel_size.",
+    )
+    # Which columns to run (set to skip slow / broken paths while iterating).
+    p.add_argument("--skip-per-frame", action="store_true")
+    p.add_argument(
+        "--json-out",
+        type=str,
+        default=None,
+        help="If set, also dump the results table as JSON to this path (for "
+             "the multi-scene suite runner).",
+    )
+    # fvdb grid init strategy. Default auto: dense bounding-box for
+    # synthetic (small, matches the smoke), empty 1x1x1 for Replica
+    # (dense-bbox at 2 cm for a room blows GPU memory).
+    p.add_argument(
+        "--fvdb-start",
+        choices=("auto", "empty", "dense"),
+        default="auto",
+        help="fvdb initial grid: auto (empty for --scene, dense for synthetic), "
+             "empty (1x1x1, union grows), or dense (auto-bbox from scene).",
+    )
+    args = p.parse_args()
+
+    if args.f_score_tau is None:
+        args.f_score_tau = args.voxel_size
+
+    if args.scene:
+        scene = load_replica_scene(
+            args.scene, max_frames=args.max_frames, stride=args.stride
+        )
+        if args.depth_downsample > 1:
+            # Spatially stride the depth + rescale intrinsics so the
+            # world-space rays are identical (just sampled sparsely).
+            ds = int(args.depth_downsample)
+            scene.depth_images = scene.depth_images[:, ::ds, ::ds].copy()
+            # Shift + scale principal point consistent with np strided slicing:
+            # pixel i in downsampled corresponds to pixel i * ds in original.
+            # Pinhole projection: x_px = fx * X/Z + cx. After downsample,
+            # new_cx = cx / ds (since a continuous pixel coord scales by 1/ds
+            # when we re-index i -> i*ds).
+            scene.K = scene.K.copy()
+            scene.K[0, 0] /= ds  # fx
+            scene.K[1, 1] /= ds  # fy
+            scene.K[0, 2] /= ds  # cx
+            scene.K[1, 2] /= ds  # cy
+        hit = (scene.depth_images > 0).sum() / scene.depth_images.size
+        print(
+            f"scene: Replica {scene.name} — {scene.n_frames} frames of "
+            f"{scene.depth_images.shape[2]}x{scene.depth_images.shape[1]}"
+            + (f" (downsampled {args.depth_downsample}x)" if args.depth_downsample > 1 else "")
+            + f", hit-ratio {hit:.2%}"
+        )
+        n_frames_eff = scene.n_frames
+    else:
+        scene = make_sphere_scene(
+            n_frames=args.n_frames,
+            W=args.W,
+            H=args.H,
+        )
+        hit = (scene.depth_images > 0).sum() / scene.depth_images.size
+        print(
+            f"scene: synthetic sphere — {args.n_frames} frames of {args.W}x{args.H}, "
+            f"sphere R={scene.sphere_radius}, hit-ratio {hit:.2%}"
+        )
+        n_frames_eff = args.n_frames
+    # Shadow the n_frames var used below — both synthetic and Replica
+    # paths set `n_frames_eff` above.
+    args.n_frames = n_frames_eff
+    print(
+        f"config: voxel_size={args.voxel_size}, truncation={args.truncation}, "
+        f"f_score_tau={args.f_score_tau}"
+    )
+
+    # Warmup: run a tiny synthetic scene through each path first to prime
+    # the CUDA kernel cache (first MC invocation otherwise eats ~70 ms of
+    # JIT overhead in whichever path runs first, skewing the comparison).
+    tiny_scene = make_sphere_scene(n_frames=2, W=64, H=48)
+    # Use start_empty for the warmup so fine-voxel configs (<= 5 mm)
+    # don't trip a 3-m dense allocation that OOMs before the real run
+    # even starts. Metadata (voxel_size, origin) still warms the kernel
+    # cache from the tiny scene's first integrate call.
+    if not args.skip_per_frame:
+        _ = integrate_fvdb(tiny_scene, args.voxel_size, args.truncation,
+                           device=args.device, mode="per_frame",
+                           start_empty=True)
+    _ = integrate_fvdb(tiny_scene, args.voxel_size, args.truncation,
+                       device=args.device, mode="frames",
+                       start_empty=True)
+    _ = integrate_open3d(tiny_scene, args.voxel_size, args.truncation)
+    _ = integrate_open3d_cuda(tiny_scene, args.voxel_size, args.truncation,
+                              device=args.device)
+
+    # grid_extent=None auto-estimates from scene sensor + depth for
+    # synthetic; 1.5 keeps the 1.5-m hand-tuned bounding box the smoke
+    # was calibrated on. For Replica we default to start_empty=True
+    # because a 2-cm dense bbox on a room-scale scene blows GPU memory.
+    fvdb_start = args.fvdb_start
+    if fvdb_start == "auto":
+        fvdb_start = "empty" if args.scene else "dense"
+    start_empty = fvdb_start == "empty"
+    real_grid_extent = None if args.scene else 1.5
+
+    # Three columns: fvdb per-frame (legacy), fvdb frames (one-shot N-frame topology), Open3D.
+    # `--skip-per-frame` elides the slow legacy path when iterating on a
+    # large real scene where we already know it's ~15x slower.
+    fvdb_per_frame: RunResult | None = None
+    if not args.skip_per_frame:
+        fvdb_per_frame = integrate_fvdb(
+            scene, args.voxel_size, args.truncation,
+            device=args.device, mode="per_frame", grid_extent=real_grid_extent,
+            start_empty=start_empty,
+        )
+    fvdb_frames = integrate_fvdb(
+        scene, args.voxel_size, args.truncation,
+        device=args.device, mode="frames", grid_extent=real_grid_extent,
+        start_empty=start_empty,
+    )
+    open3d_result = integrate_open3d(scene, args.voxel_size, args.truncation)
+    open3d_cuda_result = integrate_open3d_cuda(
+        scene, args.voxel_size, args.truncation, device=args.device,
+    )
+
+    def _quality(mesh_verts: np.ndarray) -> Dict[str, float]:
+        if args.gt_mesh:
+            return mesh_quality_vs_gt_mesh(
+                mesh_verts, args.gt_mesh,
+                f_score_tau=args.f_score_tau, device=args.device,
+            )
+        if args.scene:
+            # Replica scene without a GT mesh: skip quality.
+            return {}
+        return mesh_quality_vs_gt(
+            mesh_verts, scene, f_score_tau=args.f_score_tau, device=args.device,
+        )
+
+    fvdb_pf_q = _quality(fvdb_per_frame.mesh_verts) if fvdb_per_frame else {}
+    fvdb_fr_q = _quality(fvdb_frames.mesh_verts)
+    open3d_q = _quality(open3d_result.mesh_verts)
+    open3d_cuda_q = _quality(open3d_cuda_result.mesh_verts)
+
+    def row(name, a, b, c, d):
+        name_w = 26
+        col_w = 15
+        return f"| {name:<{name_w}} | {a:>{col_w}} | {b:>{col_w}} | {c:>{col_w}} | {d:>{col_w}} |"
+
+    print()
+    print(row("metric", "fvdb/per_frame", "fvdb/frames", "open3d(CPU)", "open3d(CUDA)"))
+    print("|" + "-" * 28 + "|" + ("-" * 16 + ":|") * 4)
+    print(row("device", args.device, args.device, "cpu", args.device))
+    print(row(
+        "integrate ms/frame",
+        f"{fvdb_per_frame.integrate_s * 1000 / args.n_frames:.2f}" if fvdb_per_frame else "-",
+        f"{fvdb_frames.integrate_s * 1000 / args.n_frames:.2f}",
+        f"{open3d_result.integrate_s * 1000 / args.n_frames:.2f}",
+        f"{open3d_cuda_result.integrate_s * 1000 / args.n_frames:.2f}",
+    ))
+    print(row(
+        "integrate total (ms)",
+        f"{fvdb_per_frame.integrate_s * 1000:.1f}" if fvdb_per_frame else "-",
+        f"{fvdb_frames.integrate_s * 1000:.1f}",
+        f"{open3d_result.integrate_s * 1000:.1f}",
+        f"{open3d_cuda_result.integrate_s * 1000:.1f}",
+    ))
+    print(row(
+        "mesh extract (ms)",
+        f"{fvdb_per_frame.mesh_extract_s * 1000:.1f}" if fvdb_per_frame else "-",
+        f"{fvdb_frames.mesh_extract_s * 1000:.1f}",
+        f"{open3d_result.mesh_extract_s * 1000:.1f}",
+        f"{open3d_cuda_result.mesh_extract_s * 1000:.1f}",
+    ))
+    print(row(
+        "mesh verts",
+        str(fvdb_per_frame.mesh_V) if fvdb_per_frame else "-",
+        str(fvdb_frames.mesh_V),
+        str(open3d_result.mesh_V),
+        str(open3d_cuda_result.mesh_V),
+    ))
+    print(row(
+        "mesh tris",
+        str(fvdb_per_frame.mesh_F) if fvdb_per_frame else "-",
+        str(fvdb_frames.mesh_F),
+        str(open3d_result.mesh_F),
+        str(open3d_cuda_result.mesh_F),
+    ))
+    print(row(
+        "peak GPU MB (torch)",
+        f"{fvdb_per_frame.peak_gpu_mb:.1f}" if fvdb_per_frame else "-",
+        f"{fvdb_frames.peak_gpu_mb:.1f}",
+        "-",
+        # torch tracker does NOT see Open3D's cudaMalloc allocations;
+        # paper should measure via nvidia-smi before/after for this column.
+        "(n/a via torch)",
+    ))
+    print(row(
+        "peak host MB (delta)",
+        f"{fvdb_per_frame.peak_host_mb:.1f}" if fvdb_per_frame else "-",
+        f"{fvdb_frames.peak_host_mb:.1f}",
+        f"{open3d_result.peak_host_mb:.1f}",
+        f"{open3d_cuda_result.peak_host_mb:.1f}",
+    ))
+    if fvdb_fr_q:  # quality metrics available
+        print(row(
+            f"F-score @ tau={args.f_score_tau:g}",
+            f"{fvdb_pf_q.get('f_score', 0):.4f}" if fvdb_pf_q else "-",
+            f"{fvdb_fr_q.get('f_score', 0):.4f}",
+            f"{open3d_q.get('f_score', 0):.4f}",
+            f"{open3d_cuda_q.get('f_score', 0):.4f}",
+        ))
+        print(row(
+            "Chamfer-L1 (m)",
+            f"{fvdb_pf_q.get('chamfer_l1', float('nan')):.4f}" if fvdb_pf_q else "-",
+            f"{fvdb_fr_q.get('chamfer_l1', float('nan')):.4f}",
+            f"{open3d_q.get('chamfer_l1', float('nan')):.4f}",
+            f"{open3d_cuda_q.get('chamfer_l1', float('nan')):.4f}",
+        ))
+    else:
+        print(row("quality vs GT", "(skipped — pass --gt-mesh to enable)", "", "", ""))
+
+    # Summary: speedup of fvdb/frames over fvdb/per_frame, and ratio vs Open3D.
+    frames_ms = fvdb_frames.integrate_s * 1000 / args.n_frames
+    open3d_ms = open3d_result.integrate_s * 1000 / args.n_frames
+    print()
+    if fvdb_per_frame is not None:
+        per_frame_ms = fvdb_per_frame.integrate_s * 1000 / args.n_frames
+        print(
+            f"fvdb/frames vs fvdb/per_frame: {per_frame_ms / frames_ms:.2f}x faster  "
+            f"({per_frame_ms:.1f} -> {frames_ms:.1f} ms/frame)"
+        )
+    def _ratio_str(ref_ms, label):
+        ratio = frames_ms / ref_ms
+        relation = "slower" if ratio >= 1 else "faster"
+        return (
+            f"fvdb/frames vs {label}: {ratio:.2f}x {relation}  "
+            f"({ref_ms:.2f} vs {frames_ms:.2f} ms/frame)"
+        )
+
+    print(_ratio_str(open3d_ms, "open3d(CPU) "))
+    open3d_cuda_ms = open3d_cuda_result.integrate_s * 1000 / args.n_frames
+    print(_ratio_str(open3d_cuda_ms, "open3d(CUDA)"))
+
+    if args.json_out:
+        import json
+
+        def result_to_dict(r: "RunResult | None"):
+            if r is None:
+                return None
+            return {
+                "library": r.library,
+                "integrate_s": r.integrate_s,
+                "integrate_ms_per_frame": r.integrate_s * 1000 / args.n_frames,
+                "mesh_extract_s": r.mesh_extract_s,
+                "mesh_V": r.mesh_V,
+                "mesh_F": r.mesh_F,
+                "peak_gpu_mb": r.peak_gpu_mb,
+                "peak_host_mb": r.peak_host_mb,
+            }
+
+        out = {
+            "scene": {
+                "name": getattr(scene, "name", "synthetic_sphere"),
+                "n_frames": args.n_frames,
+                "W": int(scene.depth_images.shape[2]),
+                "H": int(scene.depth_images.shape[1]),
+            },
+            "config": {
+                "voxel_size": args.voxel_size,
+                "truncation": args.truncation,
+                "f_score_tau": args.f_score_tau,
+                "depth_downsample": getattr(args, "depth_downsample", 1),
+                "stride": args.stride,
+                "max_frames": args.max_frames,
+                "fvdb_start": fvdb_start,
+            },
+            "fvdb_per_frame": result_to_dict(fvdb_per_frame),
+            "fvdb_frames": result_to_dict(fvdb_frames),
+            "open3d": result_to_dict(open3d_result),
+            "open3d_cuda": result_to_dict(open3d_cuda_result),
+            "quality": {
+                "fvdb_per_frame": fvdb_pf_q,
+                "fvdb_frames": fvdb_fr_q,
+                "open3d": open3d_q,
+                "open3d_cuda": open3d_cuda_q,
+            },
+        }
+        os.makedirs(os.path.dirname(os.path.abspath(args.json_out)) or ".", exist_ok=True)
+        with open(args.json_out, "w") as f:
+            json.dump(out, f, indent=2, default=float)
+        print(f"\nwrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_replica_full.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_replica_full.py
@@ -1,0 +1,324 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Multi-scene Replica TSDF + ESDF benchmark at full frame rate.
+
+Counterpart to `bench_esdf_kitti.py`: sweeps over multiple Replica
+scenes (default office0/room0/room1) and multiple voxel sizes,
+running fvdb's depth-TSDF + ESDF and nvblox's equivalents on each
+config. Reuses `_run_nvblox` and `_run_one_config` from
+`bench_esdf_replica.py` (which already returns TSDF + ESDF stats
+per config), but replaces the in-process `_run_fvdb` with a
+chunked variant that streams frames in batches to bound peak GPU
+memory at 2000-frame full-rate (where the unchunked version's
+~6.5 GB depth-image upload would already crowd the integrator).
+
+Usage:
+
+    cd fvdb-reality-capture/tests/benchmarks/tsdf_fusion/cross_library
+    CUDA_VISIBLE_DEVICES=1 PYTORCH_ALLOC_CONF=expandable_segments:True \\
+    /home/fwilliams/bin/miniconda3/envs/fvdb/bin/python -u \\
+        bench_replica_full.py \\
+        --root .../data/Replica \\
+        --scenes office0 room0 room1 \\
+        --n-frames 2000 \\
+        --voxel-sizes-m 0.02 0.01 0.005 0.003 \\
+        --json-out ./results/replica_tsdf_esdf.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import numpy as np
+import torch
+
+import fvdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from replica_loader import load_replica_scene  # noqa: E402
+import bench_esdf_replica as upstream  # noqa: E402
+
+
+def _build_seed_grid(voxel_size: float, device: str = "cuda"):
+    g = fvdb.Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=voxel_size, origin=[0, 0, 0], device=device,
+    )
+    tsdf = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
+    w    = torch.zeros(g.num_voxels, device=device, dtype=torch.float32)
+    return g, tsdf, w
+
+
+def _run_fvdb_chunked_replica(
+    scene,
+    voxel_size: float,
+    truncation: float,
+    max_distance: float,
+    esdf_warm_calls: int,
+    chunk_frames: int = 200,
+) -> Dict[str, Any]:
+    """Chunked depth-TSDF + ESDF on a Replica scene.
+
+    Equivalent to upstream.bench_esdf_replica._run_fvdb but processes
+    depth images in chunks so peak GPU memory does not include the
+    full N x H x W x 4 B depth tensor (6.5 GB at 2000 frames x
+    1200x680). Output schema matches the upstream function for
+    drop-in compatibility with `_run_one_config`'s formatter.
+    """
+    device = "cuda"
+    K_t = torch.from_numpy(scene.K).to(device=device, dtype=torch.float32)
+    cam_to_world_full = torch.from_numpy(scene.cam_to_world).to(
+        device=device, dtype=torch.float32)
+    N = scene.n_frames
+
+    g, tsdf, w = _build_seed_grid(voxel_size, device)
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for chunk_start in range(0, N, chunk_frames):
+        chunk_end = min(chunk_start + chunk_frames, N)
+        n_chunk = chunk_end - chunk_start
+        chunk_depth = torch.from_numpy(
+            scene.depth_images[chunk_start:chunk_end]
+        ).to(device=device, dtype=torch.float32)
+        chunk_c2w = cam_to_world_full[chunk_start:chunk_end]
+        K_per_frame = K_t.unsqueeze(0).expand(n_chunk, 3, 3).contiguous()
+        g, tsdf, w = g.integrate_tsdf_frames(
+            truncation_distance=truncation,
+            projection_matrices=K_per_frame,
+            cam_to_world_matrices=chunk_c2w,
+            tsdf=tsdf,
+            weights=w,
+            depth_images=chunk_depth,
+        )
+        del chunk_depth
+    torch.cuda.synchronize()
+    tsdf_s = time.perf_counter() - t0
+
+    n_voxels = int(g.num_voxels)
+    n_leaves = int(g.num_leaf_nodes)
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    esdf_grid, esdf = g.compute_esdf(
+        tsdf, w,
+        truncation_distance=truncation,
+        max_distance=max_distance,
+        use_vbm=True,
+    )
+    torch.cuda.synchronize()
+    esdf_cold_ms = (time.perf_counter() - t0) * 1000.0
+    esdf_n_voxels = int(esdf_grid.num_voxels)
+
+    warm_samples = []
+    prev_grid, prev_esdf = esdf_grid, esdf
+    for _ in range(esdf_warm_calls):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        new_grid, new_esdf = g.compute_esdf_incremental(
+            tsdf, w, prev_grid, prev_esdf,
+            truncation_distance=truncation,
+            max_distance=max_distance,
+            use_vbm=True,
+        )
+        torch.cuda.synchronize()
+        warm_samples.append((time.perf_counter() - t0) * 1000.0)
+        prev_grid, prev_esdf = new_grid, new_esdf
+
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    return {
+        "system": "fvdb",
+        "tsdf_fuse_s": tsdf_s,
+        "tsdf_ms_per_f": tsdf_s * 1000.0 / max(N, 1),
+        "tsdf_n_voxels": n_voxels,
+        "tsdf_n_leaves": n_leaves,
+        "esdf_n_voxels": esdf_n_voxels,
+        "esdf_cold_ms": esdf_cold_ms,
+        "esdf_warm_ms_min": min(warm_samples) if warm_samples else -1.0,
+        "esdf_warm_ms_median": (statistics.median(warm_samples)
+                                 if warm_samples else -1.0),
+        "esdf_warm_ms_max": max(warm_samples) if warm_samples else -1.0,
+        "esdf_warm_calls": len(warm_samples),
+        "peak_torch_gb": peak_torch_gb,
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "max_distance_m": max_distance,
+        "n_frames": N,
+        "chunk_frames": chunk_frames,
+    }
+
+
+def _run_one_config_chunked(
+    scene, voxel_size: float, truncation: float, max_distance: float,
+    esdf_warm_calls: int, skip_nvblox: bool, chunk_frames: int = 200,
+) -> Dict[str, Any]:
+    """Chunked equivalent of bench_esdf_replica._run_one_config."""
+    print(f"\n[config] voxel={voxel_size}  trunc={truncation}  "
+          f"max_dist={max_distance}", flush=True)
+    result: Dict[str, Any] = {
+        "voxel_size_m": voxel_size,
+        "truncation_m": truncation,
+        "max_distance_m": max_distance,
+    }
+
+    torch.cuda.reset_peak_memory_stats()
+    try:
+        result["fvdb"] = _run_fvdb_chunked_replica(
+            scene, voxel_size, truncation, max_distance, esdf_warm_calls,
+            chunk_frames=chunk_frames,
+        )
+        result["fvdb"]["ok"] = True
+        r = result["fvdb"]
+        print(f"  fvdb: TSDF {r['tsdf_n_voxels']:,} vx ({r['tsdf_ms_per_f']:.2f} ms/f), "
+              f"ESDF {r['esdf_n_voxels']:,} vx, "
+              f"cold {r['esdf_cold_ms']:.1f} ms, "
+              f"warm {r['esdf_warm_ms_median']:.1f} ms, "
+              f"peak_gb {r['peak_torch_gb']:.2f}", flush=True)
+    except torch.cuda.OutOfMemoryError as e:
+        print(f"  fvdb: OOM - {str(e).splitlines()[0][:140]}", flush=True)
+        result["fvdb"] = {"ok": False, "failure": f"torch OOM: {e}"}
+        torch.cuda.empty_cache(); gc.collect()
+    except RuntimeError as e:
+        msg = str(e)
+        if "out of memory" in msg.lower() or "CUDA error 2" in msg:
+            print(f"  fvdb: nanoVDB OOM - {msg.splitlines()[0][:120]}",
+                  flush=True)
+            result["fvdb"] = {"ok": False, "failure": f"nanoVDB OOM: {msg}"}
+        else:
+            print(f"  fvdb: failed - {msg[:140]}", flush=True)
+            result["fvdb"] = {"ok": False, "failure": f"runtime: {msg}"}
+        torch.cuda.empty_cache(); gc.collect()
+    except Exception as e:  # noqa: BLE001
+        print(f"  fvdb: failed ({type(e).__name__}: {e})", flush=True)
+        result["fvdb"] = {"ok": False, "failure": f"{type(e).__name__}: {e}"}
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    if skip_nvblox:
+        result["nvblox"] = {"ok": False, "failure": "skipped"}
+    else:
+        try:
+            nvblox_result = upstream._run_nvblox(
+                scene, voxel_size, truncation, max_distance, esdf_warm_calls,
+            )
+            result["nvblox"] = nvblox_result
+            if nvblox_result.get("ok", False):
+                print(f"  nvblox: approx_vx {nvblox_result['n_voxels']:,}, "
+                      f"cold {nvblox_result['esdf_cold_ms']:.1f} ms, "
+                      f"warm {nvblox_result['esdf_warm_ms_median']:.2f} ms, "
+                      f"gpu_gb {nvblox_result.get('gpu_used_gb', -1):.2f}",
+                      flush=True)
+            else:
+                print(f"  nvblox: FAILED {nvblox_result.get('failure', '?')[:120]}",
+                      flush=True)
+        except Exception as e:  # noqa: BLE001
+            print(f"  nvblox: driver error ({type(e).__name__}: {e})",
+                  flush=True)
+            result["nvblox"] = {"ok": False,
+                                "failure": f"driver: {type(e).__name__}: {e}"}
+
+    return result
+
+
+# Mai City-style known-OOM rule for nvblox at fine voxels.
+# Earlier Replica-stride10 evidence: nvblox OOMs at 5 mm.
+# At full frame rate (10x more frames) we expect OOM at 10 mm.
+_KNOWN_OOM_NVBLOX = lambda vs: vs <= 0.005   # 5 mm and below
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", required=True,
+                    help="path to extracted Replica/ (the dir containing "
+                         "office0/ etc.)")
+    ap.add_argument("--scenes", nargs="+",
+                    default=["office0", "room0", "room1"])
+    ap.add_argument("--n-frames", type=int, default=2000,
+                    help="frames per scene (default 2000 = full Nice-SLAM rate)")
+    ap.add_argument("--voxel-sizes-m", type=float, nargs="+",
+                    default=[0.02, 0.01, 0.005, 0.003])
+    ap.add_argument("--trunc-voxel-multiplier", type=float, default=3.0)
+    ap.add_argument("--max-distance-voxel-multiplier", type=float, default=10.0)
+    ap.add_argument("--esdf-warm-calls", type=int, default=5)
+    ap.add_argument("--chunk-frames", type=int, default=200,
+                    help="frames per fvdb integrate call")
+    ap.add_argument("--skip-known-oom", action="store_true", default=True)
+    ap.add_argument("--no-skip-known-oom", dest="skip_known_oom",
+                    action="store_false")
+    ap.add_argument("--skip-nvblox", action="store_true",
+                    help="skip nvblox at every voxel")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    all_results: list[Dict[str, Any]] = []
+    t_start = time.time()
+
+    for scene_name in args.scenes:
+        print(f"\n##### Replica scene='{scene_name}' #####", flush=True)
+        scene_dir = os.path.join(args.root, scene_name)
+        scene = load_replica_scene(
+            scene_dir, max_frames=args.n_frames, stride=1,
+        )
+        print(f"[load] done. {scene.n_frames} frames, "
+              f"{scene.depth_images.shape[1]}x{scene.depth_images.shape[2]} px",
+              flush=True)
+
+        for vs in args.voxel_sizes_m:
+            cfg_skip_nvblox = args.skip_nvblox or (
+                args.skip_known_oom and _KNOWN_OOM_NVBLOX(vs))
+            r = _run_one_config_chunked(
+                scene,
+                voxel_size=float(vs),
+                truncation=float(vs) * args.trunc_voxel_multiplier,
+                max_distance=float(vs) * args.max_distance_voxel_multiplier,
+                esdf_warm_calls=args.esdf_warm_calls,
+                skip_nvblox=cfg_skip_nvblox,
+                chunk_frames=args.chunk_frames,
+            )
+            r["scene"] = scene_name
+            r["dataset"] = "replica"
+            all_results.append(r)
+            if args.json_out is not None:
+                args.json_out.parent.mkdir(parents=True, exist_ok=True)
+                with args.json_out.open("w") as f:
+                    json.dump({
+                        "config": {
+                            "scenes": args.scenes,
+                            "n_frames": args.n_frames,
+                            "esdf_warm_calls": args.esdf_warm_calls,
+                            "trunc_voxel_multiplier":
+                                args.trunc_voxel_multiplier,
+                            "max_distance_voxel_multiplier":
+                                args.max_distance_voxel_multiplier,
+                            "chunk_frames": args.chunk_frames,
+                        },
+                        "results": all_results,
+                    }, f, indent=2)
+
+        # Free the scene's host-side depth array between scenes.
+        del scene
+        gc.collect()
+
+    print(f"\n##### Total wall time: {(time.time() - t_start) / 60:.1f} min #####",
+          flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/bench_seven_scenes.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/bench_seven_scenes.py
@@ -1,0 +1,227 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Long-trajectory TSDF-fusion benchmark on Microsoft 7-Scenes.
+
+Complements the Replica benchmarks (bounded room, 200 frames) with
+a much longer-trajectory workload (~6000 frames, same physical room
+revisited multiple times). Exercises the "accumGrid saturated early,
+per-frame shell small, constant-factor matters" regime that Tree 4
+(persistent growable grid) and Tree 5 (fused shell kernel) are
+designed to attack. Uses the 7-Scenes `chess` dataset by default
+(6 sequences x 1000 frames = 6000 total).
+
+Run:
+
+    python bench_seven_scenes.py --scene .../7-Scenes/chess \\
+        --voxel-sizes 0.01 0.005 0.003 --n-frames 3000 \\
+        --json-out results.json
+"""
+
+from __future__ import annotations
+
+import os
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+import argparse
+import gc
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from seven_scenes_loader import load_seven_scenes_scene  # noqa: E402
+
+
+def run_fvdb(scene, voxel_size: float, truncation: float) -> Dict[str, Any]:
+    """Run fvdb integrate_tsdf_frames on the whole scene, return stats."""
+    from fvdb import Grid
+    torch.cuda.empty_cache(); gc.collect()
+    N = scene.n_frames
+    depth = torch.from_numpy(scene.depth_images).cuda()
+    c2w = torch.from_numpy(scene.cam_to_world).cuda()
+    K = torch.from_numpy(scene.K).cuda().unsqueeze(0).expand(N, 3, 3).contiguous()
+    g = Grid.from_dense(
+        dense_dims=[1, 1, 1], ijk_min=[0, 0, 0],
+        voxel_size=voxel_size, origin=[0, 0, 0], device="cuda",
+    )
+    tsdf = torch.zeros(g.num_voxels, device="cuda")
+    w = torch.zeros(g.num_voxels, device="cuda")
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.synchronize(); t0 = time.perf_counter()
+    try:
+        g, tsdf, w = g.integrate_tsdf_frames(
+            truncation_distance=truncation,
+            projection_matrices=K,
+            cam_to_world_matrices=c2w,
+            tsdf=tsdf, weights=w, depth_images=depth,
+        )
+        torch.cuda.synchronize()
+        ms_per_f = (time.perf_counter() - t0) * 1000 / N
+        peak = torch.cuda.max_memory_allocated() / 1e9
+        n_voxels = int(g.num_voxels)
+    except torch.cuda.OutOfMemoryError as e:
+        return {"system": "fvdb", "ok": False,
+                "failure": f"OOM: {str(e).splitlines()[0][:100]}"}
+    return {
+        "system": "fvdb", "ok": True,
+        "ms_per_f": ms_per_f,
+        "peak_gb": peak,
+        "n_voxels": n_voxels,
+        "n_frames": N,
+    }
+
+
+def run_open3d_cuda(scene, voxel_size: float, truncation: float,
+                    block_count_base: int = 50000) -> Dict[str, Any]:
+    """Run Open3D CUDA VBG integrate per-frame, return stats.
+
+    Scales block_count with (base_voxel / voxel)^2 surface-area law
+    starting from `block_count_base` at 1 cm, matching the pattern in
+    `scale_scan.py`.
+    """
+    import open3d as o3d
+    import open3d.core as o3c
+    torch.cuda.empty_cache(); gc.collect()
+
+    N = scene.n_frames
+    d = o3c.Device("CUDA:0")
+    trunc_mul = truncation / voxel_size
+    # Scale block-count by (1cm/vs)^2 so fine voxels get larger hashmaps.
+    bc = max(block_count_base,
+             int(block_count_base * (0.01 / voxel_size) ** 2))
+
+    try:
+        vbg = o3d.t.geometry.VoxelBlockGrid(
+            attr_names=("tsdf", "weight"),
+            attr_dtypes=(o3c.float32, o3c.float32),
+            attr_channels=((1,), (1,)),
+            voxel_size=voxel_size, block_resolution=16,
+            block_count=bc, device=d,
+        )
+    except Exception as e:
+        return {"system": "open3d_cuda", "ok": False,
+                "failure": f"vbg_create: {str(e).splitlines()[0][:100]}",
+                "block_count": bc}
+
+    K_o3d = o3c.Tensor(np.asarray(scene.K, dtype=np.float64),
+                       o3c.float64, device=o3c.Device("CPU:0"))
+    # Stage depth on device + extrinsics on host once to keep per-frame
+    # overhead honest (matches what scale_scan.py does).
+    depths = [
+        o3d.t.geometry.Image(
+            o3c.Tensor(scene.depth_images[i].astype(np.float32),
+                       o3c.float32, d))
+        for i in range(N)
+    ]
+    exts = [
+        o3c.Tensor(
+            np.linalg.inv(scene.cam_to_world[i]).astype(np.float64),
+            o3c.float64, device=o3c.Device("CPU:0"))
+        for i in range(N)
+    ]
+
+    # Warmup.
+    try:
+        for i in range(min(2, N)):
+            f = vbg.compute_unique_block_coordinates(
+                depths[i], K_o3d, exts[i],
+                depth_scale=1.0, depth_max=4.0,
+                trunc_voxel_multiplier=trunc_mul)
+            vbg.integrate(f, depths[i], K_o3d, exts[i],
+                          depth_scale=1.0, depth_max=4.0,
+                          trunc_voxel_multiplier=trunc_mul)
+        o3c.cuda.synchronize()
+    except Exception as e:
+        return {"system": "open3d_cuda", "ok": False,
+                "failure": f"warmup: {str(e).splitlines()[0][:100]}",
+                "block_count": bc}
+
+    # Fresh VBG for timed run so warmup doesn't skew sizes.
+    vbg = o3d.t.geometry.VoxelBlockGrid(
+        attr_names=("tsdf", "weight"),
+        attr_dtypes=(o3c.float32, o3c.float32),
+        attr_channels=((1,), (1,)),
+        voxel_size=voxel_size, block_resolution=16,
+        block_count=bc, device=d,
+    )
+    t0 = time.perf_counter()
+    try:
+        for i in range(N):
+            f = vbg.compute_unique_block_coordinates(
+                depths[i], K_o3d, exts[i],
+                depth_scale=1.0, depth_max=4.0,
+                trunc_voxel_multiplier=trunc_mul)
+            vbg.integrate(f, depths[i], K_o3d, exts[i],
+                          depth_scale=1.0, depth_max=4.0,
+                          trunc_voxel_multiplier=trunc_mul)
+        o3c.cuda.synchronize()
+    except Exception as e:
+        return {"system": "open3d_cuda", "ok": False,
+                "failure": f"integrate: {str(e).splitlines()[0][:100]}",
+                "block_count": bc}
+    ms_per_f = (time.perf_counter() - t0) * 1000 / N
+    blocks = int(vbg.hashmap().size())
+    return {
+        "system": "open3d_cuda", "ok": True,
+        "ms_per_f": ms_per_f,
+        "block_count": bc,
+        "blocks": blocks,
+        "n_frames": N,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--scene", required=True,
+                   help="path to unzipped 7-Scenes scene, e.g. .../chess")
+    p.add_argument("--n-frames", type=int, default=3000,
+                   help="cap total frames (0 = use all)")
+    p.add_argument("--voxel-sizes", nargs="+", type=float,
+                   default=[0.02, 0.01, 0.005, 0.003])
+    p.add_argument("--truncation-multiplier", type=float, default=3.0)
+    p.add_argument("--systems", nargs="+",
+                   default=["fvdb", "open3d_cuda"],
+                   choices=["fvdb", "open3d_cuda"])
+    p.add_argument("--json-out", type=str, default=None)
+    args = p.parse_args()
+
+    max_frames = None if args.n_frames <= 0 else args.n_frames
+    scene = load_seven_scenes_scene(args.scene, max_frames=max_frames)
+    print(f"Loaded {scene.n_frames} frames from {args.scene!r}")
+
+    results: List[Dict[str, Any]] = []
+    for vs in args.voxel_sizes:
+        trunc = vs * args.truncation_multiplier
+        print(f"\n=== voxel_size={vs*1000:.2f}mm  trunc={trunc*1000:.2f}mm ===")
+        for system in args.systems:
+            if system == "fvdb":
+                r = run_fvdb(scene, vs, trunc)
+            elif system == "open3d_cuda":
+                r = run_open3d_cuda(scene, vs, trunc)
+            else:
+                continue
+            r["voxel_size"] = vs
+            results.append(r)
+            if r.get("ok"):
+                extra = ""
+                if "peak_gb" in r:
+                    extra = f"  peak={r['peak_gb']:.2f} GB  voxels={r['n_voxels']:,}"
+                elif "blocks" in r:
+                    extra = f"  blocks={r['blocks']:,}/{r['block_count']}"
+                print(f"  {system:15s} OK  {r['ms_per_f']:7.2f} ms/f{extra}")
+            else:
+                print(f"  {system:15s} FAIL  {r.get('failure','?')[:120]}")
+        if args.json_out:
+            with open(args.json_out, "w") as f:
+                json.dump({"results": results, "args": vars(args)},
+                          f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/download_kitti.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/download_kitti.py
@@ -1,0 +1,793 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Resumable downloader for the KITTI Odometry dataset.
+
+Use case: bringing KITTI sequence 00 (and friends) into
+`tests/benchmarks/tsdf_fusion/data/KITTI/` for the LiDAR TSDF /
+ESDF / occupancy benchmarks. The full Velodyne archive is ~80 GB
+so we want a downloader that:
+
+  - Resumes from any previously-downloaded prefix (HTTP Range).
+  - Survives connection drops, server hiccups, and Ctrl-C with
+    bounded exponential backoff retries.
+  - Reports per-second progress (so monitoring in tmux is useful).
+  - Verifies final byte count against the server's Content-Length.
+  - Is idempotent: a completed download is detected and skipped on
+    re-run; an over-full partial is treated as complete (server-
+    Content-Length mismatch within fp safety).
+
+The KITTI Odometry archives we care about for LiDAR-only benches:
+
+    data_odometry_velodyne.zip   ~80 GB  Velodyne .bin files (all 22 sequences)
+    data_odometry_calib.zip       ~1 MB  sensor calibration matrices
+    data_odometry_poses.zip       ~4 MB  ground truth poses for seq 00-10
+
+Color, grayscale, and IMU archives are NOT downloaded (LiDAR TSDF
+doesn't need them; saves ~85 GB).
+
+Hosted on https://s3.eu-central-1.amazonaws.com/avg-kitti/.
+S3 fully supports HTTP Range requests, so our resume logic works
+against the canonical source.
+
+Typical use:
+
+    cd tests/benchmarks/tsdf_fusion/cross_library
+    python3 download_kitti.py \\
+        --dest ../../data/KITTI/zips \\
+        --files calib poses velodyne
+
+Run inside tmux for the velodyne archive (~30-90 minutes depending
+on link). The script prints progress to stdout once per second; if
+tmux loses your SSH session, the download keeps going. Re-running
+the same command picks up where the partial left off.
+
+Exit codes:
+    0  all requested files completed successfully
+    1  one or more files exhausted retry budget
+    2  CLI / configuration error
+    130 SIGINT (Ctrl-C); partial files are preserved so a re-run resumes
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import os
+import shutil
+import signal
+import socket
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Deque, List, Optional, Tuple
+
+
+KITTI_S3_BASE = "https://s3.eu-central-1.amazonaws.com/avg-kitti"
+
+KITTI_FILES: dict[str, dict[str, Any]] = {
+    "velodyne": {
+        "filename": "data_odometry_velodyne.zip",
+        "approx_size_gb": 80.0,
+        "description": ("Velodyne LiDAR .bin files for all 22 odometry "
+                        "sequences. THE main download."),
+    },
+    "calib": {
+        "filename": "data_odometry_calib.zip",
+        "approx_size_gb": 0.001,
+        "description": "Sensor-to-vehicle calibration matrices.",
+    },
+    "poses": {
+        "filename": "data_odometry_poses.zip",
+        "approx_size_gb": 0.004,
+        "description": "Ground-truth poses for sequences 00-10.",
+    },
+}
+
+
+# Globals used by the SIGINT handler so we can flush + exit cleanly.
+_active_partial: Optional[Path] = None
+_active_handle = None
+
+
+def _on_sigint(signum, frame):  # noqa: ARG001
+    """Flush + close all in-progress partials before exiting so the
+    on-disk byte counts match what we wrote. Doesn't delete
+    anything -- a re-run resumes from the existing parts."""
+    global _active_partial, _active_handle, _active_progress, _active_parts_dir
+
+    # Single-stream path bookkeeping.
+    if _active_handle is not None:
+        try:
+            _active_handle.flush()
+            os.fsync(_active_handle.fileno())
+            _active_handle.close()
+        except Exception:
+            pass
+    if _active_partial is not None and _active_partial.exists():
+        sys.stderr.write(
+            f"\n[sigint] preserved partial: {_active_partial}\n"
+            f"         re-run the same command to resume.\n")
+
+    # Parallel path: signal worker threads to flush + return; main
+    # thread can't wait for them here (signal handler context), so
+    # we set the stop_event and trust the threads to fsync and exit
+    # before our sys.exit(130) tears down the process.
+    if _active_progress is not None:
+        _active_progress.stop_event.set()
+        # Brief pause to let workers fsync their part files; we run
+        # in the main thread's signal context so workers continue
+        # executing meanwhile.
+        time.sleep(0.5)
+        if _active_parts_dir is not None and _active_parts_dir.exists():
+            n = sum(1 for _ in _active_parts_dir.iterdir())
+            sys.stderr.write(
+                f"\n[sigint] preserved {n} part files in: {_active_parts_dir}\n"
+                f"         re-run the same command to resume.\n")
+
+    sys.exit(130)
+
+
+def get_remote_size(url: str, timeout: float = 30.0,
+                    max_retries: int = 5) -> int:
+    """HEAD request to read Content-Length. Retries on transient
+    network failures with exponential backoff."""
+    last_exc: Optional[Exception] = None
+    for attempt in range(max_retries):
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                cl = resp.headers.get("Content-Length")
+                if cl is None:
+                    raise RuntimeError(
+                        f"server did not send Content-Length for {url}")
+                return int(cl)
+        except (urllib.error.URLError, socket.timeout, ConnectionError) as e:
+            last_exc = e
+            backoff = min(60.0, 2.0 ** attempt)
+            sys.stderr.write(
+                f"  [head] error ({e}); retrying in {backoff:.0f}s\n")
+            time.sleep(backoff)
+    assert last_exc is not None
+    raise last_exc
+
+
+def _format_eta(remaining_bytes: float, mbps: float) -> str:
+    if mbps <= 1e-3:
+        return "??"
+    seconds = remaining_bytes / (mbps * 1e6)
+    if seconds < 60:
+        return f"{seconds:5.0f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:5.1f}m"
+    if seconds < 24 * 3600:
+        return f"{seconds / 3600:5.1f}h"
+    return f"{seconds / 86400:5.1f}d"
+
+
+def _format_elapsed(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:5.0f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:5.1f}m"
+    return f"{seconds / 3600:5.1f}h"
+
+
+class _RollingRate:
+    """Track download rate via a sliding window over the last
+    `window_seconds` of (timestamp, total_bytes) samples. Gives a
+    responsive instantaneous-ish rate that catches actual speed
+    changes much better than a session-average."""
+
+    def __init__(self, window_seconds: float = 30.0):
+        self.window_seconds = window_seconds
+        self.samples: Deque[Tuple[float, int]] = collections.deque()
+
+    def update(self, t: float, total_bytes: int) -> None:
+        self.samples.append((t, total_bytes))
+        cutoff = t - self.window_seconds
+        while len(self.samples) > 1 and self.samples[0][0] < cutoff:
+            self.samples.popleft()
+
+    def mbps(self) -> float:
+        if len(self.samples) < 2:
+            return 0.0
+        t0, b0 = self.samples[0]
+        t1, b1 = self.samples[-1]
+        dt = t1 - t0
+        if dt <= 0.0:
+            return 0.0
+        return (b1 - b0) / dt / 1e6
+
+
+# -------------------------------------------------------------------
+# Parallel multi-Range download.
+#
+# KITTI's S3 bucket throttles each HTTP connection to ~0.18 MB/s
+# (verified empirically; ping is fine at 99 ms RTT, BDP analysis
+# shows TCP-window-limit is far above what we observe). Splitting
+# the download into N parallel HTTP Range requests scales near-
+# linearly up to ~8 streams, less so beyond. Default to 8.
+# -------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _ChunkPlan:
+    """Plan for one chunk of a multi-stream download."""
+    idx: int           # chunk index (0..N-1)
+    byte_start: int    # absolute byte offset in the full file
+    byte_end: int      # absolute byte offset (inclusive)
+    part_path: Path    # per-chunk file in <dest>.parts/
+
+    @property
+    def expected_size(self) -> int:
+        return self.byte_end - self.byte_start + 1
+
+    @property
+    def have_size(self) -> int:
+        return self.part_path.stat().st_size if self.part_path.exists() else 0
+
+    @property
+    def is_complete(self) -> bool:
+        return self.have_size == self.expected_size
+
+
+# Tracker shared across all download threads. Each thread
+# atomically updates its own counter; main thread polls and
+# aggregates for the progress display. Python's GIL makes
+# integer-load-and-store on a list element atomic; we don't
+# need a lock for the reader's snapshot.
+class _ChunkProgress:
+    def __init__(self, n_chunks: int):
+        self.bytes_per_chunk: List[int] = [0] * n_chunks
+        # Per-chunk completion flag for clean shutdown reporting.
+        self.completed: List[bool] = [False] * n_chunks
+        # Set by main thread on SIGINT to ask workers to stop.
+        self.stop_event: threading.Event = threading.Event()
+        # Sticky exception from any worker.
+        self.first_error: Optional[BaseException] = None
+        self.error_lock: threading.Lock = threading.Lock()
+
+    def total_bytes(self) -> int:
+        return sum(self.bytes_per_chunk)
+
+    def record_error(self, exc: BaseException) -> None:
+        with self.error_lock:
+            if self.first_error is None:
+                self.first_error = exc
+
+
+def _download_chunk(
+    plan: _ChunkPlan,
+    url: str,
+    progress: _ChunkProgress,
+    chunk_io_size: int = 1 << 20,
+    max_retries: int = 12,
+    connect_timeout: float = 30.0,
+) -> None:
+    """Download bytes [plan.byte_start, plan.byte_end] of `url` to
+    `plan.part_path`, resuming from the existing partial size.
+    Per-chunk retry loop with exponential backoff. Honors
+    progress.stop_event for cooperative cancellation."""
+    plan.part_path.parent.mkdir(parents=True, exist_ok=True)
+    have = plan.have_size
+    progress.bytes_per_chunk[plan.idx] = have
+
+    if have >= plan.expected_size:
+        if have > plan.expected_size:
+            with open(plan.part_path, "rb+") as f:
+                f.truncate(plan.expected_size)
+            progress.bytes_per_chunk[plan.idx] = plan.expected_size
+        progress.completed[plan.idx] = True
+        return
+
+    retries = 0
+    while plan.have_size < plan.expected_size and not progress.stop_event.is_set():
+        absolute_start = plan.byte_start + plan.have_size
+        absolute_end   = plan.byte_end
+        try:
+            req = urllib.request.Request(url)
+            req.add_header("Range",
+                           f"bytes={absolute_start}-{absolute_end}")
+            with urllib.request.urlopen(req, timeout=connect_timeout) as resp:
+                if resp.status != 206:
+                    raise RuntimeError(
+                        f"chunk {plan.idx}: requested Range bytes="
+                        f"{absolute_start}-{absolute_end} but server "
+                        f"returned status {resp.status} (expected 206)")
+                with open(plan.part_path, "ab") as f:
+                    while True:
+                        if progress.stop_event.is_set():
+                            f.flush()
+                            try:
+                                os.fsync(f.fileno())
+                            except OSError:
+                                pass
+                            return
+                        chunk = resp.read(chunk_io_size)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        progress.bytes_per_chunk[plan.idx] += len(chunk)
+                    f.flush()
+                    try:
+                        os.fsync(f.fileno())
+                    except OSError:
+                        pass
+        except (urllib.error.URLError, socket.timeout,
+                ConnectionError, OSError) as e:
+            retries += 1
+            if retries > max_retries:
+                err = RuntimeError(
+                    f"chunk {plan.idx}: exhausted {max_retries} retries "
+                    f"(last: {type(e).__name__}: {e}); part preserved at "
+                    f"{plan.part_path}")
+                progress.record_error(err)
+                return
+            backoff = min(60.0, 2.0 ** min(retries, 6))
+            time.sleep(backoff)
+
+    if not progress.stop_event.is_set():
+        progress.completed[plan.idx] = True
+
+
+def _migrate_legacy_partial(dest: Path, parts_dir: Path,
+                            chunk_0_path: Path) -> None:
+    """If a previous single-stream run left behind `<dest>.partial`,
+    treat it as chunk 0's existing prefix. Salvages any progress
+    rather than re-downloading from byte 0."""
+    legacy = dest.with_name(dest.name + ".partial")
+    if not legacy.exists():
+        return
+    parts_dir.mkdir(parents=True, exist_ok=True)
+    if chunk_0_path.exists():
+        # New-format part already there; pick the larger of the two.
+        if legacy.stat().st_size > chunk_0_path.stat().st_size:
+            chunk_0_path.unlink()
+            shutil.move(str(legacy), str(chunk_0_path))
+            sys.stderr.write(
+                f"  [migrate] {legacy.name} ({chunk_0_path.stat().st_size:,} B)"
+                f" -> {chunk_0_path.name}\n")
+        else:
+            legacy.unlink()
+    else:
+        shutil.move(str(legacy), str(chunk_0_path))
+        sys.stderr.write(
+            f"  [migrate] {legacy.name} ({chunk_0_path.stat().st_size:,} B)"
+            f" -> {chunk_0_path.name}\n")
+
+
+def _concatenate_parts(plans: List[_ChunkPlan], dest: Path) -> None:
+    """Stream-concatenate completed part files into `dest`. Uses an
+    intermediate `<dest>.combining` so an interrupted concat doesn't
+    leave a half-written file at the final name."""
+    combining = dest.with_name(dest.name + ".combining")
+    if combining.exists():
+        combining.unlink()
+    with open(combining, "wb") as out:
+        for plan in plans:
+            if not plan.is_complete:
+                raise RuntimeError(
+                    f"_concatenate_parts: chunk {plan.idx} incomplete "
+                    f"({plan.have_size}/{plan.expected_size})")
+            with open(plan.part_path, "rb") as src:
+                shutil.copyfileobj(src, out, length=4 << 20)  # 4 MiB
+        out.flush()
+        os.fsync(out.fileno())
+    combining.rename(dest)
+
+
+# Track active parts dir so SIGINT handler can flag clean shutdown.
+_active_parts_dir: Optional[Path] = None
+_active_progress: Optional[_ChunkProgress] = None
+
+
+def download_resumable_parallel(
+    url: str,
+    dest_path: Path,
+    n_streams: int = 32,
+    min_chunk_bytes: int = 16 << 20,    # 16 MiB
+    max_retries: int = 12,
+    progress_interval_s: float = 1.0,
+    connect_timeout: float = 30.0,
+) -> Path:
+    """Multi-Range parallel resumable downloader.
+
+    Splits the file into up to `n_streams` chunks, downloads each in
+    its own thread via an HTTP Range request, then concatenates the
+    parts to the final destination. Each chunk is independently
+    resumable (its part file persists across runs). Falls back to
+    a single stream when the total size is small enough that
+    splitting would make each chunk smaller than `min_chunk_bytes`.
+
+    Public behaviour matches the old `download_resumable`: on entry,
+    any prior `<dest>.partial` (legacy single-stream) is migrated
+    into chunk 0's part file; on success, the final file lives at
+    `<dest>` and parts dir is removed; on SIGINT, parts are
+    preserved and a re-run picks up where each chunk left off.
+    """
+    global _active_parts_dir, _active_progress
+
+    dest = Path(dest_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    parts_dir = dest.with_name(dest.name + ".parts")
+
+    sys.stderr.write(f"[head] {url}\n")
+    final_size = get_remote_size(url, timeout=connect_timeout)
+    sys.stderr.write(f"  Content-Length: {final_size:,} bytes "
+                     f"({final_size / 1e9:.2f} GB)\n")
+
+    if dest.exists():
+        if dest.stat().st_size == final_size:
+            sys.stderr.write(f"[skip] {dest.name} already complete "
+                             f"({final_size:,} bytes)\n")
+            return dest
+        sys.stderr.write(f"[warn] {dest.name} exists at "
+                         f"{dest.stat().st_size}, expected {final_size}; "
+                         f"removing\n")
+        dest.unlink()
+
+    # Decide on stream count. Keep each chunk above min_chunk_bytes so
+    # tiny files don't fan out 8 threads to download <4 MB total.
+    desired_chunks = max(1, n_streams)
+    chunk_size = max(min_chunk_bytes, (final_size + desired_chunks - 1) // desired_chunks)
+    actual_chunks = (final_size + chunk_size - 1) // chunk_size
+    if actual_chunks <= 1:
+        sys.stderr.write(f"[plan] small file (~{final_size / 1e6:.1f} MB); "
+                         f"using 1 stream\n")
+    else:
+        sys.stderr.write(f"[plan] {actual_chunks} streams x ~"
+                         f"{chunk_size / 1e9:.2f} GB each\n")
+
+    plans: List[_ChunkPlan] = []
+    for i in range(actual_chunks):
+        start = i * chunk_size
+        end = min(start + chunk_size - 1, final_size - 1)
+        plans.append(_ChunkPlan(
+            idx=i, byte_start=start, byte_end=end,
+            part_path=parts_dir / f"chunk_{i:04d}",
+        ))
+
+    # Salvage any legacy single-stream partial -> chunk 0.
+    if actual_chunks > 0:
+        _migrate_legacy_partial(dest, parts_dir, plans[0].part_path)
+
+    progress = _ChunkProgress(len(plans))
+    for plan in plans:
+        progress.bytes_per_chunk[plan.idx] = plan.have_size
+        if plan.is_complete:
+            progress.completed[plan.idx] = True
+
+    initial_total = progress.total_bytes()
+    if initial_total > 0:
+        sys.stderr.write(f"[resume] {initial_total:,} bytes already "
+                         f"downloaded across {sum(1 for p in plans if p.have_size > 0)} "
+                         f"existing parts\n")
+
+    _active_parts_dir = parts_dir
+    _active_progress = progress
+
+    # Launch workers.
+    threads: List[threading.Thread] = []
+    for plan in plans:
+        if plan.is_complete:
+            continue
+        t = threading.Thread(
+            target=_download_chunk,
+            args=(plan, url, progress),
+            kwargs={"max_retries": max_retries,
+                    "connect_timeout": connect_timeout},
+            name=f"chunk-{plan.idx}",
+            daemon=False,
+        )
+        t.start()
+        threads.append(t)
+
+    # Main thread: aggregate progress, print once per second.
+    rate = _RollingRate(window_seconds=30.0)
+    session_start = time.time()
+    rate.update(session_start, initial_total)
+    last_log = session_start
+
+    try:
+        while any(t.is_alive() for t in threads):
+            time.sleep(0.1)
+            now = time.time()
+            cur_total = progress.total_bytes()
+            rate.update(now, cur_total)
+            if now - last_log >= progress_interval_s:
+                mbps = rate.mbps()
+                pct = cur_total / final_size * 100 if final_size > 0 else 0.0
+                eta = _format_eta(final_size - cur_total, mbps)
+                elapsed = _format_elapsed(now - session_start)
+                session_dl_gb = (cur_total - initial_total) / 1e9
+                done_chunks = sum(1 for c in progress.completed if c)
+                sys.stderr.write(
+                    f"  {pct:6.2f}%  "
+                    f"{cur_total / 1e9:7.3f} / {final_size / 1e9:6.2f} GB  "
+                    f"{mbps:6.1f} MB/s  "
+                    f"elapsed {elapsed}  ETA {eta}  "
+                    f"({done_chunks}/{len(plans)} chunks, "
+                    f"+{session_dl_gb:.2f} GB this session)\n")
+                sys.stderr.flush()
+                last_log = now
+    except KeyboardInterrupt:
+        # Bubbled up from main thread; the SIGINT handler also fires.
+        progress.stop_event.set()
+        for t in threads:
+            t.join(timeout=5.0)
+        raise
+
+    for t in threads:
+        t.join()
+
+    if progress.first_error is not None:
+        raise progress.first_error
+
+    # All chunks must be complete to concatenate.
+    incomplete = [p for p in plans if not p.is_complete]
+    if incomplete:
+        raise RuntimeError(
+            f"download_resumable_parallel: {len(incomplete)} chunks "
+            f"incomplete: " +
+            ", ".join(f"{p.idx}({p.have_size}/{p.expected_size})"
+                      for p in incomplete[:5]) +
+            ("..." if len(incomplete) > 5 else ""))
+
+    # Verify total size.
+    actual_total = sum(p.have_size for p in plans)
+    if actual_total != final_size:
+        raise RuntimeError(
+            f"size mismatch after parallel download: parts total "
+            f"{actual_total}, expected {final_size}")
+
+    sys.stderr.write(f"[concat] joining {len(plans)} parts -> {dest.name}\n")
+    _concatenate_parts(plans, dest)
+    # Remove the parts dir on success.
+    try:
+        shutil.rmtree(parts_dir)
+    except OSError:
+        pass
+
+    elapsed_total = time.time() - session_start
+    session_dl = actual_total - initial_total
+    avg_mbps = (session_dl / elapsed_total / 1e6
+                if elapsed_total > 0 else 0.0)
+    sys.stderr.write(
+        f"[done] {dest.name}: {actual_total:,} bytes "
+        f"({actual_total / 1e9:.2f} GB total, {session_dl / 1e9:.2f} GB this session, "
+        f"{_format_elapsed(elapsed_total)} session avg {avg_mbps:.1f} MB/s)\n")
+    return dest
+
+
+def download_resumable(
+    url: str,
+    dest_path: Path,
+    chunk_size: int = 1 << 20,         # 1 MiB
+    max_retries: int = 12,
+    progress_interval_s: float = 1.0,
+    connect_timeout: float = 30.0,
+) -> Path:
+    """Download ``url`` to ``dest_path`` with HTTP Range resume.
+
+    On entry: existing ``dest_path`` files are checked against the
+    server's Content-Length and skipped if complete; existing
+    ``.partial`` files are resumed from. On normal exit: the
+    completed file is renamed from ``<dest>.partial`` to ``<dest>``.
+    On SIGINT: the partial is preserved so a re-run picks up.
+
+    Raises if max_retries are exhausted on a single segment, or if
+    the final byte count doesn't match Content-Length (i.e. server
+    truncated the response).
+    """
+    global _active_partial, _active_handle
+
+    dest = Path(dest_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    partial = dest.with_name(dest.name + ".partial")
+
+    sys.stderr.write(f"[head] {url}\n")
+    final_size = get_remote_size(url, timeout=connect_timeout)
+    sys.stderr.write(f"  Content-Length: {final_size:,} bytes "
+                     f"({final_size / 1e9:.2f} GB)\n")
+
+    # Idempotent skip: same-name file already exists at expected size.
+    if dest.exists():
+        if dest.stat().st_size == final_size:
+            sys.stderr.write(f"[skip] {dest.name} already complete "
+                             f"({final_size:,} bytes)\n")
+            return dest
+        sys.stderr.write(f"[warn] {dest.name} exists but size mismatch "
+                         f"({dest.stat().st_size} vs {final_size}); "
+                         f"removing and re-downloading\n")
+        dest.unlink()
+
+    have_bytes = partial.stat().st_size if partial.exists() else 0
+
+    if have_bytes >= final_size:
+        # Over- or exactly full partial -- assume server Content-Length
+        # didn't drift; promote to final.
+        if have_bytes > final_size:
+            sys.stderr.write(f"[warn] partial ({have_bytes}) exceeds "
+                             f"expected ({final_size}); truncating\n")
+            with open(partial, "rb+") as f:
+                f.truncate(final_size)
+        partial.rename(dest)
+        return dest
+
+    if have_bytes > 0:
+        sys.stderr.write(f"[resume] {partial.name} from byte "
+                         f"{have_bytes:,} ({have_bytes / final_size * 100:.1f}%)\n")
+
+    retries = 0
+    start_session_bytes = have_bytes
+    session_start = time.time()
+    rate = _RollingRate(window_seconds=30.0)
+    rate.update(session_start, have_bytes)
+
+    while have_bytes < final_size:
+        try:
+            req = urllib.request.Request(url)
+            if have_bytes > 0:
+                req.add_header("Range", f"bytes={have_bytes}-")
+
+            with urllib.request.urlopen(req, timeout=connect_timeout) as resp:
+                # When we send a Range request, the server SHOULD respond 206
+                # Partial Content. If it returns 200, the server doesn't honor
+                # ranges and we'd silently re-download from byte 0 — fail loud
+                # instead.
+                status = resp.status
+                if have_bytes > 0 and status != 206:
+                    raise RuntimeError(
+                        f"resume failed: requested Range bytes={have_bytes}- "
+                        f"but server returned status {status} (expected 206). "
+                        f"Server doesn't support resume on this URL; re-run "
+                        f"after `rm {partial}` to start over.")
+
+                _active_partial = partial
+                with open(partial, "ab") as f:
+                    _active_handle = f
+                    last_log = time.time()
+                    while True:
+                        chunk = resp.read(chunk_size)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        have_bytes += len(chunk)
+                        now = time.time()
+                        rate.update(now, have_bytes)
+                        if now - last_log >= progress_interval_s:
+                            mbps = rate.mbps()  # rolling 30s window
+                            pct = have_bytes / final_size * 100
+                            eta = _format_eta(final_size - have_bytes, mbps)
+                            elapsed = _format_elapsed(now - session_start)
+                            session_dl_gb = (have_bytes - start_session_bytes) / 1e9
+                            sys.stderr.write(
+                                f"  {pct:6.2f}%  "
+                                f"{have_bytes / 1e9:7.3f} / "
+                                f"{final_size / 1e9:6.2f} GB  "
+                                f"{mbps:6.1f} MB/s  "
+                                f"elapsed {elapsed}  ETA {eta}  "
+                                f"(+{session_dl_gb:.2f} GB this session)\n")
+                            sys.stderr.flush()
+                            last_log = now
+                    f.flush()
+                    os.fsync(f.fileno())
+                _active_handle = None
+                _active_partial = None
+
+        except (urllib.error.URLError, socket.timeout,
+                ConnectionError, OSError) as e:
+            retries += 1
+            if retries > max_retries:
+                sys.stderr.write(
+                    f"[fatal] {dest.name}: exhausted {max_retries} retries "
+                    f"(last error: {e}). Resume from partial on next run.\n")
+                raise
+            backoff = min(60.0, 2.0 ** min(retries, 6))
+            # Re-stat the partial in case the connection dropped mid-write.
+            actual = partial.stat().st_size if partial.exists() else 0
+            sys.stderr.write(
+                f"  [retry {retries}/{max_retries}] {type(e).__name__}: {e}\n"
+                f"  partial is now {actual:,} bytes; retrying in "
+                f"{backoff:.0f}s\n")
+            sys.stderr.flush()
+            time.sleep(backoff)
+            have_bytes = partial.stat().st_size if partial.exists() else 0
+
+    actual = partial.stat().st_size
+    if actual != final_size:
+        raise RuntimeError(
+            f"size mismatch: partial has {actual} bytes, expected {final_size}")
+    partial.rename(dest)
+
+    elapsed_total = time.time() - session_start
+    session_dl = actual - start_session_bytes
+    avg_mbps = (session_dl / elapsed_total / 1e6
+                if elapsed_total > 0 else 0.0)
+    sys.stderr.write(
+        f"[done] {dest.name}: {actual:,} bytes "
+        f"({actual / 1e9:.2f} GB total, {session_dl / 1e9:.2f} GB this session, "
+        f"{_format_elapsed(elapsed_total)} session avg {avg_mbps:.1f} MB/s)\n")
+    return dest
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # Default destination mirrors the existing Mai City / Replica
+    # layout: `tests/benchmarks/tsdf_fusion/data/<DATASET>/`.
+    # __file__ is .../cross_library/download_kitti.py, so its
+    # parent.parent is .../tsdf_fusion.
+    ap.add_argument(
+        "--dest", type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "data" / "KITTI" / "zips",
+        help="Destination directory for the .zip files.")
+    ap.add_argument(
+        "--files", nargs="+", default=["calib", "poses", "velodyne"],
+        choices=sorted(KITTI_FILES.keys()),
+        help="Which archives to download. "
+             "Order: small-first by default so you get something usable "
+             "even if the velodyne download is interrupted.")
+    ap.add_argument(
+        "--max-retries", type=int, default=12,
+        help="Per-file retry budget on connection drops.")
+    ap.add_argument(
+        "--streams", type=int, default=32,
+        help="Number of parallel HTTP Range streams. KITTI's S3 "
+             "bucket throttles each connection to ~0.15-0.20 MB/s. "
+             "Empirical sweep (3 trials each, 30 s) on this link: "
+             "1->0.12, 8->1.22, 16->3.01, 24->3.75, 32->6.07, "
+             "48->8.55 MB/s aggregate. 32 is the cleanest knee: "
+             "lowest variance and a super-linear jump from 24. "
+             "Above 48 the slow-outlier tail starts to dominate. "
+             "Set to 1 for single-stream behaviour.")
+    args = ap.parse_args()
+
+    signal.signal(signal.SIGINT, _on_sigint)
+    signal.signal(signal.SIGTERM, _on_sigint)
+
+    args.dest.mkdir(parents=True, exist_ok=True)
+    sys.stderr.write(f"=== KITTI download into {args.dest} ===\n")
+
+    failed: list[str] = []
+    for name in args.files:
+        spec = KITTI_FILES[name]
+        url = f"{KITTI_S3_BASE}/{spec['filename']}"
+        dest = args.dest / spec["filename"]
+        sys.stderr.write(
+            f"\n--- {name}: {spec['filename']} "
+            f"(~{spec['approx_size_gb']} GB)\n"
+            f"    {spec['description']}\n")
+        try:
+            if args.streams <= 1:
+                download_resumable(url, dest, max_retries=args.max_retries)
+            else:
+                download_resumable_parallel(
+                    url, dest,
+                    n_streams=args.streams,
+                    max_retries=args.max_retries,
+                )
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"[fatal] {name}: {type(e).__name__}: {e}\n")
+            failed.append(name)
+
+    if failed:
+        sys.stderr.write(f"\nFAILED: {failed}\n")
+        return 1
+
+    sys.stderr.write("\nAll downloads complete.\n")
+    sys.stderr.write(f"Next steps:\n")
+    sys.stderr.write(f"  cd {args.dest.parent}\n")
+    sys.stderr.write(f"  for z in zips/*.zip; do unzip -n \"$z\"; done\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/tsdf_fusion/cross_library/download_replica.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/download_replica.py
@@ -1,0 +1,183 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Partial downloader for the NICE-SLAM Replica rendering.
+
+The published Replica.zip is 12.4 GB (all 8 scenes). Via HTTP range
+requests we can extract just the scenes / strided frames we need,
+which is several orders of magnitude faster on bandwidth-limited
+links (the ETH cvg-data mirror rate-limits to ~180 KB/s).
+
+Usage:
+
+    python download_replica.py room_0 \\
+        --out /path/to/data/Replica \\
+        --stride 10              # keep 1/10th of frames
+        --max-frames 200         # cap total frames per scene
+
+Default: stride=1, no cap (full scene, ~1.6 GB per scene).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from typing import List, Optional
+
+try:
+    from remotezip import RemoteZip
+except ImportError as e:  # pragma: no cover
+    raise ImportError(
+        "download_replica needs `remotezip` installed: pip install remotezip"
+    ) from e
+
+
+REPLICA_ZIP_URL = "https://cvg-data.inf.ethz.ch/nice-slam/data/Replica.zip"
+
+# NICE-SLAM's zip layout: `Replica/<scene>/results/...` + `Replica/<scene>/traj.txt`.
+# The archive root directory is `Replica/`.
+
+# Archive uses `frame000000.jpg` / `depth000000.png` naming.
+_FRAME_RE = re.compile(r"Replica/(?P<scene>[^/]+)/results/(?:frame|depth)(?P<idx>\d{6})\.(?:jpg|png)$")
+
+
+def _format_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{n:.1f}PB"
+
+
+def download_scene(
+    scene: str,
+    out_dir: str,
+    stride: int = 1,
+    max_frames: Optional[int] = None,
+    url: str = REPLICA_ZIP_URL,
+) -> None:
+    """Download a subset of `scene` from the remote Replica.zip via HTTP ranges.
+
+    Writes into `<out_dir>/<scene>/results/` and `<out_dir>/<scene>/traj.txt`.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    scene_root = os.path.join(out_dir, scene)
+    results_dir = os.path.join(scene_root, "results")
+    os.makedirs(results_dir, exist_ok=True)
+
+    print(f"opening remote zip @ {url} (central-directory fetch only)...")
+    with RemoteZip(url) as rz:
+        names = rz.namelist()
+
+        # Find frame indices available for this scene.
+        scene_prefix = f"Replica/{scene}/"
+        traj_name = f"{scene_prefix}traj.txt"
+        if traj_name not in names:
+            avail = sorted({n.split("/")[1] for n in names if n.startswith("Replica/") and "/" in n[len("Replica/"):]})
+            raise SystemExit(
+                f"scene {scene!r} not found in archive. Available scenes:\n  "
+                + "\n  ".join(avail)
+            )
+
+        # Enumerate (frame_idx, jpg_name, png_name) tuples for this scene.
+        frames_idx: List[int] = []
+        for n in names:
+            m = _FRAME_RE.match(n)
+            if m and m.group("scene") == scene:
+                frames_idx.append(int(m.group("idx")))
+        frames_idx = sorted(set(frames_idx))
+        n_total = len(frames_idx)
+        kept = frames_idx[::stride]
+        if max_frames is not None:
+            kept = kept[:max_frames]
+
+        members: List[str] = [traj_name]
+        for i in kept:
+            members.append(f"{scene_prefix}results/frame{i:06d}.jpg")
+            members.append(f"{scene_prefix}results/depth{i:06d}.png")
+
+        # Sum compressed sizes so we know the download bytes budget.
+        total_compressed = 0
+        for name in members:
+            try:
+                info = rz.getinfo(name)
+                total_compressed += info.compress_size
+            except KeyError:
+                print(f"  warn: missing member {name}", file=sys.stderr)
+        print(
+            f"scene={scene!r}: {n_total} frames in archive, keeping "
+            f"{len(kept)} after stride={stride} + max_frames={max_frames}; "
+            f"fetching ~{_format_bytes(total_compressed)} of compressed data"
+        )
+
+        # Extract each member to `out_dir`. remotezip translates this to
+        # HTTP Range requests under the hood.
+        t0 = time.perf_counter()
+        for i, name in enumerate(members):
+            rz.extract(name, path=out_dir)
+            if i % 20 == 0 or i == len(members) - 1:
+                dt = time.perf_counter() - t0
+                kbps = (rz._session_fetched_bytes / 1024.0 / max(dt, 1e-3)) if hasattr(rz, "_session_fetched_bytes") else None
+                rate = f"  ({kbps:.0f} KB/s)" if kbps else ""
+                print(f"  [{i + 1:>5d} / {len(members):>5d}]  {name}{rate}")
+
+        # remotezip extracts to `<out_dir>/Replica/<scene>/...`; move to
+        # `<out_dir>/<scene>/...` so `replica_loader` sees the expected
+        # layout ("scene-root has results/ and traj.txt at top level").
+        tmp_root = os.path.join(out_dir, "Replica")
+        if os.path.isdir(tmp_root):
+            extracted_scene = os.path.join(tmp_root, scene)
+            if os.path.isdir(extracted_scene):
+                # Move contents of extracted_scene into scene_root (which
+                # already exists).
+                for entry in os.listdir(extracted_scene):
+                    src = os.path.join(extracted_scene, entry)
+                    dst = os.path.join(scene_root, entry)
+                    if os.path.exists(dst):
+                        # Directory already exists: merge contents.
+                        if os.path.isdir(src) and os.path.isdir(dst):
+                            for sub in os.listdir(src):
+                                os.rename(
+                                    os.path.join(src, sub),
+                                    os.path.join(dst, sub),
+                                )
+                            os.rmdir(src)
+                        else:
+                            raise RuntimeError(
+                                f"conflict moving {src!r} -> {dst!r}"
+                            )
+                    else:
+                        os.rename(src, dst)
+                os.rmdir(extracted_scene)
+            if os.path.isdir(tmp_root) and not os.listdir(tmp_root):
+                os.rmdir(tmp_root)
+
+    print(f"done. scene written to {scene_root!r}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("scene", help="scene name (e.g. room_0, office_0)")
+    p.add_argument("--out", default=None,
+                   help="output dir (default: <this_dir>/../data/Replica)")
+    p.add_argument("--stride", type=int, default=1,
+                   help="keep 1 / stride frames")
+    p.add_argument("--max-frames", type=int, default=None,
+                   help="cap total frames after stride")
+    p.add_argument("--url", default=REPLICA_ZIP_URL)
+    args = p.parse_args()
+
+    out = args.out
+    if out is None:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = os.path.normpath(os.path.join(here, "..", "data", "Replica"))
+
+    download_scene(args.scene, out, stride=args.stride,
+                   max_frames=args.max_frames, url=args.url)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/download_replica_zip.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/download_replica_zip.py
@@ -1,0 +1,133 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Bulk download of NICE-SLAM's Replica.zip (12.44 GB) using the
+parallel multi-Range downloader from `download_kitti.py`.
+
+Why: the existing `download_replica.py` uses `remotezip` to extract
+strided subsets of frames over a single HTTP connection, which is
+the right choice when bandwidth is precious and you only need
+~200 frames per scene. For a paper-grade benchmark we want all
+8 scenes at full frame rate (~2000 frames/scene), which means
+pulling the whole archive.
+
+ETH's `cvg-data.inf.ethz.ch` mirror throttles each HTTP connection
+to ~0.1-0.2 MB/s but does not appear to apply a per-IP cap; an
+empirical sweep against the Replica.zip URL shows aggregate
+throughput scales near-linearly through 32 streams (matching
+KITTI's S3 behaviour). At 32 streams ETA is ~45 min vs ~49 hours
+single-stream.
+
+Usage:
+
+    python download_replica_zip.py            # 32 streams, default dest
+    python download_replica_zip.py --streams 16
+    python download_replica_zip.py --extract  # also unzip after download
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Reuse the parallel download primitives from the KITTI downloader.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from download_kitti import (  # noqa: E402
+    _on_sigint,
+    download_resumable,
+    download_resumable_parallel,
+)
+
+
+REPLICA_ZIP_URL = "https://cvg-data.inf.ethz.ch/nice-slam/data/Replica.zip"
+REPLICA_ZIP_SIZE_BYTES = 12_442_855_671   # ~12.44 GB
+REPLICA_SCENES = (
+    "office0", "office1", "office2", "office3", "office4",
+    "room0", "room1", "room2",
+)
+
+
+def main() -> None:
+    here = Path(__file__).resolve().parent
+    default_dest = here.parent / "data" / "Replica.zip"
+    default_extract_to = here.parent / "data" / "Replica"
+
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dest", type=Path, default=default_dest,
+                    help=f"output path for the .zip (default: {default_dest})")
+    ap.add_argument("--streams", type=int, default=32,
+                    help="parallel HTTP Range streams (default: 32)")
+    ap.add_argument("--max-retries", type=int, default=12,
+                    help="per-chunk retry budget (default: 12)")
+    ap.add_argument("--extract", action="store_true",
+                    help="after download, unzip into <dest_dir>/Replica/. "
+                         "Skips scenes already extracted with the expected "
+                         "frame counts.")
+    ap.add_argument("--extract-to", type=Path, default=default_extract_to,
+                    help=f"extract destination (default: {default_extract_to})")
+    args = ap.parse_args()
+
+    signal.signal(signal.SIGINT, _on_sigint)
+    signal.signal(signal.SIGTERM, _on_sigint)
+
+    sys.stderr.write(
+        f"=== Replica.zip download into {args.dest.parent} ===\n"
+        f"    URL    : {REPLICA_ZIP_URL}\n"
+        f"    streams: {args.streams}\n"
+        f"    expect : ~{REPLICA_ZIP_SIZE_BYTES / 1e9:.2f} GB\n\n")
+
+    args.dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.streams <= 1:
+        download_resumable(REPLICA_ZIP_URL, args.dest,
+                           max_retries=args.max_retries)
+    else:
+        download_resumable_parallel(
+            REPLICA_ZIP_URL, args.dest,
+            n_streams=args.streams,
+            max_retries=args.max_retries,
+        )
+
+    actual_size = args.dest.stat().st_size
+    if actual_size != REPLICA_ZIP_SIZE_BYTES:
+        sys.stderr.write(
+            f"[warn] downloaded size {actual_size:,} != expected "
+            f"{REPLICA_ZIP_SIZE_BYTES:,}; the upstream archive may have "
+            f"changed. Continuing anyway.\n")
+
+    if args.extract:
+        sys.stderr.write(f"\n=== Extracting into {args.extract_to} ===\n")
+        args.extract_to.mkdir(parents=True, exist_ok=True)
+        # `unzip -n`: never overwrite. Lets us re-run safely.
+        t0 = time.time()
+        proc = subprocess.run(
+            ["unzip", "-n", "-q", str(args.dest), "-d", str(args.extract_to.parent)],
+            check=False,
+        )
+        if proc.returncode != 0:
+            sys.stderr.write(
+                f"[fatal] unzip failed with code {proc.returncode}\n")
+            sys.exit(proc.returncode)
+        sys.stderr.write(f"  unzip done in {time.time() - t0:.0f} s\n")
+
+        # The archive layout is `Replica/<scene>/...` so the unzip
+        # command above unpacks into `<extract_to.parent>/Replica/...`,
+        # which already matches `args.extract_to`. List what's there:
+        scenes_present = sorted(d.name for d in args.extract_to.iterdir() if d.is_dir())
+        sys.stderr.write(f"  scenes available: {len(scenes_present)} -> {scenes_present}\n")
+
+    sys.stderr.write(
+        "\n=== Done. ===\n"
+        f"  ZIP at  : {args.dest}\n"
+        f"  Scenes  : {args.extract_to if args.extract else '(run with --extract or unzip manually)'}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/install_nvblox.sh
+++ b/tests/benchmarks/tsdf_fusion/cross_library/install_nvblox.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reproducible nvblox_torch install into a dedicated `nvblox` conda
+# env. We build from source because:
+#
+#   * `pip install nvblox_torch` doesn't work -- it's not on pypi.
+#   * The wheel on NVIDIA's Isaac index targets CUDA 12 + torch<=2.9.1;
+#     our `fvdb` env is on CUDA 13 + torch 2.10 and downgrading would
+#     break fvdb.
+#   * Running nvblox out-of-process from the benchmark driver (via
+#     `nvblox_runner.py`) is actually desirable anyway: it isolates
+#     nvblox's CUDA context + block-hash allocator pool from fvdb's,
+#     so the two libraries can't fight over GPU memory.
+#
+# End state after this script:
+#
+#   conda env `nvblox` with python 3.11, CUDA 12.4, torch 2.6.0+cu124,
+#   nvblox_torch 0.0.9 importable with `Mapper` + `Sensor.from_lidar`
+#   working. Invoke via
+#   `/home/fwilliams/bin/miniconda3/envs/nvblox/bin/python nvblox_runner.py`.
+#
+# Prereqs: a working miniconda + git. No root / sudo needed.
+#
+# Idempotent: skips work that's already done.
+
+set -euo pipefail
+
+CONDA_ROOT="${CONDA_ROOT:-/home/fwilliams/bin/miniconda3}"
+NVBLOX_SRC="${NVBLOX_SRC:-/tmp/nvblox}"
+CUDA_STAGED="${CUDA_STAGED:-/tmp/cuda-root}"
+
+echo "=== [1/5] Create conda env 'nvblox' with CUDA 12.4 ==="
+if [[ ! -d "${CONDA_ROOT}/envs/nvblox" ]]; then
+    "${CONDA_ROOT}/bin/conda" create -n nvblox -c conda-forge -c nvidia -y \
+        python=3.11 cuda-toolkit=12.4 cuda-nvcc=12.4 cmake ninja git
+fi
+NVBLOX_ENV="${CONDA_ROOT}/envs/nvblox"
+
+echo "=== [2/5] Install torch 2.6 + CUDA-12.4 wheel ==="
+if ! "${NVBLOX_ENV}/bin/python" -c "import torch; assert torch.version.cuda.startswith('12')" 2>/dev/null; then
+    "${NVBLOX_ENV}/bin/pip" install 'torch==2.6.0+cu124' 'torchvision==0.21.0+cu124' \
+        --index-url https://download.pytorch.org/whl/cu124
+fi
+
+echo "=== [3/5] Stage conda CUDA toolkit as a FindCUDA-friendly prefix ==="
+# Torch's CMake uses the legacy FindCUDA module which wants
+# ${CUDA_TOOLKIT_ROOT_DIR}/include/cuda_runtime.h at the top level.
+# Conda installs headers under `targets/x86_64-linux/include/` and
+# the prefix dir is read-only so we can't symlink into it. Stage a
+# parallel layout in /tmp that points at the real conda paths.
+if [[ ! -f "${CUDA_STAGED}/include/cuda_runtime.h" ]]; then
+    rm -rf "${CUDA_STAGED}"
+    mkdir -p "${CUDA_STAGED}/include"
+    for f in "${NVBLOX_ENV}/targets/x86_64-linux/include/"*; do
+        ln -sf "$f" "${CUDA_STAGED}/include/$(basename "$f")"
+    done
+    # nvblox's `#include <nvtx3/nvToolsExt.h>` needs an nvtx3 dir.
+    # CUDA 12 dropped the old libnvToolsExt; the nvtx3 headers live
+    # in the `nvidia.nvtx` pip subpackage that torch's install
+    # dragged in. Point the staged include at that.
+    ln -sf "${NVBLOX_ENV}/lib/python3.11/site-packages/nvidia/nvtx/include/nvtx3" \
+        "${CUDA_STAGED}/include/nvtx3"
+    ln -sf "${NVBLOX_ENV}/bin" "${CUDA_STAGED}/bin"
+    ln -sf "${NVBLOX_ENV}/lib" "${CUDA_STAGED}/lib"
+    ln -sf "${NVBLOX_ENV}/lib" "${CUDA_STAGED}/lib64"
+    ln -sf "${NVBLOX_ENV}/nvvm" "${CUDA_STAGED}/nvvm"
+fi
+
+echo "=== [4/5] Clone + build nvblox C++ (static lib + pybind) ==="
+if [[ ! -d "${NVBLOX_SRC}" ]]; then
+    git clone --depth 1 https://github.com/nvidia-isaac/nvblox.git "${NVBLOX_SRC}"
+fi
+if [[ ! -f "${NVBLOX_SRC}/build/nvblox_torch/cpp/libpy_nvblox.so" ]]; then
+    export PATH="${NVBLOX_ENV}/bin:${PATH}"
+    export CMAKE_PREFIX_PATH="${NVBLOX_ENV}/lib/python3.11/site-packages/torch/share/cmake:${NVBLOX_ENV}"
+    export CUDA_TOOLKIT_ROOT_DIR="${CUDA_STAGED}"
+    export CUDAToolkit_ROOT="${CUDA_STAGED}"
+    rm -rf "${NVBLOX_SRC}/build" && mkdir "${NVBLOX_SRC}/build" && cd "${NVBLOX_SRC}/build"
+    # Build only `py_nvblox` (the pytorch binding) and its required
+    # `libnvblox_lib.so` + `libnvblox_gpu_hash.a`. nvblox's
+    # executables (load_map_and_mesh, fuse_*) fail to link without
+    # -rpath-link wiring and we don't need them for the bench.
+    cmake .. -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CUDA_ARCHITECTURES=89 \
+        -DBUILD_PYTORCH_WRAPPER=ON \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_EXPERIMENTS=OFF \
+        -DCUDA_TOOLKIT_ROOT_DIR="${CUDA_STAGED}" \
+        -DCUDAToolkit_ROOT="${CUDA_STAGED}" \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -Dnvtx3_dir="${CUDA_STAGED}/include/nvtx3" \
+        -DPython_EXECUTABLE="${NVBLOX_ENV}/bin/python" \
+        -DCMAKE_CXX_FLAGS="-I${CUDA_STAGED}/include" \
+        -DCMAKE_CUDA_FLAGS="-I${CUDA_STAGED}/include"
+    ninja py_nvblox
+fi
+
+echo "=== [5/5] Install nvblox_torch wheel (+ runtime deps) ==="
+# nvblox_torch's `pyproject.toml` lists heavyweight runtime deps
+# (open3d, timm, matplotlib, ...) most of which aren't needed for
+# just TSDF fusion. Install with --no-deps, then add back only the
+# handful that the `Mapper` import chain actually requires.
+if ! "${NVBLOX_ENV}/bin/python" -c "import nvblox_torch" 2>/dev/null; then
+    export CUDA_VERSION=12
+    "${NVBLOX_ENV}/bin/pip" install --no-cache-dir --no-deps \
+        transforms3d imageio opencv-python einops nvtx scipy scikit-learn \
+        plotly dash flask werkzeug jinja2 markupsafe itsdangerous click \
+        blinker retrying importlib-metadata jupyter_dash nbformat narwhals \
+        threadpoolctl joblib pillow
+    "${NVBLOX_ENV}/bin/pip" install --no-deps --no-cache-dir \
+        "${NVBLOX_SRC}/nvblox_torch/"
+    # open3d is the biggest single dep and needs its own transitive
+    # set (plotly already above; open3d's _ml3d module imports
+    # sklearn which we got, addict, ...). Resolving normally is
+    # expensive; pin to the 0.18.x wheel.
+    "${NVBLOX_ENV}/bin/pip" install --no-cache-dir 'open3d==0.18.*'
+fi
+
+echo "=== Verifying import ==="
+"${NVBLOX_ENV}/bin/python" -c "
+import nvblox_torch
+from nvblox_torch.mapper import Mapper
+from nvblox_torch.sensor import Sensor
+from nvblox_torch.projective_integrator_types import ProjectiveIntegratorType
+m = Mapper(voxel_sizes_m=[0.2], integrator_types=[ProjectiveIntegratorType.TSDF])
+s = Sensor.from_lidar(1800, 64, 0.4712, 1.0)
+print(f'OK -- nvblox_torch {nvblox_torch.__version__} with {m} and {s}')
+"
+echo "=== Done ==="

--- a/tests/benchmarks/tsdf_fusion/cross_library/install_vdbfusion.sh
+++ b/tests/benchmarks/tsdf_fusion/cross_library/install_vdbfusion.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reproducible VDBFusion install into the `fvdb` conda env.
+#
+# Why this script exists: `pip install vdbfusion` fails on any modern
+# Linux toolchain because VDBFusion vendors c-blosc 1.5.0 + TBB 2018
+# as ExternalProject_Add trees and those trees do not build under
+# gcc-13+ or CMake >= 4 without extensive patches. This script
+# sidesteps the vendored stack entirely by:
+#
+#   1. Cloning OpenVDB 12 and compiling it against the `fvdb` conda
+#      env's TBB / Blosc / Boost (all of which are already modern).
+#   2. Cloning Eigen 3.4 (headers only).
+#   3. Cloning VDBFusion and applying a minimal CMake patch to make
+#      it find our freshly-built OpenVDB and explicitly link the
+#      transitive TBB / Blosc / Boost dependencies that OpenVDB's
+#      FindOpenVDB.cmake does not propagate through OpenVDB::openvdb.
+#   4. `pip install`-ing the patched VDBFusion into `fvdb`.
+#
+# Result: `import vdbfusion` works inside the `fvdb` env with no
+# toolchain conflicts. Works on Ubuntu 24.04 / gcc-13 / CMake 4.3 /
+# Python 3.12 as of 2026-04-22.
+#
+# Usage:
+#   bash tests/benchmarks/tsdf_fusion/cross_library/install_vdbfusion.sh
+#
+# Idempotent: re-running with existing /tmp state just rebuilds.
+
+set -euo pipefail
+
+FVDB_ENV="${FVDB_ENV:-/home/fwilliams/bin/miniconda3/envs/fvdb}"
+OPENVDB_SRC="${OPENVDB_SRC:-/tmp/openvdb-build/src}"
+OPENVDB_BUILD="${OPENVDB_BUILD:-/tmp/openvdb-build/build}"
+OPENVDB_PREFIX="${OPENVDB_PREFIX:-/tmp/openvdb-prefix}"
+EIGEN_SRC="${EIGEN_SRC:-/tmp/openvdb-build/eigen-src}"
+EIGEN_PREFIX="${EIGEN_PREFIX:-/tmp/eigen-prefix}"
+VDBFUSION_SRC="${VDBFUSION_SRC:-/tmp/vdbfusion_src}"
+
+export PATH="${FVDB_ENV}/bin:${PATH}"
+
+echo "=== [1/4] Clone OpenVDB 12 + Eigen ==="
+if [[ ! -d "${OPENVDB_SRC}" ]]; then
+    mkdir -p "$(dirname "${OPENVDB_SRC}")"
+    git clone --depth 1 --branch v12.0.1 \
+        https://github.com/AcademySoftwareFoundation/openvdb.git "${OPENVDB_SRC}"
+fi
+if [[ ! -d "${EIGEN_SRC}" ]]; then
+    git clone --depth 1 --branch 3.4 \
+        https://gitlab.com/libeigen/eigen.git "${EIGEN_SRC}"
+fi
+
+echo "=== [2/4] Build OpenVDB 12 against ${FVDB_ENV} ==="
+if [[ ! -f "${OPENVDB_PREFIX}/lib/libopenvdb.a" ]]; then
+    rm -rf "${OPENVDB_BUILD}"
+    mkdir -p "${OPENVDB_BUILD}"
+    cd "${OPENVDB_BUILD}"
+    cmake "${OPENVDB_SRC}" \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${OPENVDB_PREFIX}" \
+        -DCMAKE_PREFIX_PATH="${FVDB_ENV}" \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DOPENVDB_BUILD_CORE=ON \
+        -DOPENVDB_BUILD_BINARIES=OFF \
+        -DOPENVDB_BUILD_DOCS=OFF \
+        -DOPENVDB_BUILD_PYTHON_MODULE=OFF \
+        -DOPENVDB_BUILD_NANOVDB=OFF \
+        -DUSE_BLOSC=ON \
+        -DUSE_ZLIB=ON \
+        -DBUILD_SHARED_LIBS=OFF
+    ninja -j "$(nproc)"
+    ninja install
+fi
+
+echo "=== [3/4] Install Eigen 3.4 headers ==="
+if [[ ! -d "${EIGEN_PREFIX}/include/eigen3" ]]; then
+    cd "${EIGEN_SRC}"
+    cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${EIGEN_PREFIX}"
+    cmake --install build
+fi
+
+echo "=== [4/4] Clone + patch + install VDBFusion ==="
+if [[ ! -d "${VDBFUSION_SRC}" ]]; then
+    git clone --depth 1 https://github.com/PRBonn/vdbfusion.git "${VDBFUSION_SRC}"
+fi
+
+# Apply two minimal patches.
+#
+# Patch 1: the main vdbfusion lib compiles fine against OpenVDB 12 but
+# hits the gcc-13 `-Werror` wall against the ancient TBB warning style
+# that OpenVDB headers still emit. Relax the per-target options.
+#
+# Patch 2: OpenVDB's `FindOpenVDB.cmake` does not propagate TBB /
+# Blosc / Boost.iostreams / ZLIB through `OpenVDB::openvdb`'s public
+# interface (they are compile-time-only deps there), so static-built
+# libopenvdb.a leaves unresolved TBB symbols in the pybind .so,
+# causing `ImportError: undefined symbol _ZN3tbb6detail2r15spawn...`
+# at import time. Explicitly list them as PUBLIC deps, guarded by
+# `if(TARGET ...)` so we don't double-define TBB::tbb when CMake
+# config-mode loading also brings it in.
+cd "${VDBFUSION_SRC}"
+python3 - <<'PY'
+import pathlib
+p = pathlib.Path("src/vdbfusion/vdbfusion/CMakeLists.txt")
+text = p.read_text()
+if "-Wno-changes-meaning" not in text:
+    text = text.replace(
+        "target_compile_options(vdbfusion PRIVATE -Wall -Wextra)",
+        "target_compile_options(vdbfusion PRIVATE\n"
+        "    -Wall -Wextra\n"
+        "    -Wno-error -Wno-changes-meaning -Wno-template-id-cdtor\n"
+        "    -Wno-deprecated-declarations -Wno-deprecated\n"
+        "    -Wno-class-memaccess -Wno-cast-user-defined\n"
+        "    -Wno-missing-template-keyword -Wno-narrowing)",
+    )
+if "PATCH: TBB transitive link" not in text:
+    text = text.replace(
+        "target_link_libraries(vdbfusion PUBLIC Eigen3::Eigen OpenVDB::openvdb)",
+        "target_link_libraries(vdbfusion PUBLIC Eigen3::Eigen OpenVDB::openvdb)\n\n"
+        "# PATCH: TBB transitive link -- see install_vdbfusion.sh for why.\n"
+        "foreach(_dep IN ITEMS TBB::tbb TBB::tbbmalloc Blosc::blosc Boost::iostreams ZLIB::ZLIB)\n"
+        "  if(TARGET ${_dep})\n"
+        "    target_link_libraries(vdbfusion PUBLIC ${_dep})\n"
+        "  endif()\n"
+        "endforeach()",
+    )
+p.write_text(text)
+
+q = pathlib.Path("src/vdbfusion/pybind/CMakeLists.txt")
+text = q.read_text()
+if "-Wno-changes-meaning" not in text:
+    text = text.replace(
+        "target_compile_options(vdbfusion_pybind PRIVATE -Werror -Wall -Wextra)",
+        "target_compile_options(vdbfusion_pybind PRIVATE\n"
+        "    -Wall -Wextra\n"
+        "    -Wno-error -Wno-changes-meaning -Wno-template-id-cdtor\n"
+        "    -Wno-deprecated-declarations -Wno-deprecated\n"
+        "    -Wno-class-memaccess -Wno-cast-user-defined\n"
+        "    -Wno-missing-template-keyword -Wno-narrowing)",
+    )
+q.write_text(text)
+print("Patches applied.")
+PY
+
+rm -rf "${VDBFUSION_SRC}/build"
+CMAKE_ARGS="-DUSE_SYSTEM_OPENVDB=ON -DUSE_SYSTEM_EIGEN3=ON -DUSE_SYSTEM_PYBIND11=ON -DCMAKE_PREFIX_PATH=${OPENVDB_PREFIX};${EIGEN_PREFIX};${FVDB_ENV} -DCMAKE_MODULE_PATH=${OPENVDB_PREFIX}/lib/cmake/OpenVDB" \
+CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+"${FVDB_ENV}/bin/pip" install "${VDBFUSION_SRC}"
+
+echo "=== Verifying import ==="
+"${FVDB_ENV}/bin/python" -c "
+import vdbfusion, numpy as np
+v = vdbfusion.VDBVolume(voxel_size=0.2, sdf_trunc=0.6, space_carving=True)
+v.integrate(np.random.randn(1000, 3).astype(np.float64), np.zeros(3))
+verts, tris = v.extract_triangle_mesh(min_weight=0.1)
+print(f'OK -- VDBFusion integrates and meshes ({verts.shape[0]} verts, {tris.shape[0]} tris).')
+"
+echo "=== Done ==="

--- a/tests/benchmarks/tsdf_fusion/cross_library/kitti_loader.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/kitti_loader.py
@@ -1,0 +1,227 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Loader for the KITTI Odometry dataset.
+
+KITTI Odometry (Geiger et al., 2012) provides 22 Velodyne HDL-64 sweeps
+through Karlsruhe with ground-truth cam0 poses for sequences 00-10
+(11-21 are the test set with no published poses). The on-disk layout
+matches `mai_city_loader.py`'s with two differences:
+
+    <root>/dataset/sequences/XX/velodyne/NNNNNN.bin   float32[N, 4]: (x, y, z, reflectance)
+    <root>/dataset/sequences/XX/calib.txt              P0..P3 (camera intrinsics) + Tr (velo->cam0)
+    <root>/dataset/sequences/XX/times.txt              per-frame timestamps
+    <root>/dataset/poses/XX.txt                        cam0 poses (00-10 only)
+
+The two differences vs Mai City:
+
+1. **Filename width is 6 digits** (`000000.bin`), not 5.
+2. **Poses are in cam0 frame, points are in Velodyne frame.** We must
+   compose `T_velo_world = T_cam_world @ Tr` to put each sweep into
+   the same world frame as the trajectory. Mai City's `Tr` is identity
+   so its loader skips this step; KITTI's `Tr` is a meaningful 0.3 m
+   translation + ~90 degree rotation between sensors.
+
+The standard SLAM evaluation triples are 00 (4541 frames, urban),
+02 (4661 frames, residential), 05 (2761 frames, suburban). Sequences
+01 (highway), 06-10 are smaller/specialized.
+
+Download: see `download_kitti.py` (parallel resumable downloader).
+Extract:  unzip data_odometry_velodyne.zip + data_odometry_calib.zip
+          + data_odometry_poses.zip into the same root; the three
+          archives merge into `<root>/dataset/`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+
+@dataclass
+class KittiScene:
+    """Single KITTI Odometry sequence parsed and ready for TSDF fusion.
+
+    Mirrors `MaiCityScene` exactly, so all the existing benchmark
+    drivers can swap one for the other.
+    """
+
+    points_per_frame: List[np.ndarray]      # length n_frames, each [N_i, 3] fp32 world-frame
+    sensor_origins: np.ndarray              # [n_frames, 3] fp32 world-frame Velodyne positions
+    cam_to_world: np.ndarray                # [n_frames, 4, 4] fp32 Velodyne->world poses
+                                            # (NOT cam0->world; named for compatibility
+                                            # with the bench drivers that expect this attr)
+
+    @property
+    def n_frames(self) -> int:
+        return len(self.points_per_frame)
+
+    @property
+    def total_points(self) -> int:
+        return sum(p.shape[0] for p in self.points_per_frame)
+
+
+def _read_kitti_poses(path: str) -> np.ndarray:
+    """Read a KITTI-format pose file (12 floats per line = row-major 3x4
+    matrix). Returns [K, 4, 4] float32 with the bottom row [0,0,0,1]."""
+    raw = np.loadtxt(path, dtype=np.float32)
+    if raw.ndim == 1:
+        raw = raw.reshape(1, -1)
+    if raw.shape[1] != 12:
+        raise ValueError(
+            f"expected 12 floats per line in {path!r}, got {raw.shape[1]}")
+    poses = np.eye(4, dtype=np.float32)[None].repeat(raw.shape[0], axis=0)
+    poses[:, :3, :] = raw.reshape(-1, 3, 4)
+    return poses
+
+
+def _read_kitti_calib_tr(calib_path: str) -> np.ndarray:
+    """Read the `Tr:` line of a KITTI calib.txt and return a 4x4 float32
+    homogeneous transform from Velodyne to cam0 frame.
+
+    The line has 12 floats (row-major 3x4); we append [0,0,0,1].
+    """
+    with open(calib_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line.startswith("Tr"):
+                continue
+            # `Tr: <12 floats>` — split off the colon then parse.
+            after_colon = line.split(":", 1)[1].strip()
+            vals = np.fromstring(after_colon, dtype=np.float32, sep=" ")
+            if vals.size != 12:
+                raise ValueError(
+                    f"calib Tr in {calib_path!r}: expected 12 floats, got {vals.size}")
+            T = np.eye(4, dtype=np.float32)
+            T[:3, :] = vals.reshape(3, 4)
+            return T
+    raise ValueError(f"no `Tr:` line found in {calib_path!r}")
+
+
+def _read_velodyne_bin(path: str, max_points: Optional[int] = None) -> np.ndarray:
+    """Read a KITTI-format Velodyne `.bin` file. Returns [N, 3] float32
+    (intensity dropped). If `max_points` is set, deterministic stride."""
+    raw = np.fromfile(path, dtype=np.float32).reshape(-1, 4)
+    pts = raw[:, :3].copy()
+    if max_points is not None and pts.shape[0] > max_points:
+        step = pts.shape[0] // max_points
+        pts = pts[::step][:max_points].copy()
+    return pts
+
+
+def load_kitti_scene(
+    root_dir: str,
+    sequence: str = "00",
+    *,
+    max_frames: Optional[int] = None,
+    stride: int = 1,
+    max_points_per_frame: Optional[int] = None,
+) -> KittiScene:
+    """Load a KITTI Odometry sequence and return points in WORLD frame.
+
+    Arguments
+    ---------
+    root_dir:
+        Path to the extracted KITTI Odometry root, e.g.
+        `.../data/KITTI`. Must contain `dataset/sequences/<seq>/`
+        and `dataset/poses/<seq>.txt`.
+    sequence:
+        Sequence name, "00".."10" (training only; 11-21 lack poses).
+    max_frames, stride, max_points_per_frame:
+        Same semantics as `load_mai_city_scene`.
+
+    Returns
+    -------
+    KittiScene with points in world frame (Velodyne sensor origins
+    derived from `T_cam_world @ Tr`).
+    """
+    seq_dir = os.path.join(root_dir, "dataset", "sequences", sequence, "velodyne")
+    calib_path = os.path.join(root_dir, "dataset", "sequences", sequence, "calib.txt")
+    poses_path = os.path.join(root_dir, "dataset", "poses", f"{sequence}.txt")
+    if not os.path.isdir(seq_dir):
+        raise FileNotFoundError(
+            f"KITTI sequence velodyne dir missing: {seq_dir!r}\n"
+            f"Extract data_odometry_velodyne.zip into {root_dir!r} so that "
+            f"{root_dir!r}/dataset/sequences/{sequence}/velodyne/ exists.")
+    if not os.path.isfile(calib_path):
+        raise FileNotFoundError(
+            f"KITTI calib missing: {calib_path!r}\n"
+            f"Extract data_odometry_calib.zip into the same root.")
+    if not os.path.isfile(poses_path):
+        raise FileNotFoundError(
+            f"KITTI poses missing: {poses_path!r}\n"
+            f"Sequences 11-21 are the test set with no published poses; "
+            f"only 00-10 are usable for benchmarking. Extract "
+            f"data_odometry_poses.zip into the same root.")
+
+    bin_files = sorted(
+        f for f in os.listdir(seq_dir)
+        if f.endswith(".bin") and f[:-4].isdigit())
+    if not bin_files:
+        raise FileNotFoundError(f"No `.bin` velodyne files found in {seq_dir!r}")
+
+    Tr = _read_kitti_calib_tr(calib_path)              # [4, 4] velo->cam0
+    cam_poses = _read_kitti_poses(poses_path)          # [N, 4, 4] cam0->world
+
+    if cam_poses.shape[0] != len(bin_files):
+        # Some KITTI mirrors include a final trailing pose; trim if so.
+        if cam_poses.shape[0] == len(bin_files) + 1:
+            cam_poses = cam_poses[:-1]
+        else:
+            raise ValueError(
+                f"frame/pose count mismatch in seq {sequence!r}: "
+                f"{len(bin_files)} velodyne files vs {cam_poses.shape[0]} poses")
+
+    keep_idxs = list(range(0, len(bin_files), stride))
+    if max_frames is not None:
+        keep_idxs = keep_idxs[:max_frames]
+
+    points_per_frame: List[np.ndarray] = []
+    sensor_origins = np.empty((len(keep_idxs), 3), dtype=np.float32)
+    velo_to_world = np.empty((len(keep_idxs), 4, 4), dtype=np.float32)
+
+    for out_i, frame_i in enumerate(keep_idxs):
+        pts_velo = _read_velodyne_bin(
+            os.path.join(seq_dir, bin_files[frame_i]),
+            max_points=max_points_per_frame)
+
+        # Compose Velodyne -> world transform:
+        #   p_world = T_cam_world @ Tr @ p_velo
+        T_v2w = cam_poses[frame_i] @ Tr     # [4, 4]
+        R = T_v2w[:3, :3]
+        t = T_v2w[:3, 3]
+        pts_world = (pts_velo @ R.T) + t[None, :]
+        points_per_frame.append(pts_world.astype(np.float32, copy=False))
+        sensor_origins[out_i] = t
+        velo_to_world[out_i] = T_v2w
+
+    return KittiScene(
+        points_per_frame=points_per_frame,
+        sensor_origins=sensor_origins,
+        cam_to_world=velo_to_world,    # named for bench-driver compat
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument("root_dir", help="path to extracted KITTI/ (the one with dataset/ inside)")
+    p.add_argument("--sequence", default="00")
+    p.add_argument("--max-frames", type=int, default=None)
+    p.add_argument("--stride", type=int, default=1)
+    p.add_argument("--max-points-per-frame", type=int, default=None)
+    args = p.parse_args()
+    scene = load_kitti_scene(
+        args.root_dir, sequence=args.sequence,
+        max_frames=args.max_frames, stride=args.stride,
+        max_points_per_frame=args.max_points_per_frame)
+    print(f"sequence={args.sequence!r}")
+    print(f"  n_frames: {scene.n_frames}")
+    print(f"  total points: {scene.total_points:,}")
+    print(f"  avg points/frame: {scene.total_points / scene.n_frames:,.0f}")
+    print(f"  trajectory extent: {np.ptp(scene.sensor_origins, axis=0)} m")
+    print(f"  trajectory length (approx): "
+          f"{np.linalg.norm(np.diff(scene.sensor_origins, axis=0), axis=1).sum():.1f} m")

--- a/tests/benchmarks/tsdf_fusion/cross_library/mai_city_loader.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/mai_city_loader.py
@@ -1,0 +1,211 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Loader for the Mai City synthetic LiDAR dataset.
+
+Mai City (StachnissLab, Uni Bonn) provides synthetic Velodyne HDL-64
+sweeps generated from a 3D CAD model of an urban block. The dataset
+uses the KITTI odometry file format:
+
+    <root>/bin/sequences/XX/velodyne/NNNNN.bin    float32[N, 4]: (x, y, z, reflectance)
+    <root>/bin/sequences/XX/times.txt             per-frame timestamps
+    <root>/bin/sequences/XX/calib.txt             P0..P3, Tr calibration (identity for Mai City)
+    <root>/bin/poses/XX.txt                        per-frame cam0 pose as 3x4 flattened
+
+Three sequences are provided:
+    00 — 700 m drive at 10 m/s, 700 frames (main benchmark sequence)
+    01 — 100 m block loop, Velodyne HDL-64
+    02 — 100 m block loop, 320-beam Velodyne-like sensor
+
+This is the LiDAR complement to `seven_scenes_loader.py` and
+`replica_loader.py`. It matches the same `Scene`-style dataclass
+interface that the TSDF benchmark drivers consume.
+
+Download instructions:
+    wget https://www.ipb.uni-bonn.de/html/projects/mai_city/mai_city.tar.gz
+    tar -xf mai_city.tar.gz  # creates `mai_city/` with bin/, ply/, bags/
+    # we only need bin/ — ply/ is the same data in a slower format and
+    # bags/ is for ROS users; safe to delete both after extraction.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+
+@dataclass
+class MaiCityScene:
+    """Single Mai City sequence parsed and ready for TSDF fusion."""
+
+    # Per-frame data — LiDAR workloads have variable points-per-sweep,
+    # so we don't stack into a single [N_frames, N_points, 3] tensor.
+    # Instead we keep a list of [N_i, 3] fp32 point clouds.
+    points_per_frame: List[np.ndarray]      # length = n_frames, each [N_i, 3] fp32 world-frame
+    sensor_origins: np.ndarray               # [n_frames, 3] fp32 world-frame sensor translations
+    cam_to_world: np.ndarray                 # [n_frames, 4, 4] fp32 full pose (handy for
+                                             # users who want orientation too)
+
+    @property
+    def n_frames(self) -> int:
+        return len(self.points_per_frame)
+
+    @property
+    def total_points(self) -> int:
+        return sum(p.shape[0] for p in self.points_per_frame)
+
+
+def _read_kitti_poses(path: str) -> np.ndarray:
+    """Read a KITTI-format pose file.
+
+    Each non-empty line is 12 floats = a row-major 3x4 matrix. Returns
+    a [K, 4, 4] float32 array with the bottom row [0, 0, 0, 1] appended.
+    """
+    raw = np.loadtxt(path, dtype=np.float32)
+    if raw.ndim == 1:
+        raw = raw.reshape(1, -1)
+    if raw.shape[1] != 12:
+        raise ValueError(
+            f"expected 12 floats per line in {path!r}, got {raw.shape[1]}"
+        )
+    poses = np.eye(4, dtype=np.float32)[None].repeat(raw.shape[0], axis=0)
+    poses[:, :3, :] = raw.reshape(-1, 3, 4)
+    return poses
+
+
+def _read_velodyne_bin(path: str, max_points: Optional[int] = None) -> np.ndarray:
+    """Read a KITTI-format Velodyne `.bin` file.
+
+    Format: consecutive float32 quadruples (x, y, z, intensity). Returns
+    an [N, 3] float32 point cloud (intensity dropped). If `max_points`
+    is set, randomly subsample the cloud (used for throughput sanity
+    checks; real benches use all points).
+    """
+    raw = np.fromfile(path, dtype=np.float32).reshape(-1, 4)
+    pts = raw[:, :3].copy()  # drop intensity; .copy() so downstream
+                              # `.astype(torch.float32)` doesn't warn
+                              # about non-contiguous stride
+    if max_points is not None and pts.shape[0] > max_points:
+        # Deterministic stride so reruns produce identical benchmarks.
+        step = pts.shape[0] // max_points
+        pts = pts[::step][:max_points].copy()
+    return pts
+
+
+def load_mai_city_scene(
+    root_dir: str,
+    sequence: str = "00",
+    *,
+    max_frames: Optional[int] = None,
+    stride: int = 1,
+    max_points_per_frame: Optional[int] = None,
+) -> MaiCityScene:
+    """Load a Mai City sequence and return points in WORLD frame.
+
+    Arguments
+    ---------
+    root_dir:
+        Path to the extracted Mai City root, e.g. `.../data/mai_city/mai_city`.
+        Must contain `bin/sequences/<sequence>/velodyne/` and
+        `bin/poses/<sequence>.txt`.
+    sequence:
+        Sequence name ("00", "01", "02"). Default "00" (the 700 m drive).
+    max_frames:
+        Cap on frames after stride.
+    stride:
+        Keep every `stride`-th frame. `stride=1` loads all 700 frames
+        of sequence 00.
+    max_points_per_frame:
+        If set, deterministically stride-subsample each sweep to this
+        many points. Useful for quick smoke tests at ~10 K pts/sweep;
+        leave `None` for real benches (uses all ~70 K points/sweep).
+
+    Returns
+    -------
+    MaiCityScene:
+        `points_per_frame[i]` is an [N_i, 3] float32 world-frame point
+        cloud for frame `i`. `sensor_origins[i]` is the [3] float32
+        world-frame sensor position (= `cam_to_world[i, :3, 3]`).
+        `cam_to_world[i]` is the full 4x4 pose.
+    """
+    seq_dir = os.path.join(root_dir, "bin", "sequences", sequence, "velodyne")
+    poses_path = os.path.join(root_dir, "bin", "poses", f"{sequence}.txt")
+    if not os.path.isdir(seq_dir):
+        raise FileNotFoundError(
+            f"Mai City sequence velodyne dir missing: {seq_dir!r}\n"
+            f"Extract the dataset so that {root_dir!r}/bin/sequences/{sequence}/"
+            f" exists. See this file's docstring for download instructions."
+        )
+    if not os.path.isfile(poses_path):
+        raise FileNotFoundError(f"Mai City poses missing: {poses_path!r}")
+
+    # KITTI format: 5-digit numeric filenames (00000.bin, 00001.bin, ...).
+    bin_files = sorted(
+        f for f in os.listdir(seq_dir)
+        if f.endswith(".bin") and f[:-4].isdigit()
+    )
+    if not bin_files:
+        raise FileNotFoundError(
+            f"No `.bin` velodyne files found in {seq_dir!r}"
+        )
+
+    # Read all poses up front. The poses file has (N_frames + 1) lines
+    # for some sequences (last line is final state past last sweep); we
+    # just use the first N_frames matching the velodyne files.
+    all_poses = _read_kitti_poses(poses_path)
+
+    # Select frames per stride + cap.
+    keep_idxs = list(range(0, len(bin_files), stride))
+    if max_frames is not None:
+        keep_idxs = keep_idxs[:max_frames]
+
+    points_per_frame: List[np.ndarray] = []
+    sensor_origins = np.empty((len(keep_idxs), 3), dtype=np.float32)
+    cam_to_world = np.empty((len(keep_idxs), 4, 4), dtype=np.float32)
+    for out_i, frame_i in enumerate(keep_idxs):
+        # Load LiDAR points in SENSOR frame.
+        pts_sensor = _read_velodyne_bin(
+            os.path.join(seq_dir, bin_files[frame_i]),
+            max_points=max_points_per_frame,
+        )
+        # Transform to world via pose. Homogeneous multiplication:
+        # p_world = R * p_sensor + t
+        pose = all_poses[frame_i]
+        R = pose[:3, :3]
+        t = pose[:3, 3]
+        pts_world = (pts_sensor @ R.T) + t[None, :]
+        points_per_frame.append(pts_world.astype(np.float32, copy=False))
+        sensor_origins[out_i] = t
+        cam_to_world[out_i] = pose
+
+    return MaiCityScene(
+        points_per_frame=points_per_frame,
+        sensor_origins=sensor_origins,
+        cam_to_world=cam_to_world,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument("root_dir", help="path to extracted mai_city/ (the one with bin/ inside)")
+    p.add_argument("--sequence", default="00")
+    p.add_argument("--max-frames", type=int, default=None)
+    p.add_argument("--stride", type=int, default=1)
+    p.add_argument("--max-points-per-frame", type=int, default=None)
+    args = p.parse_args()
+    scene = load_mai_city_scene(
+        args.root_dir, sequence=args.sequence,
+        max_frames=args.max_frames, stride=args.stride,
+        max_points_per_frame=args.max_points_per_frame,
+    )
+    print(f"sequence={args.sequence!r}")
+    print(f"  n_frames: {scene.n_frames}")
+    print(f"  total points: {scene.total_points:,}")
+    print(f"  avg points/frame: {scene.total_points / scene.n_frames:,.0f}")
+    print(f"  trajectory extent: {np.ptp(scene.sensor_origins, axis=0)} m")
+    print(f"  trajectory length (approx): "
+          f"{np.linalg.norm(np.diff(scene.sensor_origins, axis=0), axis=1).sum():.1f} m")

--- a/tests/benchmarks/tsdf_fusion/cross_library/nvblox_runner.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/nvblox_runner.py
@@ -1,0 +1,716 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Standalone nvblox TSDF-fusion runner for cross-library benchmarks.
+
+Designed to be invoked as a subprocess from a benchmark driver that
+runs in a different conda env. This script runs in the `nvblox`
+conda env (torch==2.6.0+cu124, CUDA toolkit 12.4, the nvblox_torch
+wheel we built from source in install_nvblox.sh). It reads a
+dataset-specific JSON spec from stdin or a file, integrates the
+sweeps/frames via nvblox's `Mapper`, and writes the timing + voxel
+stats JSON to stdout or an output file.
+
+Supported workloads:
+  - LiDAR sweeps (Mai City, KITTI): the spec provides a list of
+    3D point clouds (in sensor or world frame; we always send
+    sensor-frame to nvblox and pass the world pose alongside) plus
+    HDL-64-style LiDAR intrinsics (num_azimuth, num_elevation,
+    vertical_fov_rad). The runner reprojects each sweep to a
+    (num_elevation, num_azimuth) depth image and hands it to
+    `Mapper.add_depth_frame`. Nvblox's LiDAR integrator expects
+    exactly this representation.
+  - Depth frames (Replica, 7-Scenes): the spec provides depth
+    image paths + camera intrinsics. The runner loads each depth
+    image and hands it to `Mapper.add_depth_frame`.
+
+Spec format (JSON):
+    {
+        "workload": "lidar" | "depth",
+        "voxel_size_m": 0.2,
+        "truncation_distance_m": 0.6,
+        # LiDAR only:
+        "lidar_num_azimuth": 1800,
+        "lidar_num_elevation": 64,
+        "lidar_vertical_fov_rad": 0.4712,  # ~27 deg for HDL-64
+        "lidar_min_valid_range_m": 1.0,
+        "lidar_sweeps_npz": "/path/to/mai_city_sweeps.npz",  # holds (points_per_frame, sensor_origins, cam_to_world)
+        # Depth only:
+        "depth_image_paths": [...],
+        "depth_intrinsics": {"fu": ..., "fv": ..., "cu": ..., "cv": ..., "width": ..., "height": ...},
+        "depth_poses_npy": "/path/to/poses_Nx4x4.npy",
+        "depth_scale": 1000.0,  # for uint16 mm depth
+        "depth_max_m": 8.0,
+        "warmup_frames": 2,
+    }
+
+Output (JSON to stdout or `--output`):
+    {
+        "ok": true,
+        "ms_per_f": 123.45,
+        "wall_s": 78.9,
+        "peak_rss_gb": 3.14,
+        "n_frames": 700,
+        "n_voxels": 123456,      # nvblox's activeBlockCount * 512 (approximate)
+        "n_mesh_verts": 10000,
+        "n_mesh_tris": 20000,
+        "voxel_size_m": 0.2,
+        "failure": null,
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import math
+import os
+import resource
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+from nvblox_torch.mapper import Mapper
+from nvblox_torch.mapper_params import MapperParams
+from nvblox_torch.projective_integrator_types import ProjectiveIntegratorType
+from nvblox_torch.sensor import Sensor
+
+
+def _points_to_spherical_range_image(
+    points_sensor: np.ndarray,
+    num_azimuth: int,
+    num_elevation: int,
+    vertical_fov_rad: float,
+) -> np.ndarray:
+    """Reproject an [N, 3] sensor-frame point cloud to an
+    (H, W) = (num_elevation, num_azimuth) range image matching
+    nvblox's `Sensor.from_lidar` parameterisation.
+
+    Reference: nvblox's internal `Lidar::project` uses
+        azimuth = atan2(y, x)                              # (-pi, pi]
+        elevation = atan2(z, sqrt(x**2 + y**2))            # (-v_fov/2, +v_fov/2)
+        u = (azimuth + pi) / (2*pi) * num_azimuth
+        v = (elevation + v_fov/2) / v_fov * num_elevation
+
+    Points outside the vertical FoV or mapped to the same pixel as a
+    closer point are discarded (kept: min range per pixel).
+
+    Returns an fp32 (num_elevation, num_azimuth) array; pixels with
+    no hit are 0.0 (nvblox skips depth==0 automatically).
+    """
+    if points_sensor.shape[0] == 0:
+        return np.zeros((num_elevation, num_azimuth), dtype=np.float32)
+
+    x = points_sensor[:, 0]
+    y = points_sensor[:, 1]
+    z = points_sensor[:, 2]
+    radial_xy = np.sqrt(x * x + y * y)
+    ranges = np.sqrt(radial_xy * radial_xy + z * z)
+
+    # Filter zero-range and out-of-FoV points. Keep epsilon for
+    # numerical stability at the pole (radial_xy == 0 would NaN
+    # atan2(z, 0) to +/-pi/2 which is fine but let's be defensive).
+    valid = (ranges > 1e-4) & (radial_xy > 1e-6)
+    x, y, z, radial_xy, ranges = x[valid], y[valid], z[valid], radial_xy[valid], ranges[valid]
+
+    azimuth = np.arctan2(y, x)                   # (-pi, pi]
+    elevation = np.arctan2(z, radial_xy)         # roughly (-v_fov/2, +v_fov/2) for LiDAR
+
+    # Clamp into the valid range the sensor accepts.
+    el_min = -vertical_fov_rad / 2.0
+    el_max = +vertical_fov_rad / 2.0
+    in_fov = (elevation >= el_min) & (elevation < el_max)
+    azimuth, elevation, ranges = azimuth[in_fov], elevation[in_fov], ranges[in_fov]
+
+    # Map to pixel indices.
+    u = ((azimuth + math.pi) / (2.0 * math.pi) * num_azimuth).astype(np.int64)
+    v = ((elevation - el_min) / vertical_fov_rad * num_elevation).astype(np.int64)
+    # Clip to valid range (guards against +pi azimuth rounding to num_azimuth).
+    u = np.clip(u, 0, num_azimuth - 1)
+    v = np.clip(v, 0, num_elevation - 1)
+
+    # Keep min range per pixel. Vectorised via numpy: combine (v, u)
+    # into a single flat index, then sort by range ascending and use
+    # np.unique on the flat index with `return_index=True` to pick
+    # the first (smallest-range) entry per pixel.
+    flat_idx = v * num_azimuth + u
+    order = np.argsort(ranges)              # ascending
+    flat_sorted = flat_idx[order]
+    range_sorted = ranges[order]
+    _, first_idx = np.unique(flat_sorted, return_index=True)
+    pick_flat = flat_sorted[first_idx]
+    pick_range = range_sorted[first_idx]
+
+    depth = np.zeros(num_elevation * num_azimuth, dtype=np.float32)
+    depth[pick_flat] = pick_range.astype(np.float32)
+    return depth.reshape(num_elevation, num_azimuth)
+
+
+def _world_points_to_sensor_frame(
+    points_world: np.ndarray,
+    sensor_to_world: np.ndarray,
+) -> np.ndarray:
+    """Invert the sensor pose to bring world-frame points back into
+    the sensor-local frame nvblox expects.
+    `sensor_to_world` is the 4x4 camera-to-world transform.
+    """
+    # p_s = R_ws^T (p_w - t_ws)
+    R = sensor_to_world[:3, :3]
+    t = sensor_to_world[:3, 3]
+    return (points_world - t[None, :]) @ R
+
+
+def run_lidar(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Run nvblox LiDAR TSDF on a Mai City-style sweep sequence.
+
+    The npz at `lidar_sweeps_npz` is produced by `nvblox_bench_setup_mai_city`
+    in the driver -- it's a dict with:
+      - `points_per_frame_concat`: [total_points, 3] fp32, all frames concatenated
+      - `points_per_frame_offsets`: [n_frames + 1] int64 (csr-style offsets)
+      - `sensor_origins`: [n_frames, 3] fp32
+      - `cam_to_world`: [n_frames, 4, 4] fp32
+    This indirection is much faster than JSON-encoding 700 x 100k points.
+    """
+    voxel_size_m = float(spec["voxel_size_m"])
+    trunc_m = float(spec["truncation_distance_m"])
+    num_azimuth = int(spec["lidar_num_azimuth"])
+    num_elevation = int(spec["lidar_num_elevation"])
+    vertical_fov_rad = float(spec["lidar_vertical_fov_rad"])
+    min_valid_range_m = float(spec.get("lidar_min_valid_range_m", 1.0))
+    warmup_frames = int(spec.get("warmup_frames", 2))
+
+    data = np.load(spec["lidar_sweeps_npz"])
+    pts_concat = data["points_per_frame_concat"]          # [N_total, 3]
+    pts_offsets = data["points_per_frame_offsets"]        # [n_frames + 1]
+    sensor_origins = data["sensor_origins"]               # [n_frames, 3]
+    cam_to_world_np = data["cam_to_world"]                # [n_frames, 4, 4]
+    n_frames = len(pts_offsets) - 1
+
+    # Build the nvblox mapper up-front.
+    params = MapperParams()
+    # Set truncation distance if the API exposes it. nvblox's default is
+    # 4 * voxel_size which may or may not match our desired 3x multiplier;
+    # configure explicitly so the comparison is fair.
+    try:
+        # The param name is `truncation_distance_vox` (in voxels) in
+        # recent nvblox. Compute ratio.
+        vox_ratio = trunc_m / voxel_size_m
+        params.tsdf_integrator_truncation_distance_vox = float(vox_ratio)
+    except AttributeError:
+        # Older API -- skip and accept default.
+        pass
+
+    mapper = Mapper(
+        voxel_sizes_m=[voxel_size_m],
+        integrator_types=[ProjectiveIntegratorType.TSDF],
+        mapper_parameters=params,
+    )
+
+    sensor = Sensor.from_lidar(
+        num_azimuth_divisions=num_azimuth,
+        num_elevation_divisions=num_elevation,
+        vertical_fov_rad=vertical_fov_rad,
+        min_valid_range_m=min_valid_range_m,
+    )
+
+    # Warmup on the first two frames to pre-allocate nvblox's block pool.
+    def one_frame(i: int) -> None:
+        start, end = int(pts_offsets[i]), int(pts_offsets[i + 1])
+        pts_w = pts_concat[start:end]
+        pose = cam_to_world_np[i]
+        pts_s = _world_points_to_sensor_frame(pts_w, pose)
+        depth_img = _points_to_spherical_range_image(
+            pts_s, num_azimuth, num_elevation, vertical_fov_rad)
+        depth_t = torch.from_numpy(depth_img).cuda()
+        pose_t = torch.from_numpy(pose).float()
+        mapper.add_depth_frame(
+            depth_frame=depth_t,
+            t_w_c=pose_t,
+            sensor=sensor,
+            mapper_id=0,
+        )
+
+    for i in range(min(warmup_frames, n_frames)):
+        one_frame(i)
+    mapper.clear(mapper_id=0)
+    torch.cuda.synchronize()
+    gc.collect()
+
+    base_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for i in range(n_frames):
+        one_frame(i)
+    torch.cuda.synchronize()
+    wall_s = time.perf_counter() - t0
+    ms_per_f = wall_s * 1000 / n_frames
+
+    peak_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    # Voxel count: use the TSDF layer's active-block count * 512 as a
+    # conservative upper bound on active voxels. nvblox stores an 8^3
+    # block as a unit; voxels inside a block with zero weight still
+    # "count" toward the allocation, so this inflates vs fvdb's
+    # strict surface-only narrow-band number. We report it but call
+    # out the caveat in the bench driver.
+    tsdf_view = mapper.tsdf_layer_view(mapper_id=0)
+    n_blocks = None
+    try:
+        n_blocks = int(tsdf_view.num_allocated_blocks())
+    except Exception:
+        try:
+            n_blocks = int(tsdf_view.num_blocks())
+        except Exception:
+            n_blocks = None
+    # nvblox uses 8^3 voxels per block by default; let the layer
+    # report the actual block-dim-in-voxels so we do the right math
+    # even if someone changes the block size in the future.
+    block_dim_vox = 8
+    try:
+        block_dim_vox = int(tsdf_view.block_dim_in_voxels())
+    except Exception:
+        pass
+    n_voxels_upper = (
+        n_blocks * (block_dim_vox ** 3) if n_blocks is not None else -1)
+
+    # Approximate GPU-mem peak. `num_allocated_bytes()` reports the
+    # live size of the TSDF layer only; we want the total nvblox
+    # allocator footprint. Torch's cuda memory API works in-process
+    # even though nvblox uses its own allocator pool, because nvblox
+    # goes through the same CUDA driver -- `mem_get_info()` sees the
+    # aggregate used memory.
+    gpu_used_gb = -1.0
+    try:
+        free_b, total_b = torch.cuda.mem_get_info()
+        gpu_used_gb = (total_b - free_b) / 1e9
+    except Exception:
+        pass
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    # Mesh extraction for quality reference.
+    n_mesh_verts = n_mesh_tris = -1
+    try:
+        mapper.update_color_mesh(mapper_id=0)
+        mesh = mapper.get_color_mesh(mapper_id=0)
+        n_mesh_verts = int(mesh.vertices.shape[0])
+        n_mesh_tris = int(mesh.triangles.shape[0])
+    except Exception:
+        pass
+
+    # Optional: time nvblox's ESDF-from-TSDF update step.
+    #
+    # Important caveat about `Mapper.update_esdf`: nvblox's ESDF is
+    # INCREMENTAL BY DEFAULT. The first call after a new TSDF state
+    # does the real work (building the ESDF across all dirty blocks);
+    # subsequent calls on the same unchanged TSDF state hit an
+    # internal "no dirty blocks" fast-path and take ~0.05 ms (just
+    # the dirty-block check). So we time two things separately:
+    #
+    #   - `esdf_cold_ms`: the very first `update_esdf` call after
+    #     TSDF fusion. This is the cost of "build the whole ESDF
+    #     from scratch" — directly comparable to fvdb's stateless
+    #     `compute_esdf`.
+    #   - `esdf_warm_ms_*`: subsequent calls on the same TSDF state.
+    #     These are the dirty-block-check no-op cost — directly
+    #     comparable to fvdb's `compute_esdf_incremental` on a static
+    #     scene (idempotent warm-start).
+    esdf_cold_ms = -1.0
+    esdf_warm_ms_min = -1.0
+    esdf_warm_ms_median = -1.0
+    esdf_warm_calls  = int(spec.get("esdf_warm_calls", 5))
+    if bool(spec.get("with_esdf", False)):
+        try:
+            # Cold call: the only call where nvblox actually builds
+            # the ESDF across all blocks. This is the cost we want
+            # to compare against fvdb's one-shot `compute_esdf`.
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            mapper.update_esdf(mapper_id=0)
+            torch.cuda.synchronize()
+            esdf_cold_ms = (time.perf_counter() - t0) * 1000.0
+
+            # Warm calls: same TSDF state, no dirty blocks. Should
+            # all be near-zero because nvblox short-circuits on the
+            # dirty-block check.
+            warm_samples = []
+            for _ in range(esdf_warm_calls):
+                torch.cuda.synchronize()
+                t0 = time.perf_counter()
+                mapper.update_esdf(mapper_id=0)
+                torch.cuda.synchronize()
+                warm_samples.append((time.perf_counter() - t0) * 1000.0)
+            if warm_samples:
+                warm_samples.sort()
+                esdf_warm_ms_min = warm_samples[0]
+                esdf_warm_ms_median = warm_samples[len(warm_samples) // 2]
+        except Exception:
+            # ESDF update may not be available on every mapper config.
+            esdf_cold_ms = -2.0
+            esdf_warm_ms_min = -2.0
+            esdf_warm_ms_median = -2.0
+
+    return {
+        "ok": True,
+        "ms_per_f": ms_per_f,
+        "wall_s": wall_s,
+        "peak_rss_gb": peak_rss_kb / 1e6,
+        "peak_rss_delta_gb": max(0.0, (peak_rss_kb - base_rss_kb) / 1e6),
+        "gpu_used_gb": gpu_used_gb,
+        "peak_torch_gb": peak_torch_gb,
+        "n_frames": n_frames,
+        "n_voxels": n_voxels_upper,
+        "n_blocks": n_blocks if n_blocks is not None else -1,
+        "n_mesh_verts": n_mesh_verts,
+        "n_mesh_tris": n_mesh_tris,
+        "voxel_size_m": voxel_size_m,
+        "esdf_cold_ms": esdf_cold_ms,
+        "esdf_warm_ms_min": esdf_warm_ms_min,
+        "esdf_warm_ms_median": esdf_warm_ms_median,
+        "esdf_warm_calls": esdf_warm_calls,
+    }
+
+
+def run_lidar_occupancy(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Run nvblox LiDAR occupancy (log-odds) integration on a Mai
+    City-style sweep sequence. Simpler than `run_lidar` (which does
+    TSDF + optional ESDF + optional mesh) — occupancy is a single
+    integrator type with a single per-voxel quantity, so we just:
+
+      1. Build a Mapper with ProjectiveIntegratorType.OCCUPANCY.
+      2. Feed each sweep through add_depth_frame (same spherical-
+         range-image proxy as run_lidar).
+      3. Report per-frame wall-clock, final block count, GPU memory.
+
+    No ESDF, no mesh. For the paper's scale-ceiling comparison
+    against fvdb's `integrate_occupancy_from_points_frames`.
+    """
+    voxel_size_m = float(spec["voxel_size_m"])
+    trunc_m = float(spec["truncation_distance_m"])
+    num_azimuth = int(spec["lidar_num_azimuth"])
+    num_elevation = int(spec["lidar_num_elevation"])
+    vertical_fov_rad = float(spec["lidar_vertical_fov_rad"])
+    min_valid_range_m = float(spec.get("lidar_min_valid_range_m", 1.0))
+    warmup_frames = int(spec.get("warmup_frames", 2))
+
+    data = np.load(spec["lidar_sweeps_npz"])
+    pts_concat = data["points_per_frame_concat"]
+    pts_offsets = data["points_per_frame_offsets"]
+    cam_to_world_np = data["cam_to_world"]
+    n_frames = len(pts_offsets) - 1
+
+    params = MapperParams()
+    # nvblox's occupancy integrator has its own truncation param
+    # (distinct from the TSDF one). Try the common spellings;
+    # fall back to default if neither exists on this build.
+    for attr in (
+        "occupancy_integrator_truncation_distance_vox",
+        "occupancy_integrator_max_integration_distance_m",
+    ):
+        try:
+            if "vox" in attr:
+                setattr(params, attr, float(trunc_m / voxel_size_m))
+            # max_integration_distance is different semantic; skip
+        except AttributeError:
+            pass
+
+    mapper = Mapper(
+        voxel_sizes_m=[voxel_size_m],
+        integrator_types=[ProjectiveIntegratorType.OCCUPANCY],
+        mapper_parameters=params,
+    )
+
+    sensor = Sensor.from_lidar(
+        num_azimuth_divisions=num_azimuth,
+        num_elevation_divisions=num_elevation,
+        vertical_fov_rad=vertical_fov_rad,
+        min_valid_range_m=min_valid_range_m,
+    )
+
+    def one_frame(i: int) -> None:
+        start, end = int(pts_offsets[i]), int(pts_offsets[i + 1])
+        pts_w = pts_concat[start:end]
+        pose = cam_to_world_np[i]
+        pts_s = _world_points_to_sensor_frame(pts_w, pose)
+        depth_img = _points_to_spherical_range_image(
+            pts_s, num_azimuth, num_elevation, vertical_fov_rad)
+        depth_t = torch.from_numpy(depth_img).cuda()
+        pose_t = torch.from_numpy(pose).float()
+        mapper.add_depth_frame(
+            depth_frame=depth_t, t_w_c=pose_t,
+            sensor=sensor, mapper_id=0,
+        )
+
+    for i in range(min(warmup_frames, n_frames)):
+        one_frame(i)
+    mapper.clear(mapper_id=0)
+    torch.cuda.synchronize()
+    gc.collect()
+
+    base_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for i in range(n_frames):
+        one_frame(i)
+    torch.cuda.synchronize()
+    wall_s = time.perf_counter() - t0
+    ms_per_f = wall_s * 1000 / n_frames
+
+    peak_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    # Layer-size reporting. Occupancy uses a different layer view
+    # than TSDF. Try the likely method names; tolerate absence.
+    n_blocks = None
+    block_dim_vox = 8
+    for view_getter in ("occupancy_layer_view", "tsdf_layer_view"):
+        try:
+            v = getattr(mapper, view_getter)(mapper_id=0)
+            try:
+                n_blocks = int(v.num_allocated_blocks())
+            except Exception:
+                try:
+                    n_blocks = int(v.num_blocks())
+                except Exception:
+                    continue
+            try:
+                block_dim_vox = int(v.block_dim_in_voxels())
+            except Exception:
+                pass
+            break
+        except Exception:
+            continue
+    n_voxels_upper = (
+        n_blocks * (block_dim_vox ** 3) if n_blocks is not None else -1)
+
+    gpu_used_gb = -1.0
+    try:
+        free_b, total_b = torch.cuda.mem_get_info()
+        gpu_used_gb = (total_b - free_b) / 1e9
+    except Exception:
+        pass
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    return {
+        "ok": True,
+        "ms_per_f": ms_per_f,
+        "wall_s": wall_s,
+        "peak_rss_gb": peak_rss_kb / 1e6,
+        "peak_rss_delta_gb": max(0.0, (peak_rss_kb - base_rss_kb) / 1e6),
+        "gpu_used_gb": gpu_used_gb,
+        "peak_torch_gb": peak_torch_gb,
+        "n_frames": n_frames,
+        "n_voxels": n_voxels_upper,
+        "n_blocks": n_blocks if n_blocks is not None else -1,
+        "voxel_size_m": voxel_size_m,
+    }
+
+
+def run_depth(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Run nvblox depth-TSDF on a Replica / 7-Scenes-style sequence.
+
+    The npz at `depth_npz` is produced by the driver and holds:
+      - `depth_images`: [N, H, W] fp32 in METRES (0 = no measurement)
+      - `cam_to_world`: [N, 4, 4] fp32 camera-to-world poses
+      - `K`:            [3, 3] fp32 intrinsics matrix
+            K[0,0]=fx, K[1,1]=fy, K[0,2]=cx, K[1,2]=cy
+    Mirrors the indirection used by `run_lidar` — JSON-encoding large
+    depth arrays is too slow.
+
+    nvblox input format:
+      - `Sensor.from_camera_matrix(K, W, H)`.
+      - `Mapper.add_depth_frame(depth_frame, t_w_c, sensor)`, where
+        `depth_frame` is a CUDA fp32 tensor and `t_w_c` is a 4x4
+        host tensor (matching the test_mapper_add_frames example).
+
+    Timing protocol and ESDF handling are identical to `run_lidar`.
+    """
+    voxel_size_m = float(spec["voxel_size_m"])
+    trunc_m = float(spec["truncation_distance_m"])
+    warmup_frames = int(spec.get("warmup_frames", 2))
+
+    data = np.load(spec["depth_npz"])
+    depth_images = data["depth_images"]   # [N, H, W] fp32 metres
+    cam_to_world = data["cam_to_world"]   # [N, 4, 4] fp32
+    K_np         = data["K"]              # [3, 3] fp32
+    n_frames, height, width = depth_images.shape
+
+    params = MapperParams()
+    try:
+        vox_ratio = trunc_m / voxel_size_m
+        params.tsdf_integrator_truncation_distance_vox = float(vox_ratio)
+    except AttributeError:
+        pass
+
+    mapper = Mapper(
+        voxel_sizes_m=[voxel_size_m],
+        integrator_types=[ProjectiveIntegratorType.TSDF],
+        mapper_parameters=params,
+    )
+
+    K_t = torch.from_numpy(K_np).to(dtype=torch.float32)
+    sensor = Sensor.from_camera_matrix(K_t, width, height)
+
+    def one_frame(i: int) -> None:
+        depth_t = torch.from_numpy(depth_images[i]).cuda()
+        pose_t  = torch.from_numpy(cam_to_world[i]).float()
+        mapper.add_depth_frame(
+            depth_frame=depth_t, t_w_c=pose_t,
+            sensor=sensor, mapper_id=0,
+        )
+
+    for i in range(min(warmup_frames, n_frames)):
+        one_frame(i)
+    mapper.clear(mapper_id=0)
+    torch.cuda.synchronize()
+    gc.collect()
+
+    base_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for i in range(n_frames):
+        one_frame(i)
+    torch.cuda.synchronize()
+    wall_s = time.perf_counter() - t0
+    ms_per_f = wall_s * 1000 / n_frames
+
+    peak_rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    tsdf_view = mapper.tsdf_layer_view(mapper_id=0)
+    n_blocks = None
+    try:
+        n_blocks = int(tsdf_view.num_allocated_blocks())
+    except Exception:
+        try:
+            n_blocks = int(tsdf_view.num_blocks())
+        except Exception:
+            n_blocks = None
+    block_dim_vox = 8
+    try:
+        block_dim_vox = int(tsdf_view.block_dim_in_voxels())
+    except Exception:
+        pass
+    n_voxels_upper = (
+        n_blocks * (block_dim_vox ** 3) if n_blocks is not None else -1)
+
+    gpu_used_gb = -1.0
+    try:
+        free_b, total_b = torch.cuda.mem_get_info()
+        gpu_used_gb = (total_b - free_b) / 1e9
+    except Exception:
+        pass
+    peak_torch_gb = -1.0
+    try:
+        peak_torch_gb = torch.cuda.max_memory_allocated() / 1e9
+    except Exception:
+        pass
+
+    n_mesh_verts = n_mesh_tris = -1
+    try:
+        mapper.update_color_mesh(mapper_id=0)
+        mesh = mapper.get_color_mesh(mapper_id=0)
+        n_mesh_verts = int(mesh.vertices.shape[0])
+        n_mesh_tris  = int(mesh.triangles.shape[0])
+    except Exception:
+        pass
+
+    # ESDF timing (same cold/warm split as run_lidar).
+    esdf_cold_ms = -1.0
+    esdf_warm_ms_min = -1.0
+    esdf_warm_ms_median = -1.0
+    esdf_warm_calls = int(spec.get("esdf_warm_calls", 5))
+    if bool(spec.get("with_esdf", False)):
+        try:
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            mapper.update_esdf(mapper_id=0)
+            torch.cuda.synchronize()
+            esdf_cold_ms = (time.perf_counter() - t0) * 1000.0
+
+            warm_samples = []
+            for _ in range(esdf_warm_calls):
+                torch.cuda.synchronize()
+                t0 = time.perf_counter()
+                mapper.update_esdf(mapper_id=0)
+                torch.cuda.synchronize()
+                warm_samples.append((time.perf_counter() - t0) * 1000.0)
+            if warm_samples:
+                warm_samples.sort()
+                esdf_warm_ms_min = warm_samples[0]
+                esdf_warm_ms_median = warm_samples[len(warm_samples) // 2]
+        except Exception:
+            esdf_cold_ms = -2.0
+            esdf_warm_ms_min = -2.0
+            esdf_warm_ms_median = -2.0
+
+    return {
+        "ok": True,
+        "ms_per_f": ms_per_f,
+        "wall_s": wall_s,
+        "peak_rss_gb": peak_rss_kb / 1e6,
+        "peak_rss_delta_gb": max(0.0, (peak_rss_kb - base_rss_kb) / 1e6),
+        "gpu_used_gb": gpu_used_gb,
+        "peak_torch_gb": peak_torch_gb,
+        "n_frames": n_frames,
+        "n_voxels": n_voxels_upper,
+        "n_blocks": n_blocks if n_blocks is not None else -1,
+        "n_mesh_verts": n_mesh_verts,
+        "n_mesh_tris": n_mesh_tris,
+        "voxel_size_m": voxel_size_m,
+        "esdf_cold_ms": esdf_cold_ms,
+        "esdf_warm_ms_min": esdf_warm_ms_min,
+        "esdf_warm_ms_median": esdf_warm_ms_median,
+        "esdf_warm_calls": esdf_warm_calls,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--spec", required=True, help="Path to JSON spec file")
+    p.add_argument("--output", required=True, help="Path to JSON output file")
+    args = p.parse_args()
+
+    with open(args.spec, "r") as f:
+        spec = json.load(f)
+
+    try:
+        if spec["workload"] == "lidar":
+            result = run_lidar(spec)
+        elif spec["workload"] == "lidar_occupancy":
+            result = run_lidar_occupancy(spec)
+        elif spec["workload"] == "depth":
+            result = run_depth(spec)
+        else:
+            raise NotImplementedError(
+                f"workload {spec['workload']!r} not implemented (supported: "
+                "'lidar', 'lidar_occupancy', 'depth')")
+    except Exception as e:  # noqa: BLE001
+        result = {
+            "ok": False,
+            "failure": f"{type(e).__name__}: {e}",
+            "traceback": traceback.format_exc(),
+            "voxel_size_m": spec.get("voxel_size_m", -1),
+        }
+
+    with open(args.output, "w") as f:
+        json.dump(result, f, indent=2)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/tsdf_fusion/cross_library/replica_loader.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/replica_loader.py
@@ -1,0 +1,170 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Replica NICE-SLAM format loader.
+
+Reads the RGB-D + pose sequence released by NICE-SLAM (and used by
+iMAP / Co-SLAM / ESLAM and many follow-ups), so numbers produced
+here are directly comparable against those papers' tables.
+
+Directory layout the loader expects (one scene root):
+
+    <scene>/
+        results/
+            frame000000.jpg
+            depth000000.png      (uint16 depth, scale 1/6553.5 -> metres)
+            frame000001.jpg
+            depth000001.png
+            ...
+        traj.txt                 (one 4x4 cam->world matrix per frame,
+                                  row-major, 16 floats per line)
+
+Intrinsics are fixed for the whole Replica set in the NICE-SLAM
+rendering — fx = fy = 600, cx = 599.5, cy = 339.5, W = 1200,
+H = 680 — but we expose overrides for the occasional variant.
+
+Minimal API:
+
+    scene = load_replica_scene("path/to/room_0", max_frames=200, stride=2)
+    # scene.depth_images: np.ndarray [N, H, W] float32 metres
+    # scene.cam_to_world: np.ndarray [N, 4, 4] float32
+    # scene.K: np.ndarray [3, 3] float32
+    # scene.name: str
+
+Downstream benchmark code treats the result shape-for-shape the same
+as the synthetic `SyntheticScene` returned by `make_sphere_scene`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from typing import Optional
+
+import numpy as np
+
+
+@dataclasses.dataclass
+class ReplicaScene:
+    depth_images: np.ndarray  # [N, H, W] float32, metres, 0 = no measurement
+    cam_to_world: np.ndarray  # [N, 4, 4] float32
+    K: np.ndarray             # [3, 3] float32
+    name: str
+
+    # Mimic the SyntheticScene attributes the benchmark script expects.
+    sphere_center: np.ndarray = dataclasses.field(default_factory=lambda: np.zeros(3, np.float32))
+    sphere_radius: float = 0.0
+
+    @property
+    def n_frames(self) -> int:
+        return self.depth_images.shape[0]
+
+
+# NICE-SLAM's rendering convention for Replica (standard across their
+# entire 8-scene release and the iMAP / Co-SLAM / ESLAM re-uses).
+DEFAULT_REPLICA_INTRINSICS = {
+    "W": 1200,
+    "H": 680,
+    "fx": 600.0,
+    "fy": 600.0,
+    "cx": 599.5,
+    "cy": 339.5,
+    "png_depth_scale": 6553.5,  # depth_m = depth_u16 / png_depth_scale
+}
+
+
+def _read_traj(path: str) -> np.ndarray:
+    """Parse `traj.txt`: one 4x4 row-major cam->world matrix per line."""
+    with open(path, "r") as f:
+        lines = [ln.strip() for ln in f if ln.strip()]
+    mats = []
+    for ln in lines:
+        vals = [float(x) for x in ln.split()]
+        if len(vals) != 16:
+            raise ValueError(
+                f"{path}: expected 16 floats per line (4x4 matrix), got {len(vals)}"
+            )
+        mats.append(np.asarray(vals, np.float32).reshape(4, 4))
+    return np.stack(mats, axis=0)
+
+
+def load_replica_scene(
+    scene_dir: str,
+    max_frames: Optional[int] = None,
+    stride: int = 1,
+    png_depth_scale: float = DEFAULT_REPLICA_INTRINSICS["png_depth_scale"],
+    intrinsics: Optional[dict] = None,
+) -> ReplicaScene:
+    """Load a NICE-SLAM rendered Replica scene from disk.
+
+    Args:
+        scene_dir: path to the scene root (contains `results/` and `traj.txt`).
+        max_frames: if set, load only the first `max_frames` frames (after stride).
+        stride: take every `stride`-th frame from the trajectory (1 = all frames).
+        png_depth_scale: divisor to turn uint16 PNG depth into metres.
+        intrinsics: dict overriding `fx, fy, cx, cy, W, H`. Defaults to the
+            standard NICE-SLAM Replica intrinsics.
+
+    Returns:
+        ReplicaScene with depth_images, cam_to_world, K populated.
+    """
+    # Lazy-imports so `replica_loader` can be imported in a minimal env that
+    # doesn't have PIL / opencv — we only need them when actually loading.
+    try:
+        from PIL import Image
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "load_replica_scene needs pillow installed — pip install pillow"
+        ) from e
+
+    intrinsics = {**DEFAULT_REPLICA_INTRINSICS, **(intrinsics or {})}
+    W = int(intrinsics["W"])
+    H = int(intrinsics["H"])
+    fx = float(intrinsics["fx"])
+    fy = float(intrinsics["fy"])
+    cx = float(intrinsics["cx"])
+    cy = float(intrinsics["cy"])
+    K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]], dtype=np.float32)
+
+    results_dir = os.path.join(scene_dir, "results")
+    traj_path = os.path.join(scene_dir, "traj.txt")
+    if not os.path.isdir(results_dir):
+        raise FileNotFoundError(
+            f"Replica scene at {scene_dir!r} is missing `results/` — "
+            "expected NICE-SLAM rendering layout"
+        )
+    if not os.path.isfile(traj_path):
+        raise FileNotFoundError(
+            f"Replica scene at {scene_dir!r} is missing `traj.txt`"
+        )
+
+    cam_to_world_all = _read_traj(traj_path)
+    n_total = cam_to_world_all.shape[0]
+
+    frame_indices = list(range(0, n_total, stride))
+    if max_frames is not None:
+        frame_indices = frame_indices[:max_frames]
+
+    depth_images = np.zeros((len(frame_indices), H, W), dtype=np.float32)
+    cam_to_world = np.empty((len(frame_indices), 4, 4), dtype=np.float32)
+    for out_i, src_i in enumerate(frame_indices):
+        depth_path = os.path.join(results_dir, f"depth{src_i:06d}.png")
+        if not os.path.isfile(depth_path):
+            raise FileNotFoundError(
+                f"missing {depth_path} — dataset may be incomplete"
+            )
+        depth_u16 = np.asarray(Image.open(depth_path), dtype=np.uint16)
+        if depth_u16.shape != (H, W):
+            raise ValueError(
+                f"{depth_path}: shape {depth_u16.shape} != expected ({H}, {W}); "
+                "override intrinsics via the `intrinsics=` argument"
+            )
+        depth_images[out_i] = depth_u16.astype(np.float32) / png_depth_scale
+        cam_to_world[out_i] = cam_to_world_all[src_i]
+
+    return ReplicaScene(
+        depth_images=depth_images,
+        cam_to_world=cam_to_world,
+        K=K,
+        name=os.path.basename(os.path.normpath(scene_dir)),
+    )

--- a/tests/benchmarks/tsdf_fusion/cross_library/seven_scenes_loader.py
+++ b/tests/benchmarks/tsdf_fusion/cross_library/seven_scenes_loader.py
@@ -1,0 +1,235 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Loader for the Microsoft 7-Scenes RGB-D dataset.
+
+7-Scenes is a published Kinect-v1 dataset where each "scene" (chess,
+fire, heads, office, pumpkin, redkitchen, stairs) contains 2-7
+independent recording sequences of ~1000 frames each, all of the
+same physical room. All sequences share a common global coordinate
+frame from the dataset's camera-relocalisation ground truth, so
+sequences can be concatenated into a single long trajectory for
+TSDF-fusion benchmarking.
+
+This is the long-trajectory complement to `replica_loader.py`:
+- Replica room0 at our current stride=10 gives 200 frames per
+  trajectory, and the scene is a small bedroom -- ideal for the
+  "fine voxel size at moderate frame count" scale-ceiling story.
+- 7-Scenes concatenated gives up to 6000 frames with lots of
+  trajectory revisit, which exercises the "bounded surface +
+  growing frame count + accumGrid mostly saturated" regime that
+  Tree 4 (persistent grid) is supposed to help.
+
+Typical use in the benchmarks here:
+
+    scene = load_seven_scenes_scene(
+        'path/to/7-Scenes/chess',
+        sequences=['seq-01', 'seq-02', ...],  # or None for all
+        max_frames=None,
+        stride=1,
+    )
+
+Layout on disk (after `unzip seq-0i.zip`):
+    chess/seq-01/frame-000000.color.png
+    chess/seq-01/frame-000000.depth.png
+    chess/seq-01/frame-000000.pose.txt
+    chess/seq-01/frame-000001.color.png
+    ...
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+# Microsoft 7-Scenes Kinect v1 depth intrinsics (these are used in
+# all published re-localisation / SLAM baselines on this dataset).
+# The color image has slightly different intrinsics; we only use
+# depth here so we ignore that.
+DEFAULT_SEVEN_SCENES_INTRINSICS = {
+    "W": 640,
+    "H": 480,
+    "fx": 585.0,
+    "fy": 585.0,
+    "cx": 320.0,
+    "cy": 240.0,
+    # 7-Scenes depth PNGs store depth in millimetres, with 65535
+    # reserved for invalid / too-far pixels. Default threshold for
+    # valid data: anything <= 4 m (4000 mm) -- past that the Kinect
+    # v1 sensor's noise dominates the measurement.
+    "depth_scale_mm_to_m": 1.0 / 1000.0,
+    "depth_max_m": 4.0,
+    "depth_invalid_marker": 65535,
+}
+
+
+@dataclass
+class SevenScenesScene:
+    """A parsed 7-Scenes scene ready to feed to `integrate_tsdf_frames`."""
+
+    depth_images: np.ndarray  # [N, H, W] float32 metres (invalid -> 0)
+    cam_to_world: np.ndarray  # [N, 4, 4] float32
+    K: np.ndarray             # [3, 3] float32 (intrinsic, shared)
+    sequence_ids: np.ndarray  # [N] int32: which sequence each frame came from
+
+    @property
+    def n_frames(self) -> int:
+        return self.depth_images.shape[0]
+
+
+_FRAME_RE = re.compile(r"frame-(?P<idx>\d{6})\.depth\.png$")
+
+
+def _frame_index(path: str) -> int:
+    m = _FRAME_RE.search(path)
+    if m is None:
+        raise ValueError(f"path does not match frame-XXXXXX.depth.png: {path!r}")
+    return int(m.group("idx"))
+
+
+def load_seven_scenes_scene(
+    scene_dir: str,
+    *,
+    sequences: Optional[Sequence[str]] = None,
+    max_frames: Optional[int] = None,
+    stride: int = 1,
+    intrinsics: Optional[dict] = None,
+) -> SevenScenesScene:
+    """Load one or more 7-Scenes sequences and concatenate into a single trajectory.
+
+    Arguments
+    ---------
+    scene_dir:
+        Path to the unzipped scene, e.g. `.../7-Scenes/chess`. Must
+        contain `seq-01/`, `seq-02/`, ... subdirectories.
+    sequences:
+        Explicit list of sequence names to load in order. If None,
+        loads all sequences present, sorted lexicographically.
+    max_frames:
+        Cap on total frames after stride (applied across the
+        concatenated trajectory).
+    stride:
+        Keep every `stride`-th frame (applied per-sequence before
+        concatenation so the first frame of each sequence is always
+        included -- matches the convention `replica_loader` uses).
+    intrinsics:
+        Override defaults. Only `W`, `H`, `fx`, `fy`, `cx`, `cy` are
+        read out for the camera matrix; depth scaling is always
+        `/1000` and the invalid marker is always 65535 (both are
+        fixed by the dataset).
+    """
+    try:
+        from PIL import Image
+    except ImportError as e:
+        raise ImportError(
+            "load_seven_scenes_scene needs pillow: pip install pillow"
+        ) from e
+
+    intr = {**DEFAULT_SEVEN_SCENES_INTRINSICS, **(intrinsics or {})}
+    W, H = int(intr["W"]), int(intr["H"])
+    K = np.array(
+        [[intr["fx"], 0, intr["cx"]],
+         [0, intr["fy"], intr["cy"]],
+         [0, 0, 1]],
+        dtype=np.float32,
+    )
+
+    if sequences is None:
+        sequences = sorted(
+            name for name in os.listdir(scene_dir)
+            if name.startswith("seq-") and os.path.isdir(os.path.join(scene_dir, name))
+        )
+    if not sequences:
+        raise FileNotFoundError(
+            f"No `seq-*/` subdirectories found in {scene_dir!r}"
+        )
+
+    depth_list: List[np.ndarray] = []
+    c2w_list: List[np.ndarray] = []
+    seq_id_list: List[int] = []
+
+    for sid, seq_name in enumerate(sequences):
+        seq_dir = os.path.join(scene_dir, seq_name)
+        depth_files = sorted(glob.glob(os.path.join(seq_dir, "frame-*.depth.png")),
+                              key=_frame_index)
+        if stride > 1:
+            depth_files = depth_files[::stride]
+        for dpath in depth_files:
+            idx = _frame_index(dpath)
+            ppath = os.path.join(seq_dir, f"frame-{idx:06d}.pose.txt")
+            if not os.path.isfile(ppath):
+                # Dataset has occasional missing frames; skip.
+                continue
+
+            # Depth in mm uint16; invalid = 65535 -> 0 metres.
+            d = np.array(Image.open(dpath), dtype=np.uint16)
+            if d.shape != (H, W):
+                raise ValueError(
+                    f"{dpath} depth is {d.shape}, expected ({H}, {W})"
+                )
+            d_m = d.astype(np.float32) * intr["depth_scale_mm_to_m"]
+            d_m[d == intr["depth_invalid_marker"]] = 0.0
+            # Also zero out implausibly-far pixels (sensor noise).
+            d_m[d_m > intr["depth_max_m"]] = 0.0
+
+            # Pose: space-separated 4x4.
+            pose = np.loadtxt(ppath, dtype=np.float32)
+            if pose.shape != (4, 4):
+                raise ValueError(
+                    f"{ppath} pose is {pose.shape}, expected (4, 4)"
+                )
+
+            depth_list.append(d_m)
+            c2w_list.append(pose)
+            seq_id_list.append(sid)
+
+            if max_frames is not None and len(depth_list) >= max_frames:
+                break
+        if max_frames is not None and len(depth_list) >= max_frames:
+            break
+
+    if not depth_list:
+        raise FileNotFoundError(
+            f"No frames loaded from {scene_dir!r} "
+            f"(sequences={sequences}, stride={stride})"
+        )
+
+    return SevenScenesScene(
+        depth_images=np.stack(depth_list, axis=0),
+        cam_to_world=np.stack(c2w_list, axis=0),
+        K=K,
+        sequence_ids=np.array(seq_id_list, dtype=np.int32),
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    p = argparse.ArgumentParser()
+    p.add_argument("scene_dir", help="path to unzipped 7-Scenes scene, e.g. .../7-Scenes/chess")
+    p.add_argument("--max-frames", type=int, default=None)
+    p.add_argument("--stride", type=int, default=1)
+    args = p.parse_args()
+
+    scene = load_seven_scenes_scene(
+        args.scene_dir, max_frames=args.max_frames, stride=args.stride
+    )
+    print(f"Loaded {scene.n_frames} frames from {args.scene_dir!r}")
+    print(f"  depth_images: {scene.depth_images.shape} {scene.depth_images.dtype}")
+    print(f"  cam_to_world: {scene.cam_to_world.shape} {scene.cam_to_world.dtype}")
+    print(f"  K:\n{scene.K}")
+    seqs, counts = np.unique(scene.sequence_ids, return_counts=True)
+    print(f"  per-sequence counts: " + ", ".join(
+        f"seq{sid}={c}" for sid, c in zip(seqs.tolist(), counts.tolist())
+    ))
+    valid_frac = (scene.depth_images > 0).mean()
+    print(f"  valid-depth fraction (mean over frames): {valid_frac*100:.1f}%")
+    print(f"  depth range (valid pixels): "
+          f"{scene.depth_images[scene.depth_images > 0].min():.3f} -> "
+          f"{scene.depth_images.max():.3f} m")

--- a/tests/benchmarks/tsdf_fusion/data/.gitignore
+++ b/tests/benchmarks/tsdf_fusion/data/.gitignore
@@ -1,0 +1,4 @@
+# Everything under this dir is downloaded at setup time, not committed.
+*
+!.gitignore
+!README.md

--- a/tests/benchmarks/tsdf_fusion/data/README.md
+++ b/tests/benchmarks/tsdf_fusion/data/README.md
@@ -1,0 +1,52 @@
+# TSDF fusion benchmark datasets
+
+This directory is git-ignored except for this README and `.gitignore`.
+Populate it by downloading the NICE-SLAM Replica rendering (and,
+optionally, per-scene GT meshes) — see below.
+
+## Replica (NICE-SLAM rendering)
+
+- **What**: 8 rendered RGB-D sequences over the Replica rooms /
+  offices. Each scene is ~1.6 GB on disk, full bundle 12.4 GB.
+- **Where**:
+  ```bash
+  cd $THIS_DIR
+  curl -L -O https://cvg-data.inf.ethz.ch/nice-slam/data/Replica.zip
+  unzip -q Replica.zip
+  ```
+- **Layout expected by `replica_loader.py`**:
+  ```
+  data/Replica/
+    room_0/
+      results/
+        frame000000.jpg
+        depth000000.png
+        ...
+      traj.txt
+    office_0/
+      ...
+  ```
+
+## GT meshes (Replica, for F-score / Chamfer-L1)
+
+The NICE-SLAM rendering zip above does NOT include GT meshes. They
+come from Meta's original Replica-Dataset release, which has a
+larger footprint and a license-acceptance gate. For initial
+benchmark runs the script prints perf numbers without quality
+metrics if no GT mesh is provided.
+
+To enable quality metrics, obtain the GT mesh for a scene (e.g.
+`room_0/mesh.ply`) from the Replica-Dataset release and pass its
+path via `--gt-mesh` to `bench_open3d_vs_fvdb.py`.
+
+A smaller "just the meshes" drop has occasionally circulated in the
+community (e.g. via the NICE-SLAM GitHub issues); if we find a
+stable URL we'll add a direct-download step here.
+
+## Disk budget
+
+| item              | size |
+|-------------------|------|
+| Replica.zip       | 12.4 GB (full) |
+| Replica/ extracted | ~13 GB (8 scenes)|
+| room_0 alone      | ~1.6 GB |


### PR DESCRIPTION
## Summary

Adds a `tests/benchmarks/tsdf_fusion/` benchmark suite that compares fvdb against the public sparse-voxel libraries (nvblox, VDBFusion, Open3D) on real and synthetic RGB-D / LiDAR workloads.

Pairs with the fvdb-core TSDF / ESDF / Occupancy / Decay PR ([openvdb/fvdb-core#656](https://github.com/openvdb/fvdb-core/pull/656), itself stacked on [#655](https://github.com/openvdb/fvdb-core/pull/655)). The drivers exercise the new `Grid.integrate_tsdf_frames`, `integrate_tsdf_from_points`, `integrate_occupancy_from_points`, `compute_esdf`, and `decay_and_prune` APIs.

### Per-dataset bench drivers (`tests/benchmarks/tsdf_fusion/cross_library/`)

| Driver                          | Dataset            | Workload                                        |
|---------------------------------|--------------------|-------------------------------------------------|
| `bench_open3d_vs_fvdb.py`       | Synthetic sphere   | TSDF, fvdb vs Open3D                            |
| `bench_replica_full.py`         | Replica            | TSDF + ESDF, multi-scene, full frame rate       |
| `bench_esdf_replica.py`         | Replica            | ESDF scale sweep                                |
| `bench_kitti.py`                | KITTI Odometry     | LiDAR TSDF                                      |
| `bench_esdf_kitti.py`           | KITTI Odometry     | LiDAR ESDF                                      |
| `bench_occupancy_kitti.py`      | KITTI Odometry     | LiDAR occupancy                                 |
| `bench_decay_kitti.py`          | KITTI Odometry     | Dynamic-scene decay-and-prune                   |
| `bench_mai_city.py`             | Mai City (LiDAR)   | LiDAR TSDF, fvdb vs VDBFusion vs nvblox         |
| `bench_seven_scenes.py`         | 7-Scenes (RGB-D)   | TSDF, long-trajectory                           |
| `bench_esdf_vs_nvblox.py`       | Mai City           | ESDF, fvdb vs nvblox                            |
| `bench_occupancy_vs_nvblox.py`  | Mai City           | Occupancy, fvdb vs nvblox                       |

### Supporting modules

- **`kitti_loader.py`, `replica_loader.py`, `mai_city_loader.py`, `seven_scenes_loader.py`** — minimal per-dataset loaders that yield `(intrinsics, cam_to_world, depth_or_points)` tuples.
- **`download_kitti.py`, `download_replica.py`, `download_replica_zip.py`** — resumable, parallel-stream downloaders for the public dataset archives.
- **`nvblox_runner.py`** — Python wrapper around the nvblox CLI that matches the cross-library interface used by the bench drivers above.
- **`install_nvblox.sh`, `install_vdbfusion.sh`** — reproducible install recipes for the two C++ comparison libraries (each builds against the fvdb conda env's TBB / Blosc / Boost).
- **`data/README.md`, `data/.gitignore`** — conventions for placing dataset trees under `data/`. The dataset files themselves are not vendored.

Each driver accepts `--help` for its full argument surface and writes a JSON results file alongside per-frame stdout summaries.

## Test plan

A no-external-dataset smoke test runs in a few seconds and is the easiest way to verify the setup:

```
python tests/benchmarks/tsdf_fusion/cross_library/bench_open3d_vs_fvdb.py \
    --n-frames 16 --json-out /tmp/smoke.json
```

The dataset-bound drivers expect the public archives under `tests/benchmarks/tsdf_fusion/data/<dataset>/` (gitignored; downloaders provided in the same directory).

- [ ] Synthetic sphere smoke test runs end-to-end with both fvdb and Open3D code paths and writes the JSON results file.
- [ ] At least one dataset-bound driver runs end-to-end on its public archive (e.g. `bench_replica_full.py` against a Replica scene).
- [ ] `install_nvblox.sh` / `install_vdbfusion.sh` produce working installs from a clean conda env (these are scripts, not part of the fvdb wheel).