### PR TITLE
Sync benchmark env to PyTorch 2.11 to match fvdb-core build

### DIFF
--- a/tests/benchmarks/comparative/docker/benchmark_environment.yml
+++ b/tests/benchmarks/comparative/docker/benchmark_environment.yml
@@ -44,7 +44,7 @@ dependencies:
   - py-opencv>=4.10[build=headless*]
   - pytest-benchmark
   - python=3.12
-  - pytorch-gpu=2.10.0
+  - pytorch-gpu=2.11.0
   - rich
   - scikit-build-core
   - scikit-learn
@@ -67,9 +67,6 @@ dependencies:
   - pip:
     - point-cloud-utils
     - pytest-markdown-docs
-    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse-2.1.0-cp312-cp312-linux_x86_64.whl
-    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torchsparse_20-2.0.0b0-cp312-cp312-linux_x86_64.whl
-    - https://fvdb-packages.s3.us-east-2.amazonaws.com/dev-whls/pt210cu130/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl
     - oiio-static-python
     - dlnr_lite
     - einops


### PR DESCRIPTION
Fixes #295

## What

Bump the comparative benchmark conda env to `pytorch-gpu=2.11.0` to match
`fvdb-core/env/build_environment.yml` (PyTorch 2.11 since fvdb-core `bd2c4de`),
and drop the unused `torchsparse` / `torchsparse_20` / `torch_scatter` pt210
wheels.

## Why

The nightly builds the fvdb-core wheel against torch 2.11 and installs it into
this env, which was still pinned to torch 2.10 -> undefined CUDA symbol at
`import fvdb` (which crashes the "Download mipnerf360 dataset" step, the first
thing that imports fvdb via `frgs`). Full diagnosis in #295.

## Test plan

This is a conda env pin; the validating test is the nightly benchmark workflow
itself, which requires a GPU runner with fvdb-core installed (per AGENTS.md the
local benchmark tests need that runner). After merge, the Comparative and Unit
benchmark jobs should get past the fvdb import and run.

The dropped sparse libraries are confirmed unused:
`grep -rn "torchsparse\|torch_scatter" --include="*.py"` returns 0 hits across
the repo.
