### PR TITLE
CI: install torchvision from the PyTorch CUDA index in the smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Install fvdb-core from S3 staging and fvdb-reality-capture wheel
         run: |
           uv pip install --no-cache \
-            torch==${{ needs.discover-fvdb-core.outputs.torch-version }} \
+            torch==${{ needs.discover-fvdb-core.outputs.torch-version }} torchvision \
             --extra-index-url ${{ needs.discover-fvdb-core.outputs.pytorch-index }}
           uv pip install --no-cache \
             "${{ needs.discover-fvdb-core.outputs.core-wheel-url }}"


### PR DESCRIPTION
## Problem

The release publish workflow's **smoke-test** job fails on `release/v0.5` with:

```
RuntimeError: operator torchvision::nms does not exist
```

triggered by `import torchvision` inside `fvdb_reality_capture.foundation_models.openclip`. fvdb-core itself imports and runs fine (GridBatch works on CUDA) — only torchvision is broken.

## Root cause

The smoke-test install step installed **only `torch`** from the PyTorch CUDA `--extra-index-url`, then installed the `fvdb-reality-capture` wheel. `torchvision` is unpinned in `pyproject.toml`, so it was resolved implicitly by that later `uv pip install` — which has **no** `--extra-index-url` — pulling a torchvision build from PyPI that doesn't match the `torch==*+cu128` build. Mismatched ABIs → torchvision's C++ ops fail to register.

The **Full unit tests** job in the same workflow already installs `torch torchvision` together from the CUDA index and is unaffected.

## Fix

Add `torchvision` to the torch install line in the smoke-test job so it comes from the same PyTorch CUDA index, matching the full-test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)