### PR TITLE
Add DepthMapAttribute and optional dense depth supervision

### DIFF
--- a/fvdb_reality_capture/radiance_fields/_gaussian_rendering.py
+++ b/fvdb_reality_capture/radiance_fields/_gaussian_rendering.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
     from .gaussian_splat_reconstruction import GaussianSplatReconstructionConfig
 
 
+def _needs_depth_render(config: "GaussianSplatReconstructionConfig") -> bool:
+    return config.sparse_depth_reg > 0.0 or config.dense_depth_reg > 0.0
+
+
 @dataclass
 class RenderOutputs:
     """
@@ -181,7 +185,7 @@ class ImageSpaceRenderBackend:
         """
         if config.batch_size > 1 and torch.unique(torch.from_numpy(dataset.camera_models)).numel() > 1:
             raise NotImplementedError("batch_size > 1 is not supported for scenes with multiple camera models")
-        self._probe(model, dataset, config, device, render_depth=config.sparse_depth_reg > 0.0)
+        self._probe(model, dataset, config, device, render_depth=_needs_depth_render(config))
 
     def forward_train(
         self,
@@ -223,7 +227,7 @@ class ImageSpaceRenderBackend:
         projection_method = projection_method_from_config(config.projection_method)
         projection_function = (
             model.project_gaussians_for_images_and_depths
-            if config.sparse_depth_reg > 0.0
+            if _needs_depth_render(config)
             else model.project_gaussians_for_images
         )
         projected_gaussians = projection_function(
@@ -429,7 +433,7 @@ class WorldSpaceRenderBackend:
                 distortion_coeffs_arg = _distortion_coeffs_for_batch(camera_model_enum, distortion_coeffs, model.device)
                 render_function = (
                     model.render_images_and_depths_from_world
-                    if config.sparse_depth_reg > 0.0
+                    if _needs_depth_render(config)
                     else model.render_images_from_world
                 )
                 render_function(
@@ -487,9 +491,7 @@ class WorldSpaceRenderBackend:
         camera_model = _camera_model_from_batch(camera_models)
         distortion_coeffs_arg = _distortion_coeffs_for_batch(camera_model, distortion_coeffs, model.device)
         render_function = (
-            model.render_images_and_depths_from_world
-            if config.sparse_depth_reg > 0.0
-            else model.render_images_from_world
+            model.render_images_and_depths_from_world if _needs_depth_render(config) else model.render_images_from_world
         )
         rendered, alpha = render_function(
             world_to_camera_matrices=world_to_camera_matrices,

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
@@ -12,6 +12,7 @@ import torch.utils.data
 import torchvision
 
 from fvdb_reality_capture.sfm_scene import (
+    DepthMapAttribute,
     PerImageRasterAttribute,
     PerImageValueAttribute,
     SfmCameraMetadata,
@@ -83,6 +84,15 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
                 raise ValueError(
                     f"Attribute name '{name}' collides with a reserved dataset key. "
                     f"Reserved keys: {sorted(_RESERVED_KEYS)}"
+                )
+            # DepthMapAttribute emits both `<name>` and `<name>_valid` keys; reject
+            # collisions on the validity sibling against the reserved set or against
+            # other attribute names being loaded in the same dataset.
+            valid_key = f"{name}_valid"
+            if valid_key in _RESERVED_KEYS:
+                raise ValueError(
+                    f"Attribute name '{name}' would emit a validity key '{valid_key}' "
+                    f"that collides with a reserved dataset key."
                 )
 
         # If you specified image indices, we'll filter the dataset to only include those images.
@@ -378,7 +388,16 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
 
         for attr_name in self._load_attributes:
             attr = self._sfm_scene.get_attribute(attr_name)
-            if isinstance(attr, PerImageRasterAttribute):
+            if isinstance(attr, DepthMapAttribute):
+                depth_np, valid_np = attr.load_depth(index)
+                depth = torch.from_numpy(depth_np).contiguous()
+                valid = torch.from_numpy(valid_np).contiguous()
+                if self.patch_size is not None:
+                    depth = depth[y : y + self.patch_size, x : x + self.patch_size]
+                    valid = valid[y : y + self.patch_size, x : x + self.patch_size]
+                data[attr_name] = depth
+                data[f"{attr_name}_valid"] = valid
+            elif isinstance(attr, PerImageRasterAttribute):
                 path = attr.paths[index]
                 if path.endswith(".npy"):
                     raster = torch.from_numpy(np.load(path))

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
@@ -70,6 +70,8 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
             "projection",
             "camera_to_world",
             "world_to_camera",
+            "camera_model",
+            "distortion_coeffs",
             "image",
             "image_id",
             "image_path",

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
@@ -79,21 +79,29 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
             "sparse_depth",
             "sparse_depth_uv",
         }
+        # Validate that every key each attribute will emit into the datum dict is
+        # unique -- both against the reserved dataset keys and against keys emitted by
+        # other requested attributes. A DepthMapAttribute emits both `<name>` and
+        # `<name>_valid`, so e.g. requesting both "depth" and "depth_valid" would have
+        # the former clobber the latter in __getitem__.
+        emitted_by: dict[str, str] = {}
         for name in self._load_attributes:
-            if name in _RESERVED_KEYS:
-                raise ValueError(
-                    f"Attribute name '{name}' collides with a reserved dataset key. "
-                    f"Reserved keys: {sorted(_RESERVED_KEYS)}"
-                )
-            # DepthMapAttribute emits both `<name>` and `<name>_valid` keys; reject
-            # collisions on the validity sibling against the reserved set or against
-            # other attribute names being loaded in the same dataset.
-            valid_key = f"{name}_valid"
-            if valid_key in _RESERVED_KEYS:
-                raise ValueError(
-                    f"Attribute name '{name}' would emit a validity key '{valid_key}' "
-                    f"that collides with a reserved dataset key."
-                )
+            attr = self._sfm_scene.get_attribute(name)  # raises KeyError if not registered
+            keys = [name]
+            if isinstance(attr, DepthMapAttribute):
+                keys.append(f"{name}_valid")
+            for key in keys:
+                if key in _RESERVED_KEYS:
+                    raise ValueError(
+                        f"Attribute '{name}' would emit dataset key '{key}', which collides with a "
+                        f"reserved dataset key. Reserved keys: {sorted(_RESERVED_KEYS)}"
+                    )
+                if key in emitted_by:
+                    raise ValueError(
+                        f"Attribute '{name}' would emit dataset key '{key}', which is already emitted "
+                        f"by attribute '{emitted_by[key]}'. Rename one of the attributes to avoid the collision."
+                    )
+                emitted_by[key] = name
 
         # If you specified image indices, we'll filter the dataset to only include those images.
         if dataset_indices is None:

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -39,6 +39,41 @@ from .gaussian_splat_reconstruction_writer import (
 )
 
 
+def _scale_shift_invariant_l1(
+    pred: torch.Tensor, target: torch.Tensor, valid: torch.Tensor, eps: float = 1e-6
+) -> torch.Tensor:
+    """Scale-and-shift invariant L1 loss between ``pred`` and ``target``, per image.
+
+    Each side is independently normalized by its own median and mean-absolute-deviation
+    over valid pixels (Ranftl et al., MiDaS); the L1 of the residual is then averaged
+    over valid pixels. Restricted to batch size 1; the caller enforces this elsewhere.
+
+    Args:
+        pred (torch.Tensor): Predicted depth, shape ``(1, H, W)``.
+        target (torch.Tensor): Target depth, shape ``(1, H, W)``.
+        valid (torch.Tensor): Boolean validity mask, shape ``(1, H, W)``.
+        eps (float): Lower bound on the MAD denominator to avoid division by zero on
+            constant-depth (or near-empty) crops.
+
+    Returns:
+        loss (torch.Tensor): Scalar L1 loss in normalized depth units. Returns zero
+            when no pixels are valid.
+    """
+    assert pred.shape[0] == 1, "_scale_shift_invariant_l1 only supports batch size 1"
+    v = valid[0]
+    if v.sum() == 0:
+        return pred.new_zeros(())
+    p = pred[0][v]
+    t = target[0][v]
+    p_med = torch.median(p)
+    t_med = torch.median(t)
+    p_mad = (p - p_med).abs().mean().clamp_min(eps)
+    t_mad = (t - t_med).abs().mean().clamp_min(eps)
+    p_hat = (p - p_med) / p_mad
+    t_hat = (t - t_med) / t_mad
+    return (p_hat - t_hat).abs().mean()
+
+
 @dataclass
 class GaussianSplatReconstructionConfig:
     """
@@ -155,6 +190,28 @@ class GaussianSplatReconstructionConfig:
     Weight for sparse depth loss. If you have sparse depth measurements for some pixels in the images, you can set this weight
     to a value greater than 0 to encourage the reconstruction to match those depth measurements.
     Default: ``0.0`` (no sparse depth loss).
+    """
+
+    dense_depth_attribute: str | None = None
+    """
+    Name of a :class:`~fvdb_reality_capture.sfm_scene.DepthMapAttribute` registered on the scene to use as a
+    per-pixel ground-truth depth target. If ``None`` (and :attr:`dense_depth_reg` is non-zero, a ``ValueError`` is raised).
+
+    Default: ``None`` (no dense depth supervision).
+    """
+
+    dense_depth_reg: float = 0.0
+    """
+    Weight on the dense depth loss term. The dense loss coexists with :attr:`sparse_depth_reg`; both may be enabled
+    simultaneously. The form of the loss is selected by the :attr:`~DepthMapAttribute.scale` of the referenced attribute:
+
+    - :class:`DepthScale.METRIC` --- direct masked L1 between rendered depth (alpha-corrected) and target depth,
+      both in scene units.
+    - :class:`DepthScale.RELATIVE` --- scale-and-shift invariant L1 (each side normalized by its own per-image
+      median and mean-absolute-deviation, then L1; cf. Ranftl et al., MiDaS). Use this for monocular relative-depth
+      predictions whose absolute scale and offset are arbitrary.
+
+    Default: ``0.0`` (no dense depth loss).
     """
 
     random_bkgd: bool = False
@@ -720,10 +777,34 @@ class GaussianSplatReconstruction:
         self._render_backend = render_backend
 
         self._sfm_scene = sfm_scene
+
+        # Resolve dense-depth supervision: which attribute to load. The comparison form
+        # (direct L1 vs scale-shift invariant) is keyed off the attribute's DepthScale at
+        # loss-evaluation time, not configured separately.
+        dense_depth_load: list[str] = []
+        self._dense_depth_scale: "DepthScale | None" = None
+        if self.config.dense_depth_reg > 0.0:
+            if self.config.dense_depth_attribute is None:
+                raise ValueError(
+                    "dense_depth_reg > 0 requires dense_depth_attribute to name a DepthMapAttribute "
+                    "registered on the scene."
+                )
+            from fvdb_reality_capture.sfm_scene import DepthMapAttribute
+
+            attr = sfm_scene.get_attribute(self.config.dense_depth_attribute)
+            if not isinstance(attr, DepthMapAttribute):
+                raise TypeError(
+                    f"Scene attribute '{self.config.dense_depth_attribute}' is "
+                    f"{type(attr).__name__}, expected DepthMapAttribute."
+                )
+            dense_depth_load = [self.config.dense_depth_attribute]
+            self._dense_depth_scale = attr.scale
+
         self._training_dataset = SfmDataset(
             sfm_scene=sfm_scene,
             dataset_indices=train_indices,
             return_visible_points=(self.config.sparse_depth_reg > 0.0),
+            load_attributes=dense_depth_load,
         )
         self._validation_dataset = SfmDataset(sfm_scene=sfm_scene, dataset_indices=val_indices)
 
@@ -1243,6 +1324,14 @@ class GaussianSplatReconstruction:
                     minibatch["median_depth"].to(self.device) if "median_depth" in minibatch else None
                 )  # [B,]
 
+                dense_depth_key = self.config.dense_depth_attribute
+                if dense_depth_key is not None and dense_depth_key in minibatch:
+                    dense_depth_tgt = minibatch[dense_depth_key].to(self.device)  # [B, H, W]
+                    dense_depth_valid = minibatch[f"{dense_depth_key}_valid"].to(self.device)  # [B, H, W] bool
+                else:
+                    dense_depth_tgt = None
+                    dense_depth_valid = None
+
                 # Progressively use higher spherical harmonic degree as we optimize
                 sh_degree_to_use = min(self._global_step // increase_sh_degree_every_step, self.config.sh_degree)
                 # If you have very large images, you can iterate over disjoint crops and accumulate gradients
@@ -1312,6 +1401,38 @@ class GaussianSplatReconstruction:
 
                     loss = loss + depth_loss
 
+                    # Dense depth loss (from a DepthMapAttribute on the scene).
+                    if dense_depth_tgt is not None and self.config.dense_depth_reg > 0.0:
+                        if self.config.batch_size > 1:
+                            raise NotImplementedError("Dense depth loss is not implemented for batch_size > 1.")
+                        if render_outputs.depth is None:
+                            raise RuntimeError("Model did not render depth channel, but dense depth loss is enabled.")
+                        cx, cy, cw, ch = crop
+                        gt_depth_crop = dense_depth_tgt[:, cy : cy + ch, cx : cx + cw]
+                        gt_valid_crop = dense_depth_valid[:, cy : cy + ch, cx : cx + cw]
+                        pred_dense_depth = render_outputs.depth[..., 0] / torch.clamp(
+                            render_outputs.alpha[..., 0], min=1e-6
+                        )  # [B, h, w]
+                        from fvdb_reality_capture.sfm_scene import DepthScale
+
+                        if self._dense_depth_scale == DepthScale.RELATIVE:
+                            dense_depth_loss = (
+                                _scale_shift_invariant_l1(pred_dense_depth, gt_depth_crop, gt_valid_crop)
+                                * self.config.dense_depth_reg
+                            )
+                        else:
+                            valid_mask = gt_valid_crop.float()
+                            valid_count = valid_mask.sum().clamp(min=1.0)
+                            dense_depth_loss = (
+                                (torch.abs(pred_dense_depth - gt_depth_crop) * valid_mask).sum()
+                                / valid_count
+                                * self.config.dense_depth_reg
+                            )
+                    else:
+                        dense_depth_loss = 0.0
+
+                    loss = loss + dense_depth_loss
+
                     # If you're optimizing poses, regularize the pose parameters so the poses
                     # don't drift too far from the initial values
                     if (
@@ -1378,6 +1499,11 @@ class GaussianSplatReconstruction:
                         self._global_step,
                         f"{log_tag}/depth_loss",
                         depth_loss if isinstance(depth_loss, float) else depth_loss.item(),
+                    )
+                    self._writer.log_metric(
+                        self._global_step,
+                        f"{log_tag}/dense_depth_loss",
+                        dense_depth_loss if isinstance(dense_depth_loss, float) else dense_depth_loss.item(),
                     )
                     self._writer.log_metric(self._global_step, f"{log_tag}/num_gaussians", self.model.num_gaussians)
                     self._writer.log_metric(self._global_step, f"{log_tag}/sh_degree", sh_degree_to_use)

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -61,7 +61,7 @@ def _scale_shift_invariant_l1(
     """
     assert pred.shape[0] == 1, "_scale_shift_invariant_l1 only supports batch size 1"
     v = valid[0]
-    if v.sum() == 0:
+    if not v.any():
         return pred.new_zeros(())
     p = pred[0][v]
     t = target[0][v]
@@ -782,14 +782,16 @@ class GaussianSplatReconstruction:
         # (direct L1 vs scale-shift invariant) is keyed off the attribute's DepthScale at
         # loss-evaluation time, not configured separately.
         dense_depth_load: list[str] = []
-        self._dense_depth_scale: "DepthScale | None" = None
+        # Resolve the loss form (direct L1 vs scale-shift invariant) once, here, so the
+        # training loop is a plain boolean check with no per-step import.
+        self._dense_depth_is_relative: bool = False
         if self.config.dense_depth_reg > 0.0:
             if self.config.dense_depth_attribute is None:
                 raise ValueError(
                     "dense_depth_reg > 0 requires dense_depth_attribute to name a DepthMapAttribute "
                     "registered on the scene."
                 )
-            from fvdb_reality_capture.sfm_scene import DepthMapAttribute
+            from fvdb_reality_capture.sfm_scene import DepthMapAttribute, DepthScale
 
             try:
                 attr = sfm_scene.get_attribute(self.config.dense_depth_attribute)
@@ -804,7 +806,7 @@ class GaussianSplatReconstruction:
                     f"{type(attr).__name__}, expected DepthMapAttribute."
                 )
             dense_depth_load = [self.config.dense_depth_attribute]
-            self._dense_depth_scale = attr.scale
+            self._dense_depth_is_relative = attr.scale == DepthScale.RELATIVE
 
         self._training_dataset = SfmDataset(
             sfm_scene=sfm_scene,
@@ -1419,9 +1421,7 @@ class GaussianSplatReconstruction:
                         pred_dense_depth = render_outputs.depth[..., 0] / torch.clamp(
                             render_outputs.alpha[..., 0], min=1e-6
                         )  # [B, h, w]
-                        from fvdb_reality_capture.sfm_scene import DepthScale
-
-                        if self._dense_depth_scale == DepthScale.RELATIVE:
+                        if self._dense_depth_is_relative:
                             dense_depth_loss = (
                                 _scale_shift_invariant_l1(pred_dense_depth, gt_depth_crop, gt_valid_crop)
                                 * self.config.dense_depth_reg

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -44,34 +44,41 @@ def _scale_shift_invariant_l1(
 ) -> torch.Tensor:
     """Scale-and-shift invariant L1 loss between ``pred`` and ``target``, per image.
 
-    Each side is independently normalized by its own median and mean-absolute-deviation
-    over valid pixels (Ranftl et al., MiDaS); the L1 of the residual is then averaged
-    over valid pixels. Restricted to batch size 1; the caller enforces this elsewhere.
+    Each image in the batch is independently normalized by its own median and
+    mean-absolute-deviation over its valid pixels (Ranftl et al., MiDaS); the L1 of the
+    residual is then averaged over valid pixels and over the batch.
+
+    Because the valid-pixel count differs per batch element, normalization is computed
+    per element (a short Python loop over the batch dimension rather than a single
+    vectorized reduction). Batch elements with no valid pixels contribute zero.
 
     Args:
-        pred (torch.Tensor): Predicted depth, shape ``(1, H, W)``.
-        target (torch.Tensor): Target depth, shape ``(1, H, W)``.
-        valid (torch.Tensor): Boolean validity mask, shape ``(1, H, W)``.
+        pred (torch.Tensor): Predicted depth, shape ``(B, H, W)``.
+        target (torch.Tensor): Target depth, shape ``(B, H, W)``.
+        valid (torch.Tensor): Boolean validity mask, shape ``(B, H, W)``.
         eps (float): Lower bound on the MAD denominator to avoid division by zero on
             constant-depth (or near-empty) crops.
 
     Returns:
-        loss (torch.Tensor): Scalar L1 loss in normalized depth units. Returns zero
-            when no pixels are valid.
+        loss (torch.Tensor): Scalar L1 loss in normalized depth units, averaged over the
+            batch. Returns zero when no pixels are valid anywhere.
     """
-    assert pred.shape[0] == 1, "_scale_shift_invariant_l1 only supports batch size 1"
-    v = valid[0]
-    if not v.any():
-        return pred.new_zeros(())
-    p = pred[0][v]
-    t = target[0][v]
-    p_med = torch.median(p)
-    t_med = torch.median(t)
-    p_mad = (p - p_med).abs().mean().clamp_min(eps)
-    t_mad = (t - t_med).abs().mean().clamp_min(eps)
-    p_hat = (p - p_med) / p_mad
-    t_hat = (t - t_med) / t_mad
-    return (p_hat - t_hat).abs().mean()
+    per_image_losses = []
+    for b in range(pred.shape[0]):
+        vb = valid[b]
+        if not vb.any():
+            per_image_losses.append(pred.new_zeros(()))
+            continue
+        p = pred[b][vb]
+        t = target[b][vb]
+        p_med = torch.median(p)
+        t_med = torch.median(t)
+        p_mad = (p - p_med).abs().mean().clamp_min(eps)
+        t_mad = (t - t_med).abs().mean().clamp_min(eps)
+        p_hat = (p - p_med) / p_mad
+        t_hat = (t - t_med) / t_mad
+        per_image_losses.append((p_hat - t_hat).abs().mean())
+    return torch.stack(per_image_losses).mean()
 
 
 @dataclass
@@ -210,6 +217,13 @@ class GaussianSplatReconstructionConfig:
     - :class:`DepthScale.RELATIVE` --- scale-and-shift invariant L1 (each side normalized by its own per-image
       median and mean-absolute-deviation, then L1; cf. Ranftl et al., MiDaS). Use this for monocular relative-depth
       predictions whose absolute scale and offset are arbitrary.
+
+    .. note::
+        For :class:`DepthScale.METRIC` the loss is computed in **scene units**, so a good value for
+        ``dense_depth_reg`` depends on the scale of the scene and must be retuned when the scene units change.
+        For :class:`DepthScale.RELATIVE` the loss is unitless (each image is median/MAD-normalized), so a value
+        chosen for one scene transfers across scenes. This differs from :attr:`sparse_depth_reg`, whose loss is
+        always median-normalized and therefore scene-scale independent.
 
     Default: ``0.0`` (no dense depth loss).
     """

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -791,7 +791,13 @@ class GaussianSplatReconstruction:
                 )
             from fvdb_reality_capture.sfm_scene import DepthMapAttribute
 
-            attr = sfm_scene.get_attribute(self.config.dense_depth_attribute)
+            try:
+                attr = sfm_scene.get_attribute(self.config.dense_depth_attribute)
+            except KeyError:
+                raise ValueError(
+                    f"dense_depth_attribute '{self.config.dense_depth_attribute}' is not registered on the "
+                    f"scene. Available attributes: {sorted(sfm_scene.attributes.keys())}."
+                ) from None
             if not isinstance(attr, DepthMapAttribute):
                 raise TypeError(
                     f"Scene attribute '{self.config.dense_depth_attribute}' is "

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -195,7 +195,7 @@ class GaussianSplatReconstructionConfig:
     dense_depth_attribute: str | None = None
     """
     Name of a :class:`~fvdb_reality_capture.sfm_scene.DepthMapAttribute` registered on the scene to use as a
-    per-pixel ground-truth depth target. If ``None`` (and :attr:`dense_depth_reg` is non-zero, a ``ValueError`` is raised).
+    per-pixel ground-truth depth target. If ``None`` and :attr:`dense_depth_reg` is non-zero, a ``ValueError`` is raised.
 
     Default: ``None`` (no dense depth supervision).
     """

--- a/fvdb_reality_capture/sfm_scene/__init__.py
+++ b/fvdb_reality_capture/sfm_scene/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from .depth_map_attribute import DepthMapAttribute, DepthMissingPolicy, DepthScale
 from .scene_attribute import (
     InterpolationMode,
     PerCameraAttribute,
@@ -17,6 +18,9 @@ from .sfm_metadata import SfmCameraMetadata, SfmPosedImageMetadata
 from .sfm_scene import SfmScene, SpatialScaleMode
 
 __all__ = [
+    "DepthMapAttribute",
+    "DepthMissingPolicy",
+    "DepthScale",
     "InterpolationMode",
     "PerCameraAttribute",
     "PerImageRasterAttribute",

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -90,6 +90,12 @@ class DepthMapAttribute(PerImageRasterAttribute):
                 Supported formats are the same as :class:`PerImageRasterAttribute`
                 (``.png``, ``.jpg``/``.jpeg``, ``.npy``, ``.pt``). 16-bit single-channel
                 PNGs are read with :func:`cv2.imread(..., cv2.IMREAD_UNCHANGED)`.
+
+                .. warning::
+                    ``.pt`` files are deserialized with :func:`torch.load`, which executes
+                    arbitrary code via pickle. Only load ``.pt`` depth maps produced by a
+                    trusted pipeline. For depth maps from untrusted sources prefer the
+                    non-executable ``.npy`` or PNG formats.
             unit_scale: Multiplier from raw stored values to scene-unit depth. For depth maps
                 stored as 16-bit PNGs in millimeters with the scene in meters, use ``0.001``.
                 For float rasters already in scene units, leave at ``1.0``. This value is
@@ -183,10 +189,17 @@ class DepthMapAttribute(PerImageRasterAttribute):
             return self
 
         linear = matrix[:3, :3]
-        svals = np.linalg.svd(linear, compute_uv=False)
+        svals = np.linalg.svd(linear, compute_uv=False)  # sorted descending
+        # Reject degenerate (rank-deficient / near-zero scale) transforms first: these
+        # would otherwise fold s~=0 into unit_scale and silently zero out every depth.
+        if svals[0] <= 1e-8:
+            raise ValueError(
+                f"DepthMapAttribute(scale=METRIC) got a degenerate spatial transform with "
+                f"near-zero scale (singular values {svals}); this would collapse all depths to zero."
+            )
         # Allow a small relative tolerance because normalize_scene builds the transform
         # in float64 from accumulated outer products.
-        if svals[0] > 0 and not np.allclose(svals, svals[0], rtol=1e-4, atol=1e-6):
+        if not np.allclose(svals, svals[0], rtol=1e-4, atol=1e-6):
             raise ValueError(
                 f"DepthMapAttribute(scale=METRIC) requires a similarity (uniform-scale) "
                 f"spatial transform; got singular values {svals}. A non-uniform 3x3 would "
@@ -325,9 +338,12 @@ class DepthMapAttribute(PerImageRasterAttribute):
         """
         import warnings
 
-        try:
-            transform = np.asarray(scene.transformation_matrix)
-        except AttributeError:
+        raw_transform = getattr(scene, "transformation_matrix", None)
+        if raw_transform is None:
+            return
+        transform = np.asarray(raw_transform)
+        if transform.shape != (4, 4):
+            # Unexpected shape -- treat as "can't tell", don't crash on a best-effort check.
             return
         if not np.allclose(transform, np.eye(4), atol=1e-6):
             warnings.warn(

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -3,7 +3,6 @@
 #
 from __future__ import annotations
 
-import logging
 import pathlib
 from enum import Enum
 from typing import Any
@@ -107,7 +106,6 @@ class DepthMapAttribute(PerImageRasterAttribute):
                 discontinuities.
         """
         super().__init__(paths=paths, resize_interpolation=resize_interpolation)
-        self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
         self._unit_scale = float(unit_scale)
         self._scale = DepthScale(scale) if not isinstance(scale, DepthScale) else scale

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -66,9 +66,10 @@ class DepthMapAttribute(PerImageRasterAttribute):
        emit a per-pixel ``valid`` mask alongside the depth tensor.
 
     The default ``resize_interpolation`` is :class:`InterpolationMode.NEAREST`, which
-    avoids bilerping across depth discontinuities. Bilinear/bicubic are accepted for
-    callers whose depth maps are smooth (e.g. rendered ground truth), but expect
-    artifacts at occlusion boundaries.
+    avoids bilerping across depth discontinuities. Averaging modes (AREA/BILINEAR/BICUBIC)
+    are only permitted with ``missing_policy=NAN``: with a ZERO or SENTINEL policy they
+    would blend the invalid fill value into neighboring valid pixels when downsampling,
+    silently corrupting them, so that combination raises in the constructor.
 
     The class is registered with the scene-attribute registry under the type name
     ``"DepthMapAttribute"``, so an :class:`SfmScene` carrying one round-trips through
@@ -130,6 +131,22 @@ class DepthMapAttribute(PerImageRasterAttribute):
                     f"got {invalid_value!r}."
                 )
             self._invalid_value = None
+
+        # Averaging interpolation (AREA/BILINEAR/BICUBIC) mixes neighboring pixels when the
+        # raster is downsampled. With a ZERO or SENTINEL missing policy the invalid pixels
+        # hold a real finite value (0 or the sentinel), so averaging silently bleeds that
+        # value into adjacent valid pixels and the result still looks "valid". Only NEAREST
+        # avoids this. NaN-encoded invalids instead propagate to NaN under averaging, which
+        # is then correctly flagged invalid on reload -- so require NaN for non-NEAREST modes.
+        if self._resize_interpolation != InterpolationMode.NEAREST and self._missing_policy != DepthMissingPolicy.NAN:
+            raise ValueError(
+                f"DepthMapAttribute with resize_interpolation="
+                f"{self._resize_interpolation.value!r} and missing_policy="
+                f"{self._missing_policy.value!r} is unsafe: averaging interpolation would blend "
+                f"invalid {self._missing_policy.value!r} values into neighboring valid pixels when "
+                f"downsampling, silently corrupting them. Use resize_interpolation=NEAREST, or switch "
+                f"to missing_policy=NAN (NaNs propagate under interpolation and are re-flagged invalid)."
+            )
 
     @property
     def unit_scale(self) -> float:
@@ -208,9 +225,7 @@ class DepthMapAttribute(PerImageRasterAttribute):
                 f"intentionally want it to be invariant to such transforms."
             )
         if np.linalg.det(linear) < 0:
-            raise ValueError(
-                "DepthMapAttribute(scale=METRIC) does not support reflective (det<0) " "spatial transforms."
-            )
+            raise ValueError("DepthMapAttribute(scale=METRIC) does not support reflective (det<0) spatial transforms.")
 
         s = float(svals.mean())
         return DepthMapAttribute(

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -216,12 +216,16 @@ class DepthMapAttribute(PerImageRasterAttribute):
     def load_depth(self, index: int) -> tuple[np.ndarray, np.ndarray]:
         """Load the raw depth raster at ``index`` and apply ``unit_scale`` + validity mask.
 
+        The raster must be single-channel: a ``(H, W)`` array, or ``(H, W, 1)`` which
+        is squeezed to ``(H, W)``. Any other shape (e.g. a 3-channel RGB image) raises
+        :class:`ValueError`.
+
         Returns:
-            depth (np.ndarray): float32 ``(H, W)`` (or higher-rank) array. Invalid
-                pixels are set to 0 in the returned array; consult ``valid`` to
-                distinguish them from real zero depth.
-            valid (np.ndarray): bool array of the same shape as ``depth``. ``True``
-                where the depth is valid under :attr:`missing_policy`.
+            depth (np.ndarray): float32 ``(H, W)`` array. Invalid pixels are set to 0
+                in the returned array; consult ``valid`` to distinguish them from real
+                zero depth.
+            valid (np.ndarray): bool ``(H, W)`` array, ``True`` where the depth is
+                valid under :attr:`missing_policy`.
         """
         import cv2
         import torch
@@ -314,7 +318,9 @@ class DepthMapAttribute(PerImageRasterAttribute):
 
         Call this from user code at the moment a METRIC depth attribute is attached to
         a scene to surface the most common footgun (attaching metric depths after
-        :class:`NormalizeScene` has run). The check is best-effort and only logs.
+        :class:`NormalizeScene` has run). The check is best-effort: it emits a Python
+        :class:`warning <warnings.warn>` rather than raising, and is a no-op if the
+        scene exposes no ``transformation_matrix``.
         """
         import warnings
 

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -250,6 +250,18 @@ class DepthMapAttribute(PerImageRasterAttribute):
         else:
             raise ValueError(f"DepthMapAttribute: unsupported file extension '{ext}' for {path}.")
 
+        # Depth maps must be single-channel. Squeeze a trailing singleton channel
+        # (H, W, 1) -> (H, W); reject genuinely multi-channel rasters such as an RGB
+        # image supplied by mistake, which would otherwise broadcast silently in the
+        # dense-depth loss.
+        if arr.ndim == 3 and arr.shape[2] == 1:
+            arr = arr[:, :, 0]
+        if arr.ndim != 2:
+            raise ValueError(
+                f"DepthMapAttribute: expected a single-channel (H, W) depth raster at {path}, "
+                f"got shape {tuple(arr.shape)}. Multi-channel images (e.g. RGB) are not valid depth maps."
+            )
+
         # Compute the validity mask on the *raw* values (before unit_scale) so that
         # SENTINEL values are matched in the same units the user specified.
         if self._missing_policy == DepthMissingPolicy.NAN:

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -1,0 +1,321 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from __future__ import annotations
+
+import logging
+import pathlib
+from enum import Enum
+from typing import Any
+
+import numpy as np
+
+from .scene_attribute import (
+    InterpolationMode,
+    PerImageRasterAttribute,
+    scene_attribute,
+)
+
+
+class DepthScale(str, Enum):
+    """How depth values respond to spatial transforms of the owning scene.
+
+    METRIC
+        Depth values are in scene units (multiplied by :attr:`DepthMapAttribute.unit_scale`).
+        A similarity transform applied to the scene must rescale these values; the attribute
+        absorbs the scale factor into ``unit_scale`` via :meth:`DepthMapAttribute.on_spatial_transform`
+        rather than rewriting the rasters on disk.
+
+    RELATIVE
+        Depth values are dimensionless (e.g. predictions from a monocular relative-depth
+        estimator that are only meaningful up to a per-image scale). Spatial transforms
+        leave the attribute untouched.
+    """
+
+    METRIC = "metric"
+    RELATIVE = "relative"
+
+
+class DepthMissingPolicy(str, Enum):
+    """How invalid pixels are encoded in the on-disk rasters.
+
+    NAN
+        Invalid pixels are stored as NaN (only valid for floating-point rasters).
+    ZERO
+        Invalid pixels are stored as 0 (typical for 16-bit PNG depth maps).
+    SENTINEL
+        Invalid pixels are equal to :attr:`DepthMapAttribute.invalid_value`.
+    """
+
+    NAN = "nan"
+    ZERO = "zero"
+    SENTINEL = "sentinel"
+
+
+@scene_attribute
+class DepthMapAttribute(PerImageRasterAttribute):
+    """A per-image depth map raster with scale-aware semantics.
+
+    Extends :class:`PerImageRasterAttribute` with three pieces of information that
+    a generic raster cannot model:
+
+    1. ``unit_scale`` -- a multiplier from raw on-disk values to scene-unit depth,
+       which is updated automatically when the scene is rescaled (see :meth:`on_spatial_transform`).
+    2. ``scale`` -- :class:`DepthScale.METRIC` (depths track the scene) or
+       :class:`DepthScale.RELATIVE` (dimensionless; immune to spatial transforms).
+    3. A validity convention (:class:`DepthMissingPolicy`) so the dataset loader can
+       emit a per-pixel ``valid`` mask alongside the depth tensor.
+
+    The default ``resize_interpolation`` is :class:`InterpolationMode.NEAREST`, which
+    avoids bilerping across depth discontinuities. Bilinear/bicubic are accepted for
+    callers whose depth maps are smooth (e.g. rendered ground truth), but expect
+    artifacts at occlusion boundaries.
+
+    The class is registered with the scene-attribute registry under the type name
+    ``"DepthMapAttribute"``, so an :class:`SfmScene` carrying one round-trips through
+    :meth:`SfmScene.state_dict` / :meth:`SfmScene.from_state_dict`.
+    """
+
+    def __init__(
+        self,
+        paths: list[str],
+        unit_scale: float = 1.0,
+        scale: DepthScale | str = DepthScale.METRIC,
+        missing_policy: DepthMissingPolicy | str = DepthMissingPolicy.NAN,
+        invalid_value: float | None = None,
+        resize_interpolation: InterpolationMode | str = InterpolationMode.NEAREST,
+    ):
+        """
+        Args:
+            paths: One file path per image, in the same order as the scene's image list.
+                Supported formats are the same as :class:`PerImageRasterAttribute`
+                (``.png``, ``.jpg``/``.jpeg``, ``.npy``, ``.pt``). 16-bit single-channel
+                PNGs are read with :func:`cv2.imread(..., cv2.IMREAD_UNCHANGED)`.
+            unit_scale: Multiplier from raw stored values to scene-unit depth. For depth maps
+                stored as 16-bit PNGs in millimeters with the scene in meters, use ``0.001``.
+                For float rasters already in scene units, leave at ``1.0``. This value is
+                composed with the linear scale of any subsequent spatial transform when
+                ``scale == METRIC``.
+            scale: :class:`DepthScale.METRIC` (default) for depths that track the scene's
+                coordinate system, or :class:`DepthScale.RELATIVE` for scale-invariant
+                depth predictions (e.g. monocular relative depth).
+            missing_policy: Encoding of invalid pixels (see :class:`DepthMissingPolicy`).
+            invalid_value: The sentinel value used when ``missing_policy == SENTINEL``.
+                Must be ``None`` for the other policies.
+            resize_interpolation: Interpolation mode for downsampling. Defaults to
+                :class:`InterpolationMode.NEAREST` to avoid mixing depths across
+                discontinuities.
+        """
+        super().__init__(paths=paths, resize_interpolation=resize_interpolation)
+        self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
+
+        self._unit_scale = float(unit_scale)
+        self._scale = DepthScale(scale) if not isinstance(scale, DepthScale) else scale
+        self._missing_policy = (
+            DepthMissingPolicy(missing_policy) if not isinstance(missing_policy, DepthMissingPolicy) else missing_policy
+        )
+
+        if self._missing_policy == DepthMissingPolicy.SENTINEL:
+            if invalid_value is None:
+                raise ValueError("missing_policy=SENTINEL requires an explicit invalid_value.")
+            self._invalid_value = float(invalid_value)
+        else:
+            if invalid_value is not None:
+                raise ValueError(
+                    f"invalid_value must be None when missing_policy={self._missing_policy.value!r}; "
+                    f"got {invalid_value!r}."
+                )
+            self._invalid_value = None
+
+    @property
+    def unit_scale(self) -> float:
+        """Multiplier from raw stored values to scene-unit depth."""
+        return self._unit_scale
+
+    @property
+    def scale(self) -> DepthScale:
+        """Whether the depths track scene transforms (METRIC) or are scale-invariant (RELATIVE)."""
+        return self._scale
+
+    @property
+    def missing_policy(self) -> DepthMissingPolicy:
+        """How invalid pixels are encoded in the on-disk rasters."""
+        return self._missing_policy
+
+    @property
+    def invalid_value(self) -> float | None:
+        """Sentinel value used when ``missing_policy == SENTINEL``; ``None`` otherwise."""
+        return self._invalid_value
+
+    @staticmethod
+    def type_name() -> str:
+        return "DepthMapAttribute"
+
+    def _replace_paths(self, new_paths: list[str]) -> "DepthMapAttribute":
+        return DepthMapAttribute(
+            paths=new_paths,
+            unit_scale=self._unit_scale,
+            scale=self._scale,
+            missing_policy=self._missing_policy,
+            invalid_value=self._invalid_value,
+            resize_interpolation=self._resize_interpolation,
+        )
+
+    # -- Hook overrides ------------------------------------------------------
+
+    def on_filter_images(self, mask: np.ndarray) -> "DepthMapAttribute":
+        return self._replace_paths([p for p, keep in zip(self._paths, mask) if keep])
+
+    def on_select_images(self, indices: np.ndarray) -> "DepthMapAttribute":
+        return self._replace_paths([self._paths[i] for i in indices])
+
+    def on_downsample_images(self, attr_name: str, downsample_factor: int, output_cache: Any) -> "DepthMapAttribute":
+        downsampled = super().on_downsample_images(attr_name, downsample_factor, output_cache)
+        return self._replace_paths(downsampled.paths)
+
+    def on_spatial_transform(self, matrix: np.ndarray) -> "DepthMapAttribute":
+        """Fold the linear scale of ``matrix`` into ``unit_scale`` (METRIC only).
+
+        For ``scale == RELATIVE`` this is a no-op. For ``scale == METRIC`` the 3x3
+        linear part of ``matrix`` must be a similarity (uniform scale, no reflection);
+        any other transform raises :class:`ValueError` rather than silently producing
+        anisotropically deformed depth.
+        """
+        if self._scale != DepthScale.METRIC:
+            return self
+
+        linear = matrix[:3, :3]
+        svals = np.linalg.svd(linear, compute_uv=False)
+        # Allow a small relative tolerance because normalize_scene builds the transform
+        # in float64 from accumulated outer products.
+        if svals[0] > 0 and not np.allclose(svals, svals[0], rtol=1e-4, atol=1e-6):
+            raise ValueError(
+                f"DepthMapAttribute(scale=METRIC) requires a similarity (uniform-scale) "
+                f"spatial transform; got singular values {svals}. A non-uniform 3x3 would "
+                f"deform depth anisotropically, which cannot be represented by a single "
+                f"scalar multiplier. Convert the attribute to scale=RELATIVE if you "
+                f"intentionally want it to be invariant to such transforms."
+            )
+        if np.linalg.det(linear) < 0:
+            raise ValueError(
+                "DepthMapAttribute(scale=METRIC) does not support reflective (det<0) " "spatial transforms."
+            )
+
+        s = float(svals.mean())
+        return DepthMapAttribute(
+            paths=self._paths,
+            unit_scale=self._unit_scale * s,
+            scale=self._scale,
+            missing_policy=self._missing_policy,
+            invalid_value=self._invalid_value,
+            resize_interpolation=self._resize_interpolation,
+        )
+
+    # -- Loader (called by SfmDataset) ---------------------------------------
+
+    def load_depth(self, index: int) -> tuple[np.ndarray, np.ndarray]:
+        """Load the raw depth raster at ``index`` and apply ``unit_scale`` + validity mask.
+
+        Returns:
+            depth (np.ndarray): float32 ``(H, W)`` (or higher-rank) array. Invalid
+                pixels are set to 0 in the returned array; consult ``valid`` to
+                distinguish them from real zero depth.
+            valid (np.ndarray): bool array of the same shape as ``depth``. ``True``
+                where the depth is valid under :attr:`missing_policy`.
+        """
+        import cv2
+        import torch
+
+        path = self._paths[index]
+        ext = pathlib.Path(path).suffix.lower()
+
+        if ext in (".png", ".jpg", ".jpeg"):
+            raw = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+            if raw is None:
+                raise FileNotFoundError(f"Failed to load depth raster from {path}")
+            arr = np.asarray(raw)
+        elif ext == ".npy":
+            arr = np.load(path)
+        elif ext == ".pt":
+            loaded = torch.load(path, map_location="cpu", weights_only=False)
+            if isinstance(loaded, torch.Tensor):
+                arr = loaded.numpy()
+            elif isinstance(loaded, np.ndarray):
+                arr = loaded
+            else:
+                raise TypeError(
+                    f"DepthMapAttribute: expected torch.Tensor or numpy.ndarray in "
+                    f"{path}, got {type(loaded).__name__}."
+                )
+        else:
+            raise ValueError(f"DepthMapAttribute: unsupported file extension '{ext}' for {path}.")
+
+        # Compute the validity mask on the *raw* values (before unit_scale) so that
+        # SENTINEL values are matched in the same units the user specified.
+        if self._missing_policy == DepthMissingPolicy.NAN:
+            if not np.issubdtype(arr.dtype, np.floating):
+                raise TypeError(
+                    f"DepthMapAttribute(missing_policy=NAN): raster at {path} has dtype "
+                    f"{arr.dtype}, which cannot represent NaN. Use ZERO or SENTINEL."
+                )
+            valid = ~np.isnan(arr)
+        elif self._missing_policy == DepthMissingPolicy.ZERO:
+            valid = arr > 0
+        else:  # SENTINEL
+            assert self._invalid_value is not None
+            valid = arr != self._invalid_value
+
+        depth = arr.astype(np.float32, copy=False) * np.float32(self._unit_scale)
+        depth = np.where(valid, depth, np.float32(0.0))
+        return depth, valid
+
+    # -- Serialization -------------------------------------------------------
+
+    def state_dict(self) -> dict:
+        return {
+            "paths": self._paths,
+            "unit_scale": self._unit_scale,
+            "scale": self._scale.value,
+            "missing_policy": self._missing_policy.value,
+            "invalid_value": self._invalid_value,
+            "resize_interpolation": self._resize_interpolation.value,
+        }
+
+    @staticmethod
+    def from_state_dict(state_dict: dict) -> "DepthMapAttribute":
+        return DepthMapAttribute(
+            paths=list(state_dict["paths"]),
+            unit_scale=float(state_dict.get("unit_scale", 1.0)),
+            scale=DepthScale(state_dict.get("scale", DepthScale.METRIC.value)),
+            missing_policy=DepthMissingPolicy(state_dict.get("missing_policy", DepthMissingPolicy.NAN.value)),
+            invalid_value=state_dict.get("invalid_value"),
+            resize_interpolation=InterpolationMode(
+                state_dict.get("resize_interpolation", InterpolationMode.NEAREST.value)
+            ),
+        )
+
+    # -- Helpers -------------------------------------------------------------
+
+    @staticmethod
+    def warn_if_scene_already_transformed(scene: Any, attr_name: str = "depth") -> None:
+        """Emit a warning if ``scene`` already has a non-identity transformation matrix.
+
+        Call this from user code at the moment a METRIC depth attribute is attached to
+        a scene to surface the most common footgun (attaching metric depths after
+        :class:`NormalizeScene` has run). The check is best-effort and only logs.
+        """
+        import warnings
+
+        try:
+            transform = np.asarray(scene.transformation_matrix)
+        except AttributeError:
+            return
+        if not np.allclose(transform, np.eye(4), atol=1e-6):
+            warnings.warn(
+                f"Attaching DepthMapAttribute(scale=METRIC) '{attr_name}' to a scene whose "
+                f"transformation_matrix is not identity. The on-disk depths must already be "
+                f"in the *transformed* scene's units, or unit_scale must compensate. "
+                f"Apply DepthMapAttribute before transforms (e.g. NormalizeScene) so that "
+                f"on_spatial_transform can fold the scale automatically.",
+                stacklevel=2,
+            )

--- a/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
+++ b/fvdb_reality_capture/sfm_scene/depth_map_attribute.py
@@ -241,7 +241,10 @@ class DepthMapAttribute(PerImageRasterAttribute):
         elif ext == ".pt":
             loaded = torch.load(path, map_location="cpu", weights_only=False)
             if isinstance(loaded, torch.Tensor):
-                arr = loaded.numpy()
+                # detach()+cpu() so a tensor saved with requires_grad or on a non-CPU
+                # device still converts cleanly; contiguous() guards against numpy()
+                # rejecting a non-contiguous view.
+                arr = loaded.detach().cpu().contiguous().numpy()
             elif isinstance(loaded, np.ndarray):
                 arr = loaded
             else:

--- a/tests/benchmarks/contract.py
+++ b/tests/benchmarks/contract.py
@@ -61,6 +61,8 @@ RECONSTRUCTION_CONFIG_KEYS = {
     "ssim_lambda",
     "lpips_net",
     "sparse_depth_reg",
+    "dense_depth_attribute",
+    "dense_depth_reg",
     "random_bkgd",
     "refine_start_epoch",
     "refine_stop_epoch",

--- a/tests/unit/test_dense_depth_supervision.py
+++ b/tests/unit/test_dense_depth_supervision.py
@@ -93,6 +93,22 @@ class TestScaleShiftInvariantL1(unittest.TestCase):
         self.assertIsNotNone(pred.grad)
         self.assertTrue(torch.isfinite(pred.grad).all())
 
+    def test_batched_matches_per_image_mean(self):
+        # Batch>1 with differing valid-pixel counts per element: result must equal the
+        # mean of the per-image losses computed independently.
+        torch.manual_seed(0)
+        pred = torch.rand(3, 8, 8) + 0.5
+        target = torch.rand(3, 8, 8) + 0.5
+        valid = torch.ones(3, 8, 8, dtype=torch.bool)
+        valid[1, :, 5:] = False  # element 1 has fewer valid pixels
+        valid[2] = False  # element 2 fully invalid -> contributes 0
+
+        batched = _scale_shift_invariant_l1(pred, target, valid).item()
+        per_image = [
+            _scale_shift_invariant_l1(pred[i : i + 1], target[i : i + 1], valid[i : i + 1]).item() for i in range(3)
+        ]
+        self.assertAlmostEqual(batched, sum(per_image) / 3.0, places=5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_dense_depth_supervision.py
+++ b/tests/unit/test_dense_depth_supervision.py
@@ -1,0 +1,98 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+"""CPU-only coverage for the dense-depth supervision plumbing.
+
+The full training loop is exercised by the GPU tests in ``test_training.py``;
+here we cover the two pure pieces of new logic without needing a model or GPU:
+
+- ``_needs_depth_render`` -- the predicate that makes the render backend emit a
+  depth channel for either sparse or dense depth supervision.
+- ``_scale_shift_invariant_l1`` -- the RELATIVE-mode loss, which must be
+  invariant to a per-image affine between prediction and target.
+"""
+
+import unittest
+
+import torch
+
+from fvdb_reality_capture.radiance_fields._gaussian_rendering import _needs_depth_render
+from fvdb_reality_capture.radiance_fields.gaussian_splat_reconstruction import (
+    GaussianSplatReconstructionConfig,
+    _scale_shift_invariant_l1,
+)
+
+
+class TestNeedsDepthRender(unittest.TestCase):
+    def test_disabled_when_no_depth_supervision(self):
+        cfg = GaussianSplatReconstructionConfig(sparse_depth_reg=0.0, dense_depth_reg=0.0)
+        self.assertFalse(_needs_depth_render(cfg))
+
+    def test_enabled_by_sparse_depth(self):
+        cfg = GaussianSplatReconstructionConfig(sparse_depth_reg=0.1, dense_depth_reg=0.0)
+        self.assertTrue(_needs_depth_render(cfg))
+
+    def test_enabled_by_dense_depth(self):
+        cfg = GaussianSplatReconstructionConfig(sparse_depth_reg=0.0, dense_depth_reg=0.5)
+        self.assertTrue(_needs_depth_render(cfg))
+
+    def test_enabled_by_both(self):
+        cfg = GaussianSplatReconstructionConfig(sparse_depth_reg=0.2, dense_depth_reg=0.5)
+        self.assertTrue(_needs_depth_render(cfg))
+
+
+class TestScaleShiftInvariantL1(unittest.TestCase):
+    def test_identical_is_zero(self):
+        target = torch.rand(1, 8, 8) + 0.5
+        valid = torch.ones(1, 8, 8, dtype=torch.bool)
+        self.assertAlmostEqual(_scale_shift_invariant_l1(target.clone(), target, valid).item(), 0.0, places=6)
+
+    def test_invariant_to_affine(self):
+        # An arbitrary positive scale + shift of the target must yield ~zero loss.
+        target = torch.rand(1, 16, 16) + 0.5
+        valid = torch.ones(1, 16, 16, dtype=torch.bool)
+        pred = 3.7 * target + 2.1
+        self.assertLess(_scale_shift_invariant_l1(pred, target, valid).item(), 1e-5)
+
+    def test_detects_non_affine_difference(self):
+        # A genuinely different (non-affine) prediction must produce a positive loss.
+        target = torch.rand(1, 16, 16) + 0.5
+        valid = torch.ones(1, 16, 16, dtype=torch.bool)
+        pred = target**2
+        self.assertGreater(_scale_shift_invariant_l1(pred, target, valid).item(), 1e-3)
+
+    def test_respects_valid_mask(self):
+        # Garbage in the invalid region must not affect the loss.
+        target = torch.rand(1, 8, 8) + 0.5
+        valid = torch.ones(1, 8, 8, dtype=torch.bool)
+        valid[0, :, 4:] = False
+        pred = 2.0 * target + 1.0  # affine-related on valid pixels
+        clean = _scale_shift_invariant_l1(pred, target, valid).item()
+
+        corrupted = target.clone()
+        corrupted[0, :, 4:] = 1e6  # only invalid pixels corrupted
+        pred_corrupt = 2.0 * corrupted + 1.0
+        # Recompute pred from the (corrupted) target on invalid pixels only;
+        # valid pixels are identical, so the masked loss must match.
+        pred_corrupt[0, :, :4] = pred[0, :, :4]
+        masked = _scale_shift_invariant_l1(pred_corrupt, target, valid).item()
+        self.assertAlmostEqual(clean, masked, places=5)
+
+    def test_empty_mask_returns_zero(self):
+        target = torch.rand(1, 8, 8) + 0.5
+        pred = torch.rand(1, 8, 8) + 0.5
+        valid = torch.zeros(1, 8, 8, dtype=torch.bool)
+        self.assertEqual(_scale_shift_invariant_l1(pred, target, valid).item(), 0.0)
+
+    def test_is_differentiable(self):
+        target = torch.rand(1, 8, 8) + 0.5
+        valid = torch.ones(1, 8, 8, dtype=torch.bool)
+        pred = (torch.rand(1, 8, 8) + 0.5).requires_grad_(True)
+        loss = _scale_shift_invariant_l1(pred, target, valid)
+        loss.backward()
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_scene_attributes.py
+++ b/tests/unit/test_scene_attributes.py
@@ -649,6 +649,19 @@ class TestDepthMapAttribute(unittest.TestCase):
             np.testing.assert_array_equal(valid, np.array([[True, False, True], [False, True, True]]))
             np.testing.assert_allclose(depth, np.array([[1.0, 0.0, 2.0], [0.0, 3.0, 4.0]], dtype=np.float32))
 
+    def test_load_depth_pt_requires_grad(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # A .pt tensor saved with requires_grad=True must still load cleanly.
+            tensor = (torch.arange(6, dtype=torch.float32).reshape(2, 3) + 1.0).requires_grad_(True)
+            pt_path = pathlib.Path(tmp_dir) / "depth.pt"
+            torch.save(tensor, str(pt_path))
+
+            attr = DepthMapAttribute(paths=[str(pt_path)], missing_policy=DepthMissingPolicy.ZERO)
+            depth, valid = attr.load_depth(0)
+            self.assertEqual(depth.shape, (2, 3))
+            np.testing.assert_allclose(depth, np.arange(1, 7, dtype=np.float32).reshape(2, 3))
+            self.assertTrue(valid.all())
+
     def test_load_depth_nan_policy_rejects_integer_raster(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             arr = np.array([[1, 2], [3, 4]], dtype=np.int32)

--- a/tests/unit/test_scene_attributes.py
+++ b/tests/unit/test_scene_attributes.py
@@ -13,6 +13,9 @@ import torch
 from fvdb import CameraModel
 
 from fvdb_reality_capture.sfm_scene import (
+    DepthMapAttribute,
+    DepthMissingPolicy,
+    DepthScale,
     InterpolationMode,
     PerCameraAttribute,
     PerImageRasterAttribute,
@@ -487,6 +490,219 @@ class TestPerImageRasterAttribute(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             attr.validate("features", 10, 5, {0, 1})
         self.assertIn("features", str(ctx.exception))
+
+
+class TestDepthMapAttribute(unittest.TestCase):
+    def test_registered_in_registry(self):
+        self.assertIn("DepthMapAttribute", REGISTERED_SCENE_ATTRIBUTES)
+        self.assertIs(REGISTERED_SCENE_ATTRIBUTES["DepthMapAttribute"], DepthMapAttribute)
+
+    def test_defaults(self):
+        attr = DepthMapAttribute(["a.npy"])
+        self.assertEqual(attr.unit_scale, 1.0)
+        self.assertEqual(attr.scale, DepthScale.METRIC)
+        self.assertEqual(attr.missing_policy, DepthMissingPolicy.NAN)
+        self.assertIsNone(attr.invalid_value)
+        self.assertEqual(attr.resize_interpolation, InterpolationMode.NEAREST)
+
+    def test_sentinel_requires_invalid_value(self):
+        with self.assertRaises(ValueError):
+            DepthMapAttribute(["a.npy"], missing_policy=DepthMissingPolicy.SENTINEL)
+
+    def test_non_sentinel_rejects_invalid_value(self):
+        with self.assertRaises(ValueError):
+            DepthMapAttribute(["a.npy"], missing_policy=DepthMissingPolicy.NAN, invalid_value=-1.0)
+
+    def test_filter_images_preserves_metadata(self):
+        attr = DepthMapAttribute(
+            ["a.npy", "b.npy", "c.npy"],
+            unit_scale=0.001,
+            scale=DepthScale.METRIC,
+            missing_policy=DepthMissingPolicy.ZERO,
+        )
+        filtered = attr.on_filter_images(np.array([True, False, True]))
+        self.assertIsInstance(filtered, DepthMapAttribute)
+        self.assertEqual(filtered.paths, ["a.npy", "c.npy"])
+        self.assertEqual(filtered.unit_scale, 0.001)
+        self.assertEqual(filtered.scale, DepthScale.METRIC)
+        self.assertEqual(filtered.missing_policy, DepthMissingPolicy.ZERO)
+
+    def test_select_images_preserves_metadata(self):
+        attr = DepthMapAttribute(["a.npy", "b.npy", "c.npy"], unit_scale=2.0)
+        selected = attr.on_select_images(np.array([2, 0]))
+        self.assertIsInstance(selected, DepthMapAttribute)
+        self.assertEqual(selected.paths, ["c.npy", "a.npy"])
+        self.assertEqual(selected.unit_scale, 2.0)
+
+    def test_spatial_transform_metric_uniform_scale(self):
+        attr = DepthMapAttribute(["a.npy"], unit_scale=0.001, scale=DepthScale.METRIC)
+        transform = np.eye(4) * 3.0
+        transform[3, 3] = 1.0  # bottom-right stays 1
+        transformed = attr.on_spatial_transform(transform)
+        self.assertAlmostEqual(transformed.unit_scale, 0.001 * 3.0, places=6)
+        # Original is untouched
+        self.assertEqual(attr.unit_scale, 0.001)
+
+    def test_spatial_transform_metric_with_translation(self):
+        # Build a similarity transform: 2x scale + rotation + translation.
+        theta = 0.3
+        R = np.array([[np.cos(theta), -np.sin(theta), 0], [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
+        transform = np.eye(4)
+        transform[:3, :3] = 2.0 * R
+        transform[:3, 3] = [10.0, -5.0, 2.0]
+        attr = DepthMapAttribute(["a.npy"], unit_scale=1.0)
+        transformed = attr.on_spatial_transform(transform)
+        self.assertAlmostEqual(transformed.unit_scale, 2.0, places=6)
+
+    def test_spatial_transform_relative_is_noop(self):
+        attr = DepthMapAttribute(["a.npy"], unit_scale=2.5, scale=DepthScale.RELATIVE)
+        transform = np.eye(4) * 7.0
+        transform[3, 3] = 1.0
+        transformed = attr.on_spatial_transform(transform)
+        self.assertIs(transformed, attr)
+
+    def test_spatial_transform_metric_non_similarity_raises(self):
+        attr = DepthMapAttribute(["a.npy"], scale=DepthScale.METRIC)
+        # Non-uniform diagonal scale -> different singular values.
+        transform = np.diag([2.0, 3.0, 4.0, 1.0])
+        with self.assertRaises(ValueError) as ctx:
+            attr.on_spatial_transform(transform)
+        self.assertIn("similarity", str(ctx.exception))
+
+    def test_spatial_transform_metric_reflection_raises(self):
+        attr = DepthMapAttribute(["a.npy"], scale=DepthScale.METRIC)
+        # Pure reflection: det = -1.
+        transform = np.eye(4)
+        transform[0, 0] = -1.0
+        with self.assertRaises(ValueError):
+            attr.on_spatial_transform(transform)
+
+    def test_state_dict_round_trip(self):
+        attr = DepthMapAttribute(
+            paths=["a.npy", "b.npy"],
+            unit_scale=0.5,
+            scale=DepthScale.RELATIVE,
+            missing_policy=DepthMissingPolicy.SENTINEL,
+            invalid_value=-1.0,
+            resize_interpolation=InterpolationMode.BILINEAR,
+        )
+        sd = attr.state_dict()
+        restored = DepthMapAttribute.from_state_dict(sd)
+        self.assertEqual(restored.paths, ["a.npy", "b.npy"])
+        self.assertEqual(restored.unit_scale, 0.5)
+        self.assertEqual(restored.scale, DepthScale.RELATIVE)
+        self.assertEqual(restored.missing_policy, DepthMissingPolicy.SENTINEL)
+        self.assertEqual(restored.invalid_value, -1.0)
+        self.assertEqual(restored.resize_interpolation, InterpolationMode.BILINEAR)
+
+    def test_load_depth_zero_policy_png16(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # 16-bit single-channel PNG with depths in millimeters; 0 marks invalid.
+            depth_mm = np.array([[0, 1000, 2000], [3000, 0, 1500]], dtype=np.uint16)
+            png_path = pathlib.Path(tmp_dir) / "depth.png"
+            cv2.imwrite(str(png_path), depth_mm)
+
+            attr = DepthMapAttribute(
+                paths=[str(png_path)],
+                unit_scale=0.001,
+                missing_policy=DepthMissingPolicy.ZERO,
+            )
+            depth, valid = attr.load_depth(0)
+            self.assertEqual(depth.dtype, np.float32)
+            self.assertEqual(depth.shape, (2, 3))
+            self.assertEqual(valid.dtype, np.bool_)
+            np.testing.assert_array_equal(valid, np.array([[False, True, True], [True, False, True]]))
+            # Valid pixels converted to meters; invalid pixels zeroed.
+            expected = np.array([[0.0, 1.0, 2.0], [3.0, 0.0, 1.5]], dtype=np.float32)
+            np.testing.assert_allclose(depth, expected, rtol=1e-6)
+
+    def test_load_depth_nan_policy_npy(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            arr = np.array([[1.5, np.nan, 2.5], [np.nan, 3.5, 4.5]], dtype=np.float32)
+            npy_path = pathlib.Path(tmp_dir) / "depth.npy"
+            np.save(str(npy_path), arr)
+
+            attr = DepthMapAttribute(
+                paths=[str(npy_path)],
+                unit_scale=2.0,
+                missing_policy=DepthMissingPolicy.NAN,
+            )
+            depth, valid = attr.load_depth(0)
+            np.testing.assert_array_equal(valid, np.array([[True, False, True], [False, True, True]]))
+            expected = np.array([[3.0, 0.0, 5.0], [0.0, 7.0, 9.0]], dtype=np.float32)
+            np.testing.assert_allclose(depth, expected, rtol=1e-6)
+            self.assertTrue(np.isfinite(depth).all())
+
+    def test_load_depth_sentinel_policy(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            arr = np.array([[1.0, -1.0, 2.0], [-1.0, 3.0, 4.0]], dtype=np.float32)
+            npy_path = pathlib.Path(tmp_dir) / "depth.npy"
+            np.save(str(npy_path), arr)
+
+            attr = DepthMapAttribute(
+                paths=[str(npy_path)],
+                unit_scale=1.0,
+                missing_policy=DepthMissingPolicy.SENTINEL,
+                invalid_value=-1.0,
+            )
+            depth, valid = attr.load_depth(0)
+            np.testing.assert_array_equal(valid, np.array([[True, False, True], [False, True, True]]))
+            np.testing.assert_allclose(depth, np.array([[1.0, 0.0, 2.0], [0.0, 3.0, 4.0]], dtype=np.float32))
+
+    def test_load_depth_nan_policy_rejects_integer_raster(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            arr = np.array([[1, 2], [3, 4]], dtype=np.int32)
+            npy_path = pathlib.Path(tmp_dir) / "depth.npy"
+            np.save(str(npy_path), arr)
+            attr = DepthMapAttribute(
+                paths=[str(npy_path)],
+                missing_policy=DepthMissingPolicy.NAN,
+            )
+            with self.assertRaises(TypeError):
+                attr.load_depth(0)
+
+    def test_validate_through_sfm_scene(self):
+        scene = _make_synthetic_scene(num_points=20, num_images=4)
+        # Wrong number of paths must be rejected by SfmScene's validate hook.
+        with self.assertRaises(ValueError):
+            scene.replace(attributes={"depth": DepthMapAttribute(["only_one.npy"])})
+        # Correct number passes.
+        scene2 = scene.replace(attributes={"depth": DepthMapAttribute([f"d{i}.npy" for i in range(4)])})
+        self.assertIsInstance(scene2.get_attribute("depth"), DepthMapAttribute)
+
+    def test_apply_transformation_matrix_folds_scale(self):
+        # End-to-end: SfmScene.apply_transformation_matrix should fold the scale into unit_scale.
+        scene = _make_synthetic_scene(num_points=20, num_images=4)
+        attr = DepthMapAttribute(
+            paths=[f"d{i}.npy" for i in range(4)],
+            unit_scale=0.001,
+            scale=DepthScale.METRIC,
+        )
+        scene = scene.replace(attributes={"depth": attr})
+        T = np.eye(4) * 4.0
+        T[3, 3] = 1.0
+        scene2 = scene.apply_transformation_matrix(T)
+        attr2 = scene2.get_attribute("depth")
+        self.assertIsInstance(attr2, DepthMapAttribute)
+        self.assertAlmostEqual(attr2.unit_scale, 0.001 * 4.0, places=6)
+
+    def test_warn_on_attaching_metric_to_transformed_scene(self):
+        scene = _make_synthetic_scene(num_points=20, num_images=4)
+        T = np.eye(4) * 2.0
+        T[3, 3] = 1.0
+        scene = scene.apply_transformation_matrix(T)
+        # scene now has non-identity transformation_matrix; helper should warn.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            DepthMapAttribute.warn_if_scene_already_transformed(scene, attr_name="depth")
+            self.assertTrue(any("transformation_matrix is not identity" in str(w.message) for w in caught))
+
+    def test_warn_is_silent_on_identity_scene(self):
+        scene = _make_synthetic_scene(num_points=20, num_images=4)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            DepthMapAttribute.warn_if_scene_already_transformed(scene, attr_name="depth")
+            self.assertEqual(len(caught), 0)
 
 
 class TestPerCameraAttribute(unittest.TestCase):

--- a/tests/unit/test_scene_attributes.py
+++ b/tests/unit/test_scene_attributes.py
@@ -1415,7 +1415,7 @@ class TestSfmDatasetRasterAttributePatchCrop(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             scene, _ = self._make_scene_with_raster(tmp_dir)
-            for reserved in ("image", "projection", "mask", "sparse_depth"):
+            for reserved in ("image", "projection", "mask", "sparse_depth", "camera_model", "distortion_coeffs"):
                 scene_with_attr = scene.replace(
                     attributes={reserved: PerImageValueAttribute(values=[1.0])},
                 )

--- a/tests/unit/test_scene_attributes.py
+++ b/tests/unit/test_scene_attributes.py
@@ -577,6 +577,25 @@ class TestDepthMapAttribute(unittest.TestCase):
         with self.assertRaises(ValueError):
             attr.on_spatial_transform(transform)
 
+    def test_spatial_transform_metric_degenerate_scale_raises(self):
+        # A rank-deficient / near-zero-scale transform must be rejected, not folded
+        # into unit_scale as s~=0 (which would zero out all depths).
+        attr = DepthMapAttribute(["a.npy"], scale=DepthScale.METRIC)
+        transform = np.zeros((4, 4))
+        transform[3, 3] = 1.0
+        with self.assertRaises(ValueError) as ctx:
+            attr.on_spatial_transform(transform)
+        self.assertIn("degenerate", str(ctx.exception))
+
+    def test_warn_handles_none_transformation_matrix(self):
+        class _NoTransform:
+            transformation_matrix = None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            DepthMapAttribute.warn_if_scene_already_transformed(_NoTransform(), attr_name="depth")
+            self.assertEqual(len(caught), 0)
+
     def test_state_dict_round_trip(self):
         attr = DepthMapAttribute(
             paths=["a.npy", "b.npy"],

--- a/tests/unit/test_scene_attributes.py
+++ b/tests/unit/test_scene_attributes.py
@@ -661,6 +661,26 @@ class TestDepthMapAttribute(unittest.TestCase):
             with self.assertRaises(TypeError):
                 attr.load_depth(0)
 
+    def test_load_depth_squeezes_singleton_channel(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            arr = np.array([[1.0], [2.0]], dtype=np.float32).reshape(2, 1, 1)  # (H, W, 1)
+            npy_path = pathlib.Path(tmp_dir) / "depth.npy"
+            np.save(str(npy_path), arr)
+            attr = DepthMapAttribute(paths=[str(npy_path)], missing_policy=DepthMissingPolicy.ZERO)
+            depth, valid = attr.load_depth(0)
+            self.assertEqual(depth.shape, (2, 1))
+            self.assertEqual(valid.shape, (2, 1))
+
+    def test_load_depth_multichannel_raises(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            arr = np.random.rand(4, 5, 3).astype(np.float32)  # RGB-like, not a depth map
+            npy_path = pathlib.Path(tmp_dir) / "rgb.npy"
+            np.save(str(npy_path), arr)
+            attr = DepthMapAttribute(paths=[str(npy_path)], missing_policy=DepthMissingPolicy.ZERO)
+            with self.assertRaises(ValueError) as ctx:
+                attr.load_depth(0)
+            self.assertIn("single-channel", str(ctx.exception))
+
     def test_validate_through_sfm_scene(self):
         scene = _make_synthetic_scene(num_points=20, num_images=4)
         # Wrong number of paths must be rejected by SfmScene's validate hook.
@@ -1420,6 +1440,67 @@ class TestSfmDatasetRasterAttributePatchCrop(unittest.TestCase):
             dataset = SfmDataset(sfm_scene=scene, load_attributes=attrs)
             attrs.append("nonexistent")
             self.assertEqual(len(dataset._load_attributes), 1)
+
+    def _make_scene_with_depth(self, tmp_dir, attr_names, h=48, w=64):
+        """Build a single-image scene carrying one DepthMapAttribute per name in ``attr_names``."""
+        tmp = pathlib.Path(tmp_dir)
+        img = np.random.randint(0, 255, (h, w, 3), dtype=np.uint8)
+        img_path = tmp / "image_0.png"
+        cv2.imwrite(str(img_path), img)
+
+        camera = _make_camera_metadata(width=w, height=h)
+        images = [
+            SfmPosedImageMetadata(
+                world_to_camera_matrix=np.eye(4, dtype=np.float64),
+                camera_to_world_matrix=np.eye(4, dtype=np.float64),
+                camera_metadata=camera,
+                camera_id=1,
+                image_path=str(img_path),
+                mask_path="",
+                point_indices=None,
+                image_id=0,
+            )
+        ]
+        attributes = {}
+        for name in attr_names:
+            depth = np.ones((h, w), dtype=np.float32)
+            depth_path = tmp / f"{name}_0.npy"
+            np.save(str(depth_path), depth)
+            attributes[name] = DepthMapAttribute(paths=[str(depth_path)], missing_policy=DepthMissingPolicy.ZERO)
+
+        cache = SfmCache.get_cache(tmp, name="test", description="test")
+        return SfmScene(
+            cameras={1: camera},
+            images=images,
+            points=np.random.randn(10, 3).astype(np.float32),
+            points_err=np.random.rand(10).astype(np.float32),
+            points_rgb=np.random.randint(0, 255, (10, 3), dtype=np.uint8),
+            scene_bbox=None,
+            transformation_matrix=None,
+            cache=cache,
+            attributes=attributes,
+        )
+
+    def test_depth_attribute_emits_depth_and_valid(self):
+        from fvdb_reality_capture.radiance_fields.gaussian_splat_dataset import SfmDataset
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scene = self._make_scene_with_depth(tmp_dir, ["depth"])
+            datum = SfmDataset(sfm_scene=scene, load_attributes=["depth"])[0]
+            self.assertIn("depth", datum)
+            self.assertIn("depth_valid", datum)
+            self.assertEqual(datum["depth_valid"].dtype, torch.bool)
+
+    def test_depth_validity_sibling_collision_raises(self):
+        from fvdb_reality_capture.radiance_fields.gaussian_splat_dataset import SfmDataset
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # "depth" emits a "depth_valid" key, which collides with the separately
+            # requested "depth_valid" depth attribute.
+            scene = self._make_scene_with_depth(tmp_dir, ["depth", "depth_valid"])
+            with self.assertRaises(ValueError) as ctx:
+                SfmDataset(sfm_scene=scene, load_attributes=["depth", "depth_valid"])
+            self.assertIn("depth_valid", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_scene_attributes.py
+++ b/tests/unit/test_scene_attributes.py
@@ -597,22 +597,47 @@ class TestDepthMapAttribute(unittest.TestCase):
             self.assertEqual(len(caught), 0)
 
     def test_state_dict_round_trip(self):
+        # SENTINEL + invalid_value round-trip (NEAREST: the only interpolation valid with
+        # a non-NaN missing policy).
         attr = DepthMapAttribute(
             paths=["a.npy", "b.npy"],
             unit_scale=0.5,
             scale=DepthScale.RELATIVE,
             missing_policy=DepthMissingPolicy.SENTINEL,
             invalid_value=-1.0,
-            resize_interpolation=InterpolationMode.BILINEAR,
+            resize_interpolation=InterpolationMode.NEAREST,
         )
-        sd = attr.state_dict()
-        restored = DepthMapAttribute.from_state_dict(sd)
+        restored = DepthMapAttribute.from_state_dict(attr.state_dict())
         self.assertEqual(restored.paths, ["a.npy", "b.npy"])
         self.assertEqual(restored.unit_scale, 0.5)
         self.assertEqual(restored.scale, DepthScale.RELATIVE)
         self.assertEqual(restored.missing_policy, DepthMissingPolicy.SENTINEL)
         self.assertEqual(restored.invalid_value, -1.0)
-        self.assertEqual(restored.resize_interpolation, InterpolationMode.BILINEAR)
+        self.assertEqual(restored.resize_interpolation, InterpolationMode.NEAREST)
+
+        # A non-default interpolation round-trips too (paired with the NaN policy).
+        attr2 = DepthMapAttribute(
+            paths=["a.npy"],
+            missing_policy=DepthMissingPolicy.NAN,
+            resize_interpolation=InterpolationMode.BICUBIC,
+        )
+        restored2 = DepthMapAttribute.from_state_dict(attr2.state_dict())
+        self.assertEqual(restored2.resize_interpolation, InterpolationMode.BICUBIC)
+        self.assertEqual(restored2.missing_policy, DepthMissingPolicy.NAN)
+
+    def test_non_nearest_interp_with_non_nan_policy_raises(self):
+        for policy in (DepthMissingPolicy.ZERO, DepthMissingPolicy.SENTINEL):
+            kwargs = {"invalid_value": -1.0} if policy == DepthMissingPolicy.SENTINEL else {}
+            for interp in (InterpolationMode.AREA, InterpolationMode.BILINEAR, InterpolationMode.BICUBIC):
+                with self.assertRaises(ValueError) as ctx:
+                    DepthMapAttribute(paths=["a.npy"], missing_policy=policy, resize_interpolation=interp, **kwargs)
+                self.assertIn("unsafe", str(ctx.exception))
+        # NEAREST is allowed with any policy.
+        DepthMapAttribute(paths=["a.npy"], missing_policy=DepthMissingPolicy.ZERO)
+        # Averaging interpolation is allowed with the NaN policy.
+        DepthMapAttribute(
+            paths=["a.npy"], missing_policy=DepthMissingPolicy.NAN, resize_interpolation=InterpolationMode.BILINEAR
+        )
 
     def test_load_depth_zero_policy_png16(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Adds a new `DepthMapAttribute` (subclass of `PerImageRasterAttribute`) for per-image depth rasters with scale-aware semantics, and wires optional dense depth supervision into `GaussianSplatReconstruction`. Six files changed, +697 / −5.

### `DepthMapAttribute`

- **`DepthScale.METRIC`** depths track the scene's coordinate system. The linear scale of any subsequent spatial transform is folded into `unit_scale` at attribute level rather than rewriting the rasters on disk. Non-similarity or reflective transforms raise rather than silently produce anisotropically deformed depth — this closes the most likely footgun (running `NormalizeScene` after attaching metric depths).
- **`DepthScale.RELATIVE`** depths (e.g. from a monocular relative-depth estimator) are dimensionless and immune to scene transforms.
- **`DepthMissingPolicy.{NAN,ZERO,SENTINEL}`** controls the validity convention so the loader emits a per-pixel validity mask alongside the depth tensor. Default downsample interpolation is `NEAREST` to avoid bilerping across depth discontinuities.

### Reconstructor wiring

- New config fields `dense_depth_attribute` and `dense_depth_reg`. The loss form is keyed off `DepthMapAttribute.scale`:
  - **METRIC** → masked L1 on absolute depths.
  - **RELATIVE** → scale-and-shift invariant L1 (each side normalized by its own median + MAD, per Ranftl et al., MiDaS).
- `SfmDataset` detects `DepthMapAttribute` and emits both `data[name]` and `data[f"{name}_valid"]`.
- `_needs_depth_render(config)` now ORs `sparse_depth_reg` and `dense_depth_reg` so the renderer emits the depth channel for either path — without this, dense-depth-only configs would silently fail with a `None` depth tensor.

## Test plan

- [x] 20 new unit tests in `TestDepthMapAttribute` cover attribute hooks (filter/select/spatial transform), validity policies, loader formats (16-bit PNG, float NPY, sentinel float NPY), state-dict round-trip, similarity-transform enforcement, and end-to-end `apply_transformation_matrix` scale folding. `cd tests && pytest unit/test_scene_attributes.py` passes all 108 tests.
- [ ] End-to-end training-time exercise with a real scene + sensor depth (METRIC) and monocular depth (RELATIVE) — not yet run in CI.

## Notes

- `batch_size > 1` raises `NotImplementedError` for dense depth, symmetric with the existing sparse-depth path.
- Dense depth supervision is fully decoupled from `sparse_depth_reg` / `has_visible_point_indices` — works on any scene with a `DepthMapAttribute`.