### PR TITLE
Fix TSDF integration for fvdb-core's batched image API

### DIFF
--- a/fvdb_reality_capture/tools/_tsdf_from_splats.py
+++ b/fvdb_reality_capture/tools/_tsdf_from_splats.py
@@ -201,16 +201,20 @@ def tsdf_from_splats(
             weight_images = ((depth_images > near_i) & (depth_images < far_i) & alpha_mask).to(dtype).squeeze(0)
         else:
             weight_images = ((depth_images > near_i) & (depth_images < far_i)).to(dtype).squeeze(0)
+        # fvdb-core's TSDF integration expects a leading batch dimension whose size
+        # matches the grid batch size (1 for a single Grid): projection (B, 3, 3),
+        # cam-to-world (B, 4, 4), depth (B, H, W), features (B, H, W, C), weights
+        # (B, H, W). We integrate one camera per iteration, so B == 1.
         accum_grid, tsdf, weights, features = accum_grid.integrate_tsdf_with_features(
             truncation_margin,
-            projection_matrix.to(dtype),
-            cam_to_world_matrix.to(dtype),
+            projection_matrix.to(dtype).unsqueeze(0),
+            cam_to_world_matrix.to(dtype).unsqueeze(0),
             tsdf,
             features,
             weights,
-            depth_images,
-            feature_images,
-            weight_images,
+            depth_images.unsqueeze(0),
+            feature_images.unsqueeze(0),
+            weight_images.unsqueeze(0),
         )
 
         if show_progress:

--- a/fvdb_reality_capture/tools/_tsdf_from_splats_dlnr.py
+++ b/fvdb_reality_capture/tools/_tsdf_from_splats_dlnr.py
@@ -662,16 +662,20 @@ def tsdf_from_splats_dlnr(
             depth_image = depth_image.to(dtype)
             weight_image = weight_image.to(dtype)
 
+            # squeeze(0) drops the DataLoader collation dim; unsqueeze(0) then adds the
+            # fvdb grid-batch dim (1 for a single Grid). fvdb-core expects batched
+            # inputs: projection (B, 3, 3), cam-to-world (B, 4, 4), depth (B, H, W),
+            # features (B, H, W, C), weights (B, H, W).
             accum_grid, tsdf, weights, colors = accum_grid.integrate_tsdf_with_features(
                 truncation_margin,
-                projection_matrix.to(dtype),
-                cam_to_world_matrix.to(dtype),
+                projection_matrix.to(dtype).unsqueeze(0),
+                cam_to_world_matrix.to(dtype).unsqueeze(0),
                 tsdf,
                 colors,
                 weights,
-                depth_image.squeeze(0).to(device),
-                rgb_image.squeeze(0).to(device),
-                weight_image.squeeze(0).to(device),
+                depth_image.squeeze(0).to(device).unsqueeze(0),
+                rgb_image.squeeze(0).to(device).unsqueeze(0),
+                weight_image.squeeze(0).to(device).unsqueeze(0),
             )
 
             if show_progress:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
 license="Apache-2.0"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
-    "fvdb-core>=0.4.0",
+    "fvdb-core>=0.5.0.dev0",
     "boto3",
     "dlnr_lite",
     "nanovdb-editor<0.2.0",


### PR DESCRIPTION
## Summary

The `mesh_from_splats(...)` function call (→ `tsdf_from_splats` → `Grid.integrate_tsdf_with_features`), and `tsdf_from_splats_dlnr`, crash on current `fvdb-core` with:

```
ValueError: Depth images must be of shape (batch_size, image_height, image_width) ...
```

This fix realigns reality-capture `main` with fvdb-core `main` and fixes the [radiance field & mesh reconstruction tutorial](https://fvdb-reality-capture.readthedocs.io/latest/tutorials/radiance_field_and_mesh_reconstruction.html), which is currently broken with both `main` branches checked out.

## Root cause

`fvdb-core` #582 (`c997735`) changed `Grid.integrate_tsdf_with_features` to require a leading **batch** dimension (`B == 1` for a single `Grid`). Previously (≤ v0.4.2) it accepted unbatched images and added the batch dim internally. Our TSDF tools still pass unbatched `(H, W)` tensors, so the C++ shape check fails.

## Fix

- Add `.unsqueeze(0)` to the projection matrix, cam-to-world matrix, depth, feature, and weight tensors at both `integrate_tsdf_with_features` call sites.
- Bump `fvdb-core>=0.4.0` → `fvdb-core>=0.5.0`.

## Compatibility

This is backward-incompatible with `fvdb-core` < 0.5.0: v0.4.x requires unbatched inputs and raises on a batch dim, so a single code path can't support both contracts. (Alternative, if v0.4.x support must be kept: restore the internal `.unsqueeze(0)` in `fvdb-core`'s `Grid.integrate_tsdf_with_features`.)