### PR TITLE
Fix legacy NuRec USDZ export for SH degree 1 and 2 (#124)

### DIFF
--- a/fvdb_reality_capture/cli/frgs/_convert.py
+++ b/fvdb_reality_capture/cli/frgs/_convert.py
@@ -76,7 +76,7 @@ class Convert(BaseCommand):
 
     # Legacy export only (--legacy). SH degree to write into the exported model; must be 0 or 3
     # (the degrees the Isaac Sim < 6.0 NuRec importer supports). Directional SH coefficients are
-    # zero-padded or truncated to match. Leaving this unset promotes degree 1/2 models to 3.
+    # zero-padded or truncated to match. Leaving this unset normalizes any non-0/3 degree to 3.
     # Ignored by the default ParticleField3DGaussianSplat export, which writes the native SH degree.
     target_sh_degree: int | None = None
 

--- a/fvdb_reality_capture/cli/frgs/_convert.py
+++ b/fvdb_reality_capture/cli/frgs/_convert.py
@@ -74,6 +74,12 @@ class Convert(BaseCommand):
     # Implied if the output path already ends in .usdz.
     usdz: bool = False
 
+    # Legacy export only (--legacy). SH degree to write into the exported model; must be 0 or 3
+    # (the degrees the Isaac Sim < 6.0 NuRec importer supports). Directional SH coefficients are
+    # zero-padded or truncated to match. Leaving this unset promotes degree 1/2 models to 3.
+    # Ignored by the default ParticleField3DGaussianSplat export, which writes the native SH degree.
+    target_sh_degree: int | None = None
+
     @torch.no_grad()
     def execute(self) -> None:
         valid_input_types = (".ply", ".pt", ".pth")
@@ -118,6 +124,12 @@ class Convert(BaseCommand):
             raise ValueError("--prim-path is only supported for USD export (output file must end in .usdc or .usdz)")
         if self.legacy and self.prim_path is not None:
             raise ValueError("--legacy cannot be used with --prim-path")
+        if self.target_sh_degree is not None and not self.legacy:
+            raise ValueError("--target-sh-degree only applies to legacy export (use with --legacy)")
+        if self.target_sh_degree is not None and self.target_sh_degree not in (0, 3):
+            raise ValueError(
+                "--target-sh-degree must be 0 or 3 (the SH degrees the legacy NuRec importer supports)"
+            )
 
         if in_file_type == ".ply":
             model, metadata = GaussianSplat3d.from_ply(self.in_path)
@@ -157,6 +169,7 @@ class Convert(BaseCommand):
                 legacy=self.legacy,
                 usdz=usdz,
                 asset_name=self.prim_path,
+                target_sh_degree=self.target_sh_degree,
             )
             if self.legacy:
                 logger.info(

--- a/fvdb_reality_capture/cli/frgs/_convert.py
+++ b/fvdb_reality_capture/cli/frgs/_convert.py
@@ -127,9 +127,7 @@ class Convert(BaseCommand):
         if self.target_sh_degree is not None and not self.legacy:
             raise ValueError("--target-sh-degree only applies to legacy export (use with --legacy)")
         if self.target_sh_degree is not None and self.target_sh_degree not in (0, 3):
-            raise ValueError(
-                "--target-sh-degree must be 0 or 3 (the SH degrees the legacy NuRec importer supports)"
-            )
+            raise ValueError("--target-sh-degree must be 0 or 3 (the SH degrees the legacy NuRec importer supports)")
 
         if in_file_type == ".ply":
             model, metadata = GaussianSplat3d.from_ply(self.in_path)

--- a/fvdb_reality_capture/tools/_export_splats_to_usd.py
+++ b/fvdb_reality_capture/tools/_export_splats_to_usd.py
@@ -894,12 +894,14 @@ def build_legacy_gaussians_payload(
     Args:
         model (GaussianSplat3d): Gaussian splat model to serialize.
         archive_stem (str): Base filename stem for ``{stem}.nurec`` and referenced layers.
-        target_sh_degree (int | None): SH degree to write into the exported model. The legacy NuRec
-            importer (Isaac Sim prior to 6.0) only supports SH degree 0 or 3 and silently fails to
-            import models with an intermediate number of coefficients, so an explicit value must be
-            ``0`` or ``3`` (the directional SH coefficients are zero-padded or truncated to match).
-            If ``None`` (the default), degree 0 and 3 models are exported unchanged while degree 1
-            and 2 models are promoted to degree 3. See issue #124.
+        target_sh_degree (int | None): SH degree to normalize the exported model to. This sets the
+            number of directional SH coefficients written to ``features_specular`` and the reported
+            ``n_active_features`` (coefficients are zero-padded or truncated to match); the NuRec
+            ``radiance_sph_degree`` buffer capacity is left at 3 regardless. The legacy NuRec importer
+            (Isaac Sim prior to 6.0) only supports SH degree 0 or 3 and silently fails to import
+            models with an intermediate number of coefficients, so an explicit value must be ``0`` or
+            ``3``. If ``None`` (the default), degree 0 and 3 models are exported unchanged while
+            degree 1 and 2 models are promoted to degree 3. See issue #124.
 
     Returns:
         Tuple of (gauss USD stage, compressed NuRec model file).

--- a/fvdb_reality_capture/tools/_export_splats_to_usd.py
+++ b/fvdb_reality_capture/tools/_export_splats_to_usd.py
@@ -869,10 +869,12 @@ def _resize_sh_coefficients(shN: np.ndarray, target_sh_degree: int) -> np.ndarra
             coefficients are zero (which leaves the rendered radiance unchanged).
 
     Raises:
-        ValueError: If ``target_sh_degree`` is negative.
+        ValueError: If ``target_sh_degree`` is negative or ``shN`` is not a 3D ``(N, K-1, C)`` array.
     """
     if target_sh_degree < 0:
         raise ValueError(f"target_sh_degree must be non-negative, but got {target_sh_degree}")
+    if shN.ndim != 3:
+        raise ValueError(f"shN must be a 3D array of shape (N, K-1, C), but got shape {shN.shape}")
     target_coeffs = (target_sh_degree + 1) ** 2 - 1
     num_gaussians, current_coeffs, num_channels = shN.shape
     if current_coeffs == target_coeffs:

--- a/fvdb_reality_capture/tools/_export_splats_to_usd.py
+++ b/fvdb_reality_capture/tools/_export_splats_to_usd.py
@@ -854,9 +854,39 @@ def _write_particlefield3d_usdz(
     logger.info(f"USDZ file created successfully at {file_path}")
 
 
+def _resize_sh_coefficients(shN: np.ndarray, target_sh_degree: int) -> np.ndarray:
+    """
+    Pad (with zeros) or truncate the directional SH coefficients so the exported model has
+    exactly ``(target_sh_degree + 1) ** 2 - 1`` coefficients per channel.
+
+    Args:
+        shN (np.ndarray): Directional SH coefficients of shape ``(N, K - 1, C)`` where ``K`` is the
+            number of SH bases in the source model and ``C`` is the number of channels.
+        target_sh_degree (int): Desired SH degree for the exported model.
+
+    Returns:
+        np.ndarray: SH coefficients of shape ``(N, (target_sh_degree + 1) ** 2 - 1, C)``. Padded
+            coefficients are zero (which leaves the rendered radiance unchanged).
+
+    Raises:
+        ValueError: If ``target_sh_degree`` is negative.
+    """
+    if target_sh_degree < 0:
+        raise ValueError(f"target_sh_degree must be non-negative, but got {target_sh_degree}")
+    target_coeffs = (target_sh_degree + 1) ** 2 - 1
+    num_gaussians, current_coeffs, num_channels = shN.shape
+    if current_coeffs == target_coeffs:
+        return shN
+    if current_coeffs > target_coeffs:
+        return shN[:, :target_coeffs, :]
+    padding = np.zeros((num_gaussians, target_coeffs - current_coeffs, num_channels), dtype=shN.dtype)
+    return np.concatenate([shN, padding], axis=1)
+
+
 def build_legacy_gaussians_payload(
     model: GaussianSplat3d,
     archive_stem: str,
+    target_sh_degree: Optional[int] = None,
 ) -> tuple[NamedUSDStage, "NamedSerialized"]:
     """
     Build ``gauss.usda`` and ``.nurec`` payload layers for legacy NuRec USDZ export.
@@ -864,9 +894,18 @@ def build_legacy_gaussians_payload(
     Args:
         model (GaussianSplat3d): Gaussian splat model to serialize.
         archive_stem (str): Base filename stem for ``{stem}.nurec`` and referenced layers.
+        target_sh_degree (int | None): SH degree to write into the exported model. The legacy NuRec
+            importer (Isaac Sim prior to 6.0) only supports SH degree 0 or 3 and silently fails to
+            import models with an intermediate number of coefficients, so an explicit value must be
+            ``0`` or ``3`` (the directional SH coefficients are zero-padded or truncated to match).
+            If ``None`` (the default), degree 0 and 3 models are exported unchanged while degree 1
+            and 2 models are promoted to degree 3. See issue #124.
 
     Returns:
         Tuple of (gauss USD stage, compressed NuRec model file).
+
+    Raises:
+        ValueError: If ``target_sh_degree`` is not one of ``None``, ``0``, or ``3``.
     """
     means = model.means.cpu().numpy()
     quats = model.quats.cpu().numpy()
@@ -874,7 +913,19 @@ def build_legacy_gaussians_payload(
     logit_opacities = model.logit_opacities.cpu().numpy()
     sh0 = model.sh0.cpu().numpy()
     shN = model.shN.cpu().numpy()
-    n_sh_coeffs = model.num_sh_bases
+
+    # Normalize the directional SH to a degree the legacy NuRec importer supports. Only degree 1
+    # and 2 (which silently fail to import in Isaac Sim < 6.0) are promoted to degree 3 by default,
+    # leaving the already-supported degree 0 and 3 exports untouched. See issue #124.
+    if target_sh_degree is None:
+        target_sh_degree = model.sh_degree if model.sh_degree in (0, 3) else 3
+    elif target_sh_degree not in (0, 3):
+        raise ValueError(
+            "target_sh_degree must be 0 or 3 (the SH degrees the legacy NuRec importer supports), "
+            f"but got {target_sh_degree}"
+        )
+    shN = _resize_sh_coefficients(shN, target_sh_degree)
+    n_sh_coeffs = (target_sh_degree + 1) ** 2
 
     usdz_params = {
         "positions": means,
@@ -890,7 +941,9 @@ def build_legacy_gaussians_payload(
         "rotation_activation": "normalize",
         "density_kernel_density_clamping": True,
         "density_kernel_min_response": 0.0113,
-        "radiance_sph_degree": 3,
+        # NuRec has historically only been validated with a degree-3 radiance buffer; keep that
+        # capacity unless a smaller non-zero degree was explicitly requested.
+        "radiance_sph_degree": target_sh_degree if target_sh_degree > 0 else 3,
         "transmittance_threshold": 0.0001,
         "global_z_order": True,
         "n_rolling_shutter_iterations": 5,
@@ -1163,7 +1216,9 @@ def fill_3dgut_template(
     return template
 
 
-def _export_splats_to_usdz_legacy(model: GaussianSplat3d, out_path: Union[str, Path]) -> None:
+def _export_splats_to_usdz_legacy(
+    model: GaussianSplat3d, out_path: Union[str, Path], target_sh_degree: Optional[int] = None
+) -> None:
     """
     Export an :class:`fvdb.GaussianSplat3d` model to a USDZ file using the legacy NuRec format (UsdVol.Volume + .nurec msgpack).
 
@@ -1171,12 +1226,14 @@ def _export_splats_to_usdz_legacy(model: GaussianSplat3d, out_path: Union[str, P
         model (fvdb.GaussianSplat3d): The Gaussian Splat model to save to a usdz file
         out_path (str | Path): The output path for the usdz file. If the file extension is not ``.usdz``,
             it will be added. *e.g.*, ``./scene`` will save to ``./scene.usdz``.
+        target_sh_degree (int | None): SH degree to write into the exported model (see
+            :func:`build_legacy_gaussians_payload`). ``None`` (default) promotes degree 1/2 models to 3.
     """
     if isinstance(out_path, str):
         out_path = Path(out_path)
     out_path = out_path.with_suffix(".usdz")
 
-    gauss_usd, model_file = build_legacy_gaussians_payload(model, out_path.stem)
+    gauss_usd, model_file = build_legacy_gaussians_payload(model, out_path.stem, target_sh_degree=target_sh_degree)
     default_usd = serialize_usd_default_layer(gauss_usd)
     write_to_usdz(out_path, model_file, gauss_usd, default_usd)
 
@@ -1229,6 +1286,7 @@ def export_splats_to_usd(
     sorting_mode_hint: str = DEFAULT_SORTING_MODE_HINT,
     projection_mode_hint: str = DEFAULT_PROJECTION_MODE_HINT,
     asset_name: Optional[str] = None,
+    target_sh_degree: Optional[int] = None,
 ) -> Path:
     """
     Export a :class:`fvdb.GaussianSplat3d` (and optional collision mesh) to a USD file.
@@ -1265,6 +1323,12 @@ def export_splats_to_usd(
         asset_name (str | None): Optional override for the asset name placed under ``/World``
             (e.g. ``/World/<asset_name>``). Defaults to the output file's stem. Ignored when
             ``legacy=True``, which uses a fixed prim name.
+        target_sh_degree (int | None): Legacy export only. SH degree to write into the exported
+            model; an explicit value must be ``0`` or ``3`` (the degrees the legacy NuRec importer
+            in Isaac Sim prior to 6.0 supports). Directional SH coefficients are zero-padded or
+            truncated to match. ``None`` (the default) promotes degree 1/2 models to 3. Ignored for
+            the ParticleField3DGaussianSplat export, which always writes the model's native SH
+            degree. See issue #124.
 
     Returns:
         Path: The final output path (with the resolved ``.usdc``/``.usdz`` extension).
@@ -1319,7 +1383,7 @@ def export_splats_to_usd(
         raise ValueError("model is required for splats-only export")
 
     if legacy:
-        _export_splats_to_usdz_legacy(model, out_path)
+        _export_splats_to_usdz_legacy(model, out_path, target_sh_degree=target_sh_degree)
     else:
         _export_splats_to_usdz_particlefield3d(
             model,

--- a/fvdb_reality_capture/tools/_export_splats_to_usd.py
+++ b/fvdb_reality_capture/tools/_export_splats_to_usd.py
@@ -900,8 +900,9 @@ def build_legacy_gaussians_payload(
             ``radiance_sph_degree`` buffer capacity is left at 3 regardless. The legacy NuRec importer
             (Isaac Sim prior to 6.0) only supports SH degree 0 or 3 and silently fails to import
             models with an intermediate number of coefficients, so an explicit value must be ``0`` or
-            ``3``. If ``None`` (the default), degree 0 and 3 models are exported unchanged while
-            degree 1 and 2 models are promoted to degree 3. See issue #124.
+            ``3``. If ``None`` (the default), degree 0 and 3 models are exported unchanged while any
+            other degree is normalized to degree 3 (degrees 1-2 are zero-padded up, and any degree
+            above 3 is truncated). See issue #124.
 
     Returns:
         Tuple of (gauss USD stage, compressed NuRec model file).
@@ -916,9 +917,10 @@ def build_legacy_gaussians_payload(
     sh0 = model.sh0.cpu().numpy()
     shN = model.shN.cpu().numpy()
 
-    # Normalize the directional SH to a degree the legacy NuRec importer supports. Only degree 1
-    # and 2 (which silently fail to import in Isaac Sim < 6.0) are promoted to degree 3 by default,
-    # leaving the already-supported degree 0 and 3 exports untouched. See issue #124.
+    # Normalize the directional SH to a degree the legacy NuRec importer supports. By default any
+    # degree other than 0 or 3 is normalized to degree 3 (degrees 1-2, which silently fail to import
+    # in Isaac Sim < 6.0, are zero-padded up; any degree above 3 is truncated), leaving the
+    # already-supported degree 0 and 3 exports untouched. See issue #124.
     if target_sh_degree is None:
         target_sh_degree = model.sh_degree if model.sh_degree in (0, 3) else 3
     elif target_sh_degree not in (0, 3):
@@ -1229,7 +1231,7 @@ def _export_splats_to_usdz_legacy(
         out_path (str | Path): The output path for the usdz file. If the file extension is not ``.usdz``,
             it will be added. *e.g.*, ``./scene`` will save to ``./scene.usdz``.
         target_sh_degree (int | None): SH degree to write into the exported model (see
-            :func:`build_legacy_gaussians_payload`). ``None`` (default) promotes degree 1/2 models to 3.
+            :func:`build_legacy_gaussians_payload`). ``None`` (default) normalizes any non-0/3 degree to 3.
     """
     if isinstance(out_path, str):
         out_path = Path(out_path)
@@ -1328,7 +1330,7 @@ def export_splats_to_usd(
         target_sh_degree (int | None): Legacy export only. SH degree to write into the exported
             model; an explicit value must be ``0`` or ``3`` (the degrees the legacy NuRec importer
             in Isaac Sim prior to 6.0 supports). Directional SH coefficients are zero-padded or
-            truncated to match. ``None`` (the default) promotes degree 1/2 models to 3. Ignored for
+            truncated to match. ``None`` (the default) normalizes any non-0/3 degree to 3. Ignored for
             the ParticleField3DGaussianSplat export, which always writes the model's native SH
             degree. See issue #124.
 

--- a/fvdb_reality_capture/tools/_export_splats_to_usd.py
+++ b/fvdb_reality_capture/tools/_export_splats_to_usd.py
@@ -941,9 +941,9 @@ def build_legacy_gaussians_payload(
         "rotation_activation": "normalize",
         "density_kernel_density_clamping": True,
         "density_kernel_min_response": 0.0113,
-        # NuRec has historically only been validated with a degree-3 radiance buffer; keep that
-        # capacity unless a smaller non-zero degree was explicitly requested.
-        "radiance_sph_degree": target_sh_degree if target_sh_degree > 0 else 3,
+        # NuRec is only validated with a degree-3 radiance buffer, and degree-0 exports (which carry
+        # no directional coefficients) reuse that same buffer, so this is always 3.
+        "radiance_sph_degree": 3,
         "transmittance_threshold": 0.0001,
         "global_z_order": True,
         "n_rolling_shutter_iterations": 5,

--- a/tests/unit/test_export_splats_to_usd.py
+++ b/tests/unit/test_export_splats_to_usd.py
@@ -185,6 +185,11 @@ class ResizeShCoefficientsTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             _resize_sh_coefficients(shN, target_sh_degree=-1)
 
+    def test_non_3d_input_raises(self):
+        # A non-3D shN would otherwise fail with a cryptic tuple-unpack error.
+        with self.assertRaises(ValueError):
+            _resize_sh_coefficients(np.zeros((5, 3), dtype=np.float32), target_sh_degree=3)
+
 
 class LegacyNurecShDegreeTests(unittest.TestCase):
     # Per-channel directional-coefficient counts the legacy NuRec importer accepts (SH degree 0 or 3).

--- a/tests/unit/test_export_splats_to_usd.py
+++ b/tests/unit/test_export_splats_to_usd.py
@@ -152,9 +152,7 @@ def _decode_nurec_payload(raw: bytes) -> dict:
     return {
         "specular_coeffs": state_dict[".gaussians_nodes.gaussians.features_specular.shape"][1],
         "n_active_features": n_active,
-        "radiance_sph_degree": unpacked["nre_data"]["config"]["layers"]["gaussians"]["particle"][
-            "radiance_sph_degree"
-        ],
+        "radiance_sph_degree": unpacked["nre_data"]["config"]["layers"]["gaussians"]["particle"]["radiance_sph_degree"],
     }
 
 

--- a/tests/unit/test_export_splats_to_usd.py
+++ b/tests/unit/test_export_splats_to_usd.py
@@ -145,7 +145,8 @@ class ExportSplatsToUsdTests(unittest.TestCase):
 
 def _decode_nurec_payload(raw: bytes) -> dict:
     """Decode the gzipped-msgpack legacy NuRec payload and pull out its SH layout metadata."""
-    unpacked = msgpack.unpackb(gzip.GzipFile(fileobj=io.BytesIO(raw)).read(), raw=False)
+    with gzip.GzipFile(fileobj=io.BytesIO(raw)) as gz:
+        unpacked = msgpack.unpackb(gz.read(), raw=False)
     state_dict = unpacked["nre_data"]["state_dict"]
     n_active = int(np.frombuffer(state_dict[".gaussians_nodes.gaussians.n_active_features"], dtype=np.int64)[0])
     return {

--- a/tests/unit/test_export_splats_to_usd.py
+++ b/tests/unit/test_export_splats_to_usd.py
@@ -1,16 +1,21 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
+import gzip
+import io
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
+import msgpack
 import numpy as np
 import torch
 from fvdb import GaussianSplat3d
 from pxr import Usd, UsdVol
 
 from fvdb_reality_capture.tools import export_splats_to_usd
+from fvdb_reality_capture.tools._export_splats_to_usd import _resize_sh_coefficients, build_legacy_gaussians_payload
 
 
 def _make_test_splats(num_gaussians: int = 8, sh_degree: int = 1, seed: int = 0) -> GaussianSplat3d:
@@ -136,6 +141,112 @@ class ExportSplatsToUsdTests(unittest.TestCase):
             out_path = Path(tmp_dir) / "scene.usdc"
             with self.assertRaises(ValueError):
                 export_splats_to_usd(model, out_path, legacy=True, usdz=True, apply_ecef2enu_rotation=True)
+
+
+def _decode_nurec_payload(raw: bytes) -> dict:
+    """Decode the gzipped-msgpack legacy NuRec payload and pull out its SH layout metadata."""
+    unpacked = msgpack.unpackb(gzip.GzipFile(fileobj=io.BytesIO(raw)).read(), raw=False)
+    state_dict = unpacked["nre_data"]["state_dict"]
+    n_active = int(np.frombuffer(state_dict[".gaussians_nodes.gaussians.n_active_features"], dtype=np.int64)[0])
+    return {
+        "specular_coeffs": state_dict[".gaussians_nodes.gaussians.features_specular.shape"][1],
+        "n_active_features": n_active,
+        "radiance_sph_degree": unpacked["nre_data"]["config"]["layers"]["gaussians"]["particle"][
+            "radiance_sph_degree"
+        ],
+    }
+
+
+class ResizeShCoefficientsTests(unittest.TestCase):
+    def test_pad_appends_zeros_and_preserves_original(self):
+        shN = np.random.rand(5, 3, 3).astype(np.float32)  # degree 1 -> 3 coeffs
+        out = _resize_sh_coefficients(shN, target_sh_degree=3)  # -> 15 coeffs
+        self.assertEqual(out.shape, (5, 15, 3))
+        np.testing.assert_array_equal(out[:, :3, :], shN)  # original coefficients preserved
+        np.testing.assert_array_equal(out[:, 3:, :], np.zeros((5, 12, 3), dtype=np.float32))  # padding is zero
+
+    def test_truncate_keeps_leading_coefficients(self):
+        shN = np.random.rand(5, 15, 3).astype(np.float32)  # degree 3 -> 15 coeffs
+        out = _resize_sh_coefficients(shN, target_sh_degree=1)  # -> 3 coeffs
+        self.assertEqual(out.shape, (5, 3, 3))
+        np.testing.assert_array_equal(out, shN[:, :3, :])
+
+    def test_identity_returns_input_unchanged(self):
+        shN = np.random.rand(5, 8, 3).astype(np.float32)  # degree 2 -> already matches
+        self.assertIs(_resize_sh_coefficients(shN, target_sh_degree=2), shN)
+
+    def test_degree_zero_source(self):
+        shN = np.zeros((5, 0, 3), dtype=np.float32)  # degree 0 -> no directional coeffs
+        self.assertEqual(_resize_sh_coefficients(shN, target_sh_degree=0).shape, (5, 0, 3))
+        self.assertEqual(_resize_sh_coefficients(shN, target_sh_degree=3).shape, (5, 15, 3))
+
+    def test_negative_degree_raises(self):
+        # A negative degree would otherwise silently drop coefficients via a negative-index slice.
+        shN = np.zeros((5, 3, 3), dtype=np.float32)
+        with self.assertRaises(ValueError):
+            _resize_sh_coefficients(shN, target_sh_degree=-1)
+
+
+class LegacyNurecShDegreeTests(unittest.TestCase):
+    # Per-channel directional-coefficient counts the legacy NuRec importer accepts (SH degree 0 or 3).
+    _SUPPORTED_SPECULAR_COEFFS = {0, 15}
+
+    def _payload_info(self, model: GaussianSplat3d, **kwargs) -> dict:
+        _, model_file = build_legacy_gaussians_payload(model, "scene", **kwargs)
+        return _decode_nurec_payload(model_file.serialized)
+
+    def test_auto_promotes_intermediate_degrees_to_supported_layout(self):
+        # Degree 1 and 2 have an intermediate coefficient count that silently fails to import;
+        # they must be promoted to the degree-3 layout (issue #124).
+        for degree in (1, 2):
+            with self.subTest(source_degree=degree):
+                info = self._payload_info(_make_test_splats(sh_degree=degree))
+                self.assertEqual(info["specular_coeffs"], 15)
+                self.assertEqual(info["n_active_features"], 16)
+                self.assertEqual(info["radiance_sph_degree"], 3)
+
+    def test_auto_leaves_supported_degrees_unchanged(self):
+        # Degree 0 and 3 already import correctly and must be exported unchanged.
+        for degree, expected_coeffs, expected_n_active in ((0, 0, 1), (3, 15, 16)):
+            with self.subTest(source_degree=degree):
+                info = self._payload_info(_make_test_splats(sh_degree=degree))
+                self.assertEqual(info["specular_coeffs"], expected_coeffs)
+                self.assertEqual(info["n_active_features"], expected_n_active)
+
+    def test_every_auto_export_uses_a_supported_layout(self):
+        for degree in (0, 1, 2, 3):
+            with self.subTest(source_degree=degree):
+                info = self._payload_info(_make_test_splats(sh_degree=degree))
+                self.assertIn(info["specular_coeffs"], self._SUPPORTED_SPECULAR_COEFFS)
+
+    def test_explicit_target_pads_and_truncates(self):
+        padded = self._payload_info(_make_test_splats(sh_degree=0), target_sh_degree=3)
+        self.assertEqual(padded["specular_coeffs"], 15)
+        self.assertEqual(padded["n_active_features"], 16)
+
+        truncated = self._payload_info(_make_test_splats(sh_degree=3), target_sh_degree=0)
+        self.assertEqual(truncated["specular_coeffs"], 0)
+        self.assertEqual(truncated["n_active_features"], 1)
+
+    def test_unsupported_explicit_target_is_rejected(self):
+        # Explicit targets outside {0, 3} would produce a NuRec file the importer cannot load.
+        model = _make_test_splats(sh_degree=3)
+        for bad_degree in (-1, 1, 2, 4):
+            with self.subTest(target_sh_degree=bad_degree):
+                with self.assertRaises(ValueError):
+                    build_legacy_gaussians_payload(model, "scene", target_sh_degree=bad_degree)
+
+    def test_end_to_end_legacy_usdz_promotes_degree(self):
+        # Full public path: a degree-2 model exported via export_splats_to_usd(legacy=True) must
+        # produce a degree-3 NuRec payload inside the .usdz archive.
+        model = _make_test_splats(sh_degree=2)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out_path = export_splats_to_usd(model, Path(tmp_dir) / "scene", legacy=True, usdz=True)
+            self.assertTrue(out_path.exists())
+            with zipfile.ZipFile(out_path) as zf:
+                nurec_name = next(name for name in zf.namelist() if name.endswith(".nurec"))
+                info = _decode_nurec_payload(zf.read(nurec_name))
+        self.assertEqual(info["specular_coeffs"], 15)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #124. The legacy NuRec USDZ export (`export_splats_to_usd(..., legacy=True)`, used for Isaac Sim < 6.0) hardcoded `radiance_sph_degree=3` while serializing the model's actual `shN`. As a result, Gaussian splats trained at **SH degree 1 or 2** were written with an intermediate directional-coefficient count (3 or 8 per channel) that the NuRec importer cannot interpret, so Isaac Sim **silently hangs** on import. Degree 0 (0 coeffs) and degree 3 (15 coeffs) happened to be self-consistent, which is why only those imported.

## Fix

- Normalize the exported directional SH to a degree the legacy importer supports: **pad degree 1/2 up to 3** (zero-filled higher bands leave the rendered radiance unchanged) and leave degree **0/3 untouched** (byte-identical to before).
- Add an optional `target_sh_degree` control (must be `0` or `3`) to `export_splats_to_usd` and `build_legacy_gaussians_payload`, and a `--target-sh-degree` flag to `frgs convert`, implementing the request in #124 to pad/remove `f_rest` components.
- Validate up front: unsupported (`1`, `2`, `>3`) or negative values raise `ValueError` rather than producing a corrupt/unloadable file.

**Scope:** only the legacy NuRec path is affected. The default `ParticleField3DGaussianSplat` export already writes the model's native SH degree faithfully and is unchanged.

## Testing

Extends `tests/unit/test_export_splats_to_usd.py` (17 tests pass, incl. the 7 pre-existing):
- `_resize_sh_coefficients` pad / truncate / identity / degree-0 / negative-raises.
- Legacy NuRec payload SH layout for degrees 0–3 (auto), explicit pad/truncate, unsupported-target rejection, and an end-to-end `.usdz` round-trip decoding the embedded `.nurec`.

## Notes

I was unable to test the actual Isaac Sim import here; the tests assert the exported `.nurec` SH layout matches the known-working degree-3 case, per the importer's documented "degree 0 or 3 only" behavior reported in #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)