### PR TITLE
Adopt release v0.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Install fvdb-core from S3 staging and fvdb-reality-capture wheel
         run: |
           uv pip install --no-cache \
-            torch==${{ needs.discover-fvdb-core.outputs.torch-version }} \
+            torch==${{ needs.discover-fvdb-core.outputs.torch-version }} torchvision \
             --extra-index-url ${{ needs.discover-fvdb-core.outputs.pytorch-index }}
           uv pip install --no-cache \
             "${{ needs.discover-fvdb-core.outputs.core-wheel-url }}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ author = "Contributors to the OpenVDB Project"
 
 # Stable fvdb-core version shown in installation examples.
 # Updated automatically by fvdb-core's devtools/update-doc-versions.sh during release.
-fvdb_core_stable_version = "0.4.0"
+fvdb_core_stable_version = "0.5.0"
 
 version = fvdb_core_stable_version
 release = fvdb_core_stable_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fvdb_reality_capture"
-version = "0.5.0"
+version = "0.6.0.dev0"
 description = "fVDB Reality Capture Toolbox."
 authors = [
     {name = "Francis Williams", email = "francis@fwilliams.info"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fvdb_reality_capture"
-version = "0.5.0.dev0"
+version = "0.5.0"
 description = "fVDB Reality Capture Toolbox."
 authors = [
     {name = "Francis Williams", email = "francis@fwilliams.info"},
@@ -22,7 +22,7 @@ authors = [
 license="Apache-2.0"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
-    "fvdb-core>=0.5.0.dev0",
+    "fvdb-core>=0.5.0dev0",
     "boto3",
     "dlnr_lite",
     "nanovdb-editor<0.2.0",


### PR DESCRIPTION
## Adopt release v0.5.0

Merge release changes from `release/v0.5` into `main` via the
`adopt/v0.5` branch. The version in `pyproject.toml` has been set to
the current `main` development version to avoid conflicts.

**Tag:** `v0.5.0`

This PR replaces the original release PR (#303) which was
closed because `release/v0.5` intentionally carries a different version
string (`0.5.0`) than `main`.

### To merge

Merge this PR once CI passes. Use a **merge commit** (not squash) to preserve
the release branch history on `main`.