### PR TITLE
CI: don't skip required checks on docs-only PRs

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -29,11 +29,12 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           # Use the default 'some' quantifier: `src` is true when AT LEAST ONE
-          # changed file is a source file. A mixed PR (code + docs) therefore
-          # still runs the tests; only a PR whose files are ALL docs/non-code is
-          # treated as docs-only. Do NOT use 'every' here — that would skip the
-          # tests whenever any file is excluded (e.g. a code change that also
-          # touches a README), leaving real source changes untested.
+          # changed file is outside the excluded paths below. A PR mixing
+          # excluded and non-excluded files therefore still runs the tests; only
+          # a PR whose files are ALL in excluded paths is treated as skippable.
+          # Do NOT use 'every' here — that would skip the tests whenever any file
+          # is excluded (e.g. a code change that also touches a README), leaving
+          # real changes untested.
           filters: |
             src:
               - '**'

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -28,7 +28,12 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request_target'
         with:
-          predicate-quantifier: 'every'
+          # Use the default 'some' quantifier: `src` is true when AT LEAST ONE
+          # changed file is a source file. A mixed PR (code + docs) therefore
+          # still runs the tests; only a PR whose files are ALL docs/non-code is
+          # treated as docs-only. Do NOT use 'every' here — that would skip the
+          # tests whenever any file is excluded (e.g. a code change that also
+          # touches a README), leaving real source changes untested.
           filters: |
             src:
               - '**'

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -1,0 +1,40 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reusable workflow: detect whether a PR touches source files or only
+# documentation / non-code paths. Callers gate their real jobs on the
+# `should_test` output so that docs-only PRs are marked as passed
+# (not perpetually "waiting for status").
+
+name: Check for relevant changes
+
+on:
+  workflow_call:
+    outputs:
+      should_test:
+        description: "'true' when the change includes source files, 'false' for docs-only"
+        value: ${{ jobs.check-changes.outputs.should_test }}
+
+# Permissions are inherited from the calling workflow; do not set them here.
+
+jobs:
+  check-changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ github.event_name != 'pull_request_target' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request_target'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '**'
+              - '!**/*.md'
+              - '!CODEOWNERS'
+              - '!debug/**'
+              - '!examples/**'
+              - '!notebooks/**'
+              - '!scripts/**'

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -3,9 +3,6 @@ on:
     pull_request:
       branches:
         - main
-      paths-ignore:
-          - 'CODEOWNERS'
-          - '**.md'
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,15 @@
 name: fvdb-reality-capture Unit Tests
 
 on:
+  # No paths-ignore here: this workflow provides required status checks, and a
+  # workflow skipped via paths-ignore never reports them, leaving docs-only PRs
+  # blocked forever. Instead the check-changes job below detects docs-only
+  # changes and the expensive jobs are gated on it (reporting "skipped", which
+  # satisfies the required checks). The push trigger keeps paths-ignore since
+  # push builds are not required PR checks.
   pull_request_target:
     branches:
       - '**'
-    paths-ignore:
-        - 'CODEOWNERS'
-        - '**.md'
-        - 'debug/**'
-        - 'examples/**'
-        - 'notebooks/**'
-        - 'scripts/**'
   push:
     branches:
       - main
@@ -42,11 +41,19 @@ permissions:
   id-token: write
 
 jobs:
+  # Detect whether the PR touches source files or only docs/non-code paths.
+  # The expensive build/test jobs are gated on this so docs-only PRs skip the
+  # work while still reporting the required status checks (skipped == passed).
+  check-changes:
+    uses: ./.github/workflows/check-changes.yml
+
   ##############################################################################
   # BUILD FVDB
   ##############################################################################
   start-build-runner:
     name: Start CPU-only EC2 runner for build
+    needs: check-changes
+    if: needs.check-changes.outputs.should_test == 'true'
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-build-runner.outputs.label }}
@@ -175,7 +182,8 @@ jobs:
       - start-build-runner # required to get output from the start-build-runner job
       - fvdb-reality-capture-build # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    # Don't try to stop a runner that was never started (docs-only PRs skip start-build-runner).
+    if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -357,7 +365,8 @@ jobs:
       - fvdb-reality-capture-unit-tests # required to wait when the main job is done
       #- fvdb-reality-capture-docs-test # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    # Don't try to stop a runner that was never started (docs-only PRs skip start-tests-gpu-runner).
+    if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Problem

Docs-only PRs (e.g. the CODEOWNERS/governance-doc PR #298) are stuck **BLOCKED**. The `main` ruleset marks `fvdb-reality-capture Unit Tests`, `Check Python code style with black`, and `Check SPDX identifiers` as **required**, but `tests.yml` and `codestyle.yml` used workflow-level `paths-ignore` for `**.md`/`CODEOWNERS`. A workflow skipped via `paths-ignore` never reports its checks, so required checks sit at "Expected" forever and block the merge.

## Fix (mirrors fvdb-core)

- **codestyle.yml**: remove `paths-ignore`. The lint jobs are cheap and now always run and report.
- **tests.yml**: remove `paths-ignore` from the `pull_request_target` trigger; add a `check-changes` reusable workflow (dorny/paths-filter) and gate the expensive build/GPU jobs on `should_test`. On docs-only PRs the jobs report **skipped** (which satisfies the required check) instead of never reporting. The stop-runner jobs are guarded so they do not try to stop runners that were never started. The `push` trigger keeps `paths-ignore` (push builds are not required PR checks).

Verified: `fvdb-core` already uses this pattern and its docs-only PR #676 is CLEAN with all heavy jobs `skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)