### PR TITLE
GARfVDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ tests/data/
 *.h264
 *.mp4
 *.ipynb_checkpoints
+*.garfvdb

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ fVDB-Reality-Capture Version History
 ## Version 0.6.0 - Unreleased
 
 - Added first-class GARfVDB scale-conditioned instance segmentation through the Python API and
-  `frgs instance-segmentation` command.
+  `frgs segment-instances` command.
 - Added portable `.garfvdb` bundles using NanoVDB encoder fields, safetensors network weights, and a PLY Gaussian
   carrier. Manifests carry an explicit `schema_version` used to select an exact reader for future compatibility.
   Added product-aware `frgs show` and `frgs resume` dispatch.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@ fVDB-Reality-Capture Version History
   dispatches stable method IDs without relying on product extensions or falling through unknown methods to Gaussian
   reconstruction.
 
+### Gaussian Splatting API
+
+- Moved the high-level `GaussianSplat3d`, `ProjectedGaussianSplats`, `gaussian_render_jagged`, and `evaluate_spherical_harmonics` APIs from `fvdb` to `fvdb_reality_capture`. This is a breaking import-path change; the low-level compiled kernels and supporting tensor types remain in fVDB-core.
+- Moved `RollingShutterType`, `CameraModel`, and `ProjectionMethod` from `fvdb` to `fvdb_reality_capture`, preserving their member names and values. This is also a breaking import-path change.
+- Added `gaussian_splat_to_view_data`, a zero-copy adapter from `GaussianSplat3d` to the core-owned `fvdb.viz.GaussianSplatViewData` contract. Pass the adapted data to `fvdb.viz.Scene.add_gaussian_splat_3d` instead of coupling the viewer directly to the reality-capture model. The minimum `fvdb-core` version is now `0.6.0dev0` for this contract.
+
 ## Version 0.5.0 - July 1, 2026
 
 *23 commits, 100+ files changed, 7 contributors.*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 fVDB-Reality-Capture Version History
 ====================================
 
+## Version 0.6.0 - Unreleased
+
+- Added first-class GARfVDB scale-conditioned instance segmentation through the Python API and
+  `frgs instance-segmentation` command.
+- Added portable `.garfvdb` bundles using NanoVDB encoder fields, safetensors network weights, and a PLY Gaussian
+  carrier. Manifests carry an explicit `schema_version` used to select an exact reader for future compatibility.
+  Added product-aware `frgs show` and `frgs resume` dispatch.
+- Integrated GARfVDB preprocessing with the standard scene-transform pipeline. SAM2 supervision is represented by a
+  registered, namespaced scene attribute so it composes with other derived scene products without replacing the
+  scene cache or discarding existing attributes.
+- Added a method-neutral, versioned training-checkpoint envelope and resume-handler registry. `frgs resume` now
+  dispatches stable method IDs without relying on product extensions or falling through unknown methods to Gaussian
+  reconstruction.
+
 ## Version 0.5.0 - July 1, 2026
 
 *23 commits, 100+ files changed, 7 contributors.*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 fVDB-Reality-Capture is a reality-capture toolbox built on top of [fVDB](https://fvdb-core.readthedocs.io). It
 provides high-level abstractions and APIs for common reality capture tasks, such as loading sensor data, reconstructing
-radiance fields, extracting meshes and point clouds, visualization, and exporting results across standard formats such
+radiance fields, learning scale-conditioned instance feature fields, extracting meshes and point clouds, visualization,
+and exporting results across standard formats such
 as PLY and USD (USDC/USDZ).
 
 By leveraging the power of fVDB, fVDB-Reality-Capture can scale reconstruction to very large or dense

--- a/docs/api/checkpoints.rst
+++ b/docs/api/checkpoints.rst
@@ -1,0 +1,14 @@
+Training checkpoints
+====================
+
+Reality Capture training checkpoints use a method-neutral, versioned envelope. The envelope identifies the stable
+method ID and keeps method-owned optimizer, dataset, and model state inside ``state``. Product extensions such as
+``.garfvdb`` are not used for resume dispatch.
+
+Each method owns its method ID and any adapter for checkpoints written before the envelope was introduced. The
+``frgs resume`` command separately owns resume-handler registration and output defaults, keeping CLI policy out of
+the serialization layer.
+
+.. automodule:: fvdb_reality_capture.checkpoints
+   :members: TrainingCheckpoint, create_training_checkpoint, load_training_checkpoint,
+             parse_training_checkpoint, register_legacy_checkpoint_adapter

--- a/docs/api/checkpoints.rst
+++ b/docs/api/checkpoints.rst
@@ -9,6 +9,29 @@ Each method owns its method ID and any adapter for checkpoints written before th
 ``frgs resume`` command separately owns resume-handler registration and output defaults, keeping CLI policy out of
 the serialization layer.
 
+Container schema versus method
+------------------------------
+
+A checkpoint carries two independent versions — one for the outer container and one for the method payload inside
+it — on orthogonal axes:
+
+- ``schema`` / ``schema_version`` version the **container format itself**: the fixed set of top-level keys
+  (``schema``, ``schema_version``, ``method``, ``method_version``, ``state``) and how they are parsed. ``schema`` is
+  a constant string shared by every method, and ``schema_version`` is owned centrally by
+  :mod:`fvdb_reality_capture.checkpoints` and selects the reader used to parse the container. Bump it only when the
+  container structure changes, which affects every method at once. Nothing method-specific lives at this level.
+- ``method`` / ``method_version`` version the **method-owned payload** carried in ``state``. ``method`` is the stable
+  identifier of the training method that produced the checkpoint (for example ``radiance_fields.gaussian_splat`` or
+  ``instance_segmentation.garfvdb``) and is the dispatch key used on resume. ``method_version`` versions that
+  method's ``state`` layout and is owned by the method's package as a single source of truth, so the writer's
+  recorded version and the method's ``state_dict``/``from_state_dict`` cannot drift. Bump it only when that one
+  method's ``state`` changes, independently of other methods.
+
+Everything method-specific — model weights, optimizer and scheduler state, configuration, global step, and method
+metadata — lives inside ``state`` and is opaque to the container layer; only the method interprets it. Because the
+axes are independent, the container can stay at one ``schema_version`` while different methods evolve their
+``method_version`` separately, and restructuring the container advances ``schema_version`` regardless of any method.
+
 .. automodule:: fvdb_reality_capture.checkpoints
    :members: TrainingCheckpoint, create_training_checkpoint, load_training_checkpoint,
              parse_training_checkpoint, register_legacy_checkpoint_adapter

--- a/docs/api/checkpoints.rst
+++ b/docs/api/checkpoints.rst
@@ -1,11 +1,11 @@
 Training checkpoints
 ====================
 
-Reality Capture training checkpoints use a method-neutral, versioned envelope. The envelope identifies the stable
+Reality Capture training checkpoints use a method-neutral, versioned container. The container identifies the stable
 method ID and keeps method-owned optimizer, dataset, and model state inside ``state``. Product extensions such as
 ``.garfvdb`` are not used for resume dispatch.
 
-Each method owns its method ID and any adapter for checkpoints written before the envelope was introduced. The
+Each method owns its method ID and any adapter for checkpoints written before the container was introduced. The
 ``frgs resume`` command separately owns resume-handler registration and output defaults, keeping CLI policy out of
 the serialization layer.
 

--- a/docs/api/frgs.rst
+++ b/docs/api/frgs.rst
@@ -1,11 +1,12 @@
 ``frgs 🐸 CLI Tool``
 ==========================================
 
-fVDB-Reality-Capture provides a command-line interface (CLI) tool called ``frgs`` for tools related to Gaussian splatting.
+fVDB-Reality-Capture provides a command-line interface (CLI) tool called ``frgs`` for tools related to Gaussian Splatting
+and derived spatial products.
 ``frgs`` is pronounced "frogs" 🐸, and is short for  **F**\ vdb-\ **R**\ eality-capture **G**\ aussian **S**\ platting.
 
-This tool allows users to perform Gaussian-splatting-related tasks such as reconstruction, format conversions,
-mesh and point cloud extraction, and visualization directly from the command line, without needing to write any code.
+This tool covers reconstruction, derived instance feature fields, format conversion, mesh and point-cloud extraction,
+and visualization directly from the command line without requiring Python code.
 
 
 ``frgs convert``
@@ -27,6 +28,11 @@ mesh and point cloud extraction, and visualization directly from the command lin
 ----------------------
 
 .. include:: frgs/mesh_basic.rst
+
+``frgs instance-segmentation``
+--------------------------------
+
+.. include:: frgs/instance_segmentation.rst
 
 ``frgs mesh-dlnr``
 ----------------------

--- a/docs/api/frgs.rst
+++ b/docs/api/frgs.rst
@@ -5,7 +5,7 @@ fVDB-Reality-Capture provides a command-line interface (CLI) called ``frgs`` for
 and derived spatial products.
 ``frgs`` is pronounced "frogs" 🐸, and is short for  **F**\ vdb-\ **R**\ eality-capture **G**\ aussian **S**\ platting.
 
-This tool covers reconstruction, derived instance feature fields, format conversion, mesh and point-cloud extraction,
+`frgs` provides reconstruction, derived instance feature fields, format conversion, mesh and point-cloud extraction,
 and visualization directly from the command line without requiring Python code.
 
 

--- a/docs/api/frgs.rst
+++ b/docs/api/frgs.rst
@@ -1,7 +1,7 @@
 ``frgs 🐸 CLI Tool``
 ==========================================
 
-fVDB-Reality-Capture provides a command-line interface (CLI) tool called ``frgs`` for tools related to Gaussian Splatting
+fVDB-Reality-Capture provides a command-line interface (CLI) called ``frgs`` for tools related to Gaussian Splatting
 and derived spatial products.
 ``frgs`` is pronounced "frogs" 🐸, and is short for  **F**\ vdb-\ **R**\ eality-capture **G**\ aussian **S**\ platting.
 

--- a/docs/api/frgs.rst
+++ b/docs/api/frgs.rst
@@ -29,10 +29,10 @@ and visualization directly from the command line without requiring Python code.
 
 .. include:: frgs/mesh_basic.rst
 
-``frgs instance-segmentation``
+``frgs segment-instances``
 --------------------------------
 
-.. include:: frgs/instance_segmentation.rst
+.. include:: frgs/segment_instances.rst
 
 ``frgs mesh-dlnr``
 ----------------------

--- a/docs/api/frgs/evaluate.rst
+++ b/docs/api/frgs/evaluate.rst
@@ -45,6 +45,6 @@
     │ -s, --save-images, --no-save-images                                                            │
     │     Whether to save the rendered images. Defaults to True. (default: True)                     │
     │ --device STR|DEVICE                                                                            │
-    │     Device to use for computation. Defaults to "cuda". (default: cuda)                         │
+    │     Device to use for computation. Defaults to "cuda:0". (default: cuda:0)                     │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/api/frgs/instance_segmentation.rst
+++ b/docs/api/frgs/instance_segmentation.rst
@@ -12,4 +12,4 @@
 
    Required inputs are the original posed-image dataset and the matching Reality Capture PLY or checkpoint.
    The output is a portable directory containing NanoVDB encoder grids, safetensors network weights, and the
-   exact filtered Gaussian carrier.
+   exact filtered Gaussian model.

--- a/docs/api/frgs/instance_segmentation.rst
+++ b/docs/api/frgs/instance_segmentation.rst
@@ -1,0 +1,15 @@
+.. code-block:: text
+
+   usage: frgs instance-segmentation [-h] [INSTANCE-SEGMENTATION OPTIONS] PATH
+
+   Train a GARfVDB scale-conditioned instance feature field from an existing Reality Capture reconstruction.
+
+   Example:
+
+       frgs instance-segmentation ./colmap_dataset \
+           --reconstruction-path scene.ply \
+           --out-path scene.garfvdb
+
+   Required inputs are the original posed-image dataset and the matching Reality Capture PLY or checkpoint.
+   The output is a portable directory containing NanoVDB encoder grids, safetensors network weights, and the
+   exact filtered Gaussian carrier.

--- a/docs/api/frgs/mesh_basic.rst
+++ b/docs/api/frgs/mesh_basic.rst
@@ -67,6 +67,6 @@
    │ -o PATH, --output-path PATH                                                                    │
    │                         Path to save the extracted mesh (default is "mesh.ply"). (default:     │
    │                         mesh.ply)                                                              │
-   │ -d STR, --device STR    Extract a mesh from a Gaussian Splat reconstruction. (default: cuda)   │
+   │ -d STR, --device STR    Extract a mesh from a Gaussian Splat reconstruction. (default: cuda:0) │
    ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/api/frgs/mesh_basic.rst
+++ b/docs/api/frgs/mesh_basic.rst
@@ -67,6 +67,6 @@
    │ -o PATH, --output-path PATH                                                                    │
    │                         Path to save the extracted mesh (default is "mesh.ply"). (default:     │
    │                         mesh.ply)                                                              │
-   │ -d STR, --device STR    Extract a mesh from a Gaussian Splat reconstruction. (default: cuda:0) │
+   │ -d STR, --device STR    Device to use for computation (default is "cuda:0"). (default: cuda:0) │
    ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/api/frgs/mesh_dlnr.rst
+++ b/docs/api/frgs/mesh_dlnr.rst
@@ -66,6 +66,6 @@
    │ -o PATH, --output-path PATH                                                                    │
    │                         Path to save the extracted mesh (default is "mesh.ply"). (default:     │
    │                         mesh.ply)                                                              │
-   │ -d STR, --device STR    Extract a mesh from a Gaussian Splat reconstruction. (default: cuda:0) │
+   │ -d STR, --device STR    Device to use for computation (default is "cuda:0"). (default: cuda:0) │
    ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/api/frgs/mesh_dlnr.rst
+++ b/docs/api/frgs/mesh_dlnr.rst
@@ -66,6 +66,6 @@
    │ -o PATH, --output-path PATH                                                                    │
    │                         Path to save the extracted mesh (default is "mesh.ply"). (default:     │
    │                         mesh.ply)                                                              │
-   │ -d STR, --device STR    Extract a mesh from a Gaussian Splat reconstruction. (default: cuda)   │
+   │ -d STR, --device STR    Extract a mesh from a Gaussian Splat reconstruction. (default: cuda:0) │
    ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/api/frgs/points.rst
+++ b/docs/api/frgs/points.rst
@@ -58,6 +58,6 @@
     │ -o PATH, --output-path PATH                                                                    │
     │                         Path to save the extracted mesh (default is "mesh.ply"). (default:     │
     │                         points.ply)                                                            │
-    │ -d STR, --device STR    Device to use for computation (default is "cuda"). (default: cuda)     │
+    │ -d STR, --device STR    Device to use for computation (default is "cuda:0"). (default: cuda:0) │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/api/frgs/reconstruct.rst
+++ b/docs/api/frgs/reconstruct.rst
@@ -42,7 +42,7 @@
     │ -d STR|DEVICE, --device STR|DEVICE                                                           │
     │     Which device to use for reconstruction. Must be a cuda device. You can pass in a         │
     │     specific device index via cuda:N where N is the device index, or "cuda" to use the       │
-    │     default cuda device. CPU is not supported. Default is "cuda". (default: cuda)            │
+    │     default cuda device. CPU is not supported. Default is "cuda:0". (default: cuda:0)        │
     │ -v, --verbose, --no-verbose                                                                  │
     │     If set, show verbose debug messages. (default: False)                                    │
     │ -nc INT INT INT, --nchunks INT INT INT                                                       │

--- a/docs/api/frgs/resume.rst
+++ b/docs/api/frgs/resume.rst
@@ -2,9 +2,8 @@
 
     usage: frgs resume [-h] [RESUME OPTIONS] PATH
 
-    Resume reconstructing a 3D Gaussian Splat radiance field from a checkpoint. This command loads a
-    model checkpoint and continues reconstruction from that point. The dataset used to create the
-    checkpoint must be at the same path as when the checkpoint was created.
+    Resume a Reality Capture training run. The versioned checkpoint envelope identifies the method and dispatches
+    its registered resume handler. Source dataset paths recorded by the checkpoint must remain available.
 
     Example usage:
 
@@ -13,7 +12,7 @@
 
     ╭─ positional arguments ───────────────────────────────────────────────────────────────────────╮
     │ PATH                                                                                         │
-    │     Path to the checkpoint file containing the Gaussian Splat radiance field. (required)     │
+    │     Path to a versioned Reality Capture training checkpoint. (required)                      │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────╯
     ╭─ options ────────────────────────────────────────────────────────────────────────────────────╮
     │ -h, --help                                                                                   │
@@ -36,8 +35,9 @@
     │ -v, --verbose, --no-verbose                                                                  │
     │     If set, show verbose debug messages. (default: False)                                    │
     │ -o PATH, --out-path PATH                                                                     │
-    │     Path to save the output PLY file. Defaults to `out.ply` in the current working           │
-    │     directory. Path must end in .ply, .usdc, or .usdz. (default: out_resumed.ply)            │
+    │     Output product path. The default is selected by the checkpoint method. (default: None)   │
+    │ -r {None}|PATH, --reconstruction-path {None}|PATH                                            │
+    │     Override a reconstruction referenced by a derived-product checkpoint. (default: None)   │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────╯
     ╭─ io options ─────────────────────────────────────────────────────────────────────────────────╮
     │ Configure saving and logging metrics, images, and checkpoints.                               │

--- a/docs/api/frgs/resume.rst
+++ b/docs/api/frgs/resume.rst
@@ -2,7 +2,7 @@
 
     usage: frgs resume [-h] [RESUME OPTIONS] PATH
 
-    Resume a Reality Capture training run. The versioned checkpoint envelope identifies the method and dispatches
+    Resume a Reality Capture training run. The versioned checkpoint container identifies the method and dispatches
     its registered resume handler. Source dataset paths recorded by the checkpoint must remain available.
 
     Example usage:

--- a/docs/api/frgs/resume.rst
+++ b/docs/api/frgs/resume.rst
@@ -31,7 +31,7 @@
     │ -d STR|DEVICE, --device STR|DEVICE                                                           │
     │     Which device to use for reconstruction. Must be a cuda device. You can pass in a         │
     │     specific device index via cuda:N where N is the device index, or "cuda" to use the       │
-    │     default cuda device. CPU is not supported. Default is "cuda". (default: cuda)            │
+    │     default cuda device. CPU is not supported. Default is "cuda:0". (default: cuda:0)        │
     │ -v, --verbose, --no-verbose                                                                  │
     │     If set, show verbose debug messages. (default: False)                                    │
     │ -o PATH, --out-path PATH                                                                     │

--- a/docs/api/frgs/segment_instances.rst
+++ b/docs/api/frgs/segment_instances.rst
@@ -1,12 +1,12 @@
 .. code-block:: text
 
-   usage: frgs instance-segmentation [-h] [INSTANCE-SEGMENTATION OPTIONS] PATH
+   usage: frgs segment-instances [-h] [SEGMENT-INSTANCES OPTIONS] PATH
 
    Train a GARfVDB scale-conditioned instance feature field from an existing Reality Capture reconstruction.
 
    Example:
 
-       frgs instance-segmentation ./colmap_dataset \
+       frgs segment-instances ./colmap_dataset \
            --reconstruction-path scene.ply \
            --out-path scene.garfvdb
 

--- a/docs/api/frgs/show.rst
+++ b/docs/api/frgs/show.rst
@@ -24,5 +24,5 @@
     │                         The port to expose the viewer server on. (default: 127.0.0.1)        │
     │ -v, --verbose, --no-verbose                                                                  │
     │                         If True, then the viewer will log verbosely. (default: False)        │
-    │ --device STR|DEVICE     Device to use for computation (default is "cuda"). (default: cuda)   │
+    │ --device STR|DEVICE     Device to use for computation (default is "cuda:0"). (default: cuda:0) │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/docs/api/frgs/show.rst
+++ b/docs/api/frgs/show.rst
@@ -2,8 +2,8 @@
 
     usage: frgs show [-h] [SHOW OPTIONS] PATH
 
-    Visualize a Gaussian splat radiance field in a saved PLY or checkpoint file. This will plot the
-    splats in an interactive viewer shown in a browser window.
+    Visualize a saved Reality Capture product. Supported inputs are Gaussian PLY/checkpoint files
+    and portable GARfVDB bundle directories.
 
     # Example usage:
 
@@ -14,8 +14,7 @@
         frgs show model.pt --viewer-port 8888
 
     ╭─ positional arguments ───────────────────────────────────────────────────────────────────────╮
-    │ PATH                    Path to the input PLY or checkpoint file. Must end in .ply, .pt, or  │
-    │                         .pth. (required)                                                     │
+    │ PATH                    Path to a PLY, checkpoint, or .garfvdb bundle. (required)            │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────╯
     ╭─ options ────────────────────────────────────────────────────────────────────────────────────╮
     │ -h, --help              show this help message and exit                                      │
@@ -27,4 +26,3 @@
     │                         If True, then the viewer will log verbosely. (default: False)        │
     │ --device STR|DEVICE     Device to use for computation (default is "cuda"). (default: cuda)   │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────╯
-

--- a/docs/api/frgs/show.rst
+++ b/docs/api/frgs/show.rst
@@ -21,7 +21,7 @@
     │ -p INT, --viewer-port INT                                                                    │
     │                         The port to expose the viewer server on. (default: 8080)             │
     │ -ip STR, --viewer-ip-address STR                                                             │
-    │                         The port to expose the viewer server on. (default: 127.0.0.1)        │
+    │                         The IP address to expose the viewer server on. (default: 127.0.0.1)  │
     │ -v, --verbose, --no-verbose                                                                  │
     │                         If True, then the viewer will log verbosely. (default: False)        │
     │ --device STR|DEVICE     Device to use for computation (default is "cuda:0"). (default: cuda:0) │

--- a/docs/api/frgs/show_data.rst
+++ b/docs/api/frgs/show_data.rst
@@ -56,7 +56,7 @@
     │ -p INT, --viewer-port INT                                                                    │
     │     The port to expose the viewer server on. (default: 8080)                                 │
     │ -ip STR, --viewer-ip-address STR                                                             │
-    │     The port to expose the viewer server on. (default: 127.0.0.1)                            │
+    │     The IP address to expose the viewer server on. (default: 127.0.0.1)                      │
     │ -v, --verbose, --no-verbose                                                                  │
     │     If True, then the viewer will log verbosely. (default: False)                            │
     │ -ppf FLOAT, --points-percentile-filter FLOAT                                                 │

--- a/docs/api/instance_segmentation.rst
+++ b/docs/api/instance_segmentation.rst
@@ -1,0 +1,39 @@
+Instance segmentation
+=====================
+
+Portable bundle format
+----------------------
+
+``.garfvdb`` manifests use the schema name ``fvdb_reality_capture.garfvdb`` and an integer ``schema_version``.
+The current version is available as :data:`ARTIFACT_SCHEMA_VERSION`. Loaders select an exact version-specific
+reader and raise :class:`GARfVDBArtifactVersionError` for unsupported versions.
+
+GARfVDB
+-------
+
+.. currentmodule:: fvdb_reality_capture.instance_segmentation
+
+.. autoclass:: GARfVDB
+   :members:
+
+.. autoclass:: GARfVDBTrainer
+   :members: new, from_state_dict, from_checkpoint_file, train, to_product, state_dict
+
+.. autoclass:: GARfVDBConfig
+   :members:
+
+.. autoclass:: GARfVDBTrainingConfig
+   :members:
+
+.. autoclass:: GARfVDBTransformConfig
+   :members:
+
+.. autoclass:: GARfVDBMaskAttribute
+   :members:
+
+.. autoclass:: GenerateGARfVDBMasks
+   :members:
+
+.. autoexception:: GARfVDBArtifactError
+
+.. autoexception:: GARfVDBArtifactVersionError

--- a/docs/api/transforms.rst
+++ b/docs/api/transforms.rst
@@ -34,5 +34,8 @@
     :special-members: __init__, __call__
 
 .. autoclass:: fvdb_reality_capture.transforms.Identity
-    :members:
+   :members:
+
+.. autoclass:: fvdb_reality_capture.transforms.SceneTransformConfig
+   :members:
     :special-members: __init__, __call__

--- a/docs/api/transforms.rst
+++ b/docs/api/transforms.rst
@@ -34,8 +34,8 @@
     :special-members: __init__, __call__
 
 .. autoclass:: fvdb_reality_capture.transforms.Identity
-   :members:
+    :members:
 
 .. autoclass:: fvdb_reality_capture.transforms.SceneTransformConfig
-   :members:
+    :members:
     :special-members: __init__, __call__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Features
 - Extraction of high-quality meshes and point clouds from reconstructed radiance fields, with support for various output
   formats.
 - Visualization tools for inspecting sensor data, radiance fields, and reconstruction results.
+- Scale-conditioned 3D instance feature fields using GARfVDB, stored as portable NanoVDB-based artifacts.
 - Extensible design that allows users to easily add new functionality and customize existing components.
 - Comprehensive documentation and tutorials to help users get started quickly.
 - Automatic scaling to multiple GPUs in a single machine for large-scale reconstructions
@@ -96,6 +97,7 @@ A common reality capture pipeline typically resembles the figure below:
    tutorials/sensor_data_loading_and_manipulation
    tutorials/radiance_field_and_mesh_reconstruction
    tutorials/frgs
+   tutorials/instance_segmentation
 
 .. toctree::
    :maxdepth: 1
@@ -105,7 +107,9 @@ A common reality capture pipeline typically resembles the figure below:
    api/sfm_scene
    api/tools
    api/transforms
+   api/checkpoints
    api/frgs
+   api/instance_segmentation
 
 .. toctree::
    :maxdepth: 1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,6 +21,7 @@ opencv-python-headless
 pycolmap>=3.11
 pyproj
 requests
+safetensors
 scikit-image
 scipy
 torch==2.8.0+cpu

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -66,7 +66,7 @@ The Python API accepts grouping scales in scene units:
 
    from fvdb_reality_capture.instance_segmentation import GARfVDB
 
-   product = GARfVDB.load("safety-park.garfvdb", device="cuda")
+   product = GARfVDB.load("safety-park.garfvdb", device="cuda:0")
    scale = 0.1 * product.max_grouping_scale
    per_gaussian_features = product.gaussian_affinities(scale)
 

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -1,0 +1,84 @@
+GARfVDB instance segmentation
+=============================
+
+GARfVDB learns a scale-conditioned instance feature field from an existing Gaussian reconstruction. The Gaussian
+splat is an input and rendering carrier; the resulting product is a separate, portable instance-segmentation field.
+
+Train from an existing reconstruction
+-------------------------------------
+
+First reconstruct the scene, then train GARfVDB against the same posed-image dataset:
+
+.. code-block:: console
+
+   frgs reconstruct --run-name safety-park data/safety_park -o safety-park.ply
+   frgs instance-segmentation data/safety_park \
+       --reconstruction-path safety-park.ply \
+       --out-path safety-park.garfvdb
+
+The reconstruction must have been produced by fVDB Reality Capture and contain its ``normalization_transform``
+metadata. Training checkpoints and metrics are written beneath ``frgs_logs`` by default.
+
+Scene transforms and mask supervision
+-------------------------------------
+
+GARfVDB uses the standard Reality Capture scene-transform pipeline for alignment, point filtering, image
+downsampling, image filtering, and cropping. Its SAM2 step is appended as the terminal transform because its mask
+rasters and grouping scales describe the final image dimensions and scene coordinate system.
+
+The resulting supervision is attached to the scene as a registered ``GARfVDBMaskAttribute`` named
+``garfvdb_masks``. It does not replace ``SfmScene.cache`` or discard other scene attributes. Other segmentation
+products can attach their own namespaced attribute and terminal transform, use different SAM2 settings or
+post-processing, and coexist on the same scene without adopting GARfVDB's mask/CDF/scale data contract.
+
+Portable artifact
+-----------------
+
+``safety-park.garfvdb`` is a versioned directory containing:
+
+* ``manifest.json`` — schema identity and version, configuration, ordered grid metadata, and payload checksums.
+* ``encoder.nvdb`` — the ordered multiresolution grid topology and learned per-voxel features.
+* ``network.safetensors`` — dense network parameters and scale-quantile lookup tensors.
+* ``carrier.ply`` — the exact filtered Gaussian scene carrier and its reconstruction metadata.
+
+The bundle contains no PyTorch pickle payload. It can be moved and loaded without the original dataset or
+reconstruction. Training and resume still require the source image paths recorded in the checkpoint.
+
+Bundle compatibility
+--------------------
+
+Every manifest identifies the format with ``schema: "fvdb_reality_capture.garfvdb"`` and an integer
+``schema_version``. The initial format is schema version 1. Loading dispatches to a reader for that exact version;
+unknown versions fail before any payload is loaded. A bundle written by a newer release reports that the installed
+Reality Capture package must be upgraded. Future format changes can retain an older reader or add an explicit
+migration without guessing from package versions or payload contents.
+
+Visualize and query
+-------------------
+
+.. code-block:: console
+
+   frgs show safety-park.garfvdb --scale-fraction 0.1 --mask-blend 0.5
+
+The Python API accepts grouping scales in scene units:
+
+.. code-block:: python
+
+   from fvdb_reality_capture.instance_segmentation import GARfVDB
+
+   product = GARfVDB.load("safety-park.garfvdb", device="cuda")
+   scale = 0.1 * product.max_grouping_scale
+   per_gaussian_features = product.gaussian_affinities(scale)
+
+Resume training
+---------------
+
+``frgs resume`` reads the generic training-checkpoint envelope and dispatches the stable
+``instance_segmentation.garfvdb`` method ID to the GARfVDB resume handler. If the reconstruction moved, pass its new
+path explicitly. Portable ``.garfvdb`` products are inference artifacts and cannot be resumed:
+
+.. code-block:: console
+
+   frgs resume frgs_logs/my-run/checkpoints/00010000/train_ckpt.pt \
+       --reconstruction-path safety-park.ply \
+       --out-path safety-park-resumed.garfvdb

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -12,7 +12,7 @@ First reconstruct the scene, then train GARfVDB against the same posed-image dat
 .. code-block:: console
 
    frgs reconstruct --run-name safety-park data/safety_park -o safety-park.ply
-   frgs instance-segmentation data/safety_park \
+   frgs segment-instances data/safety_park \
        --reconstruction-path safety-park.ply \
        --out-path safety-park.garfvdb
 

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -73,7 +73,7 @@ The Python API accepts grouping scales in scene units:
 Resume training
 ---------------
 
-``frgs resume`` reads the generic training-checkpoint envelope and dispatches the stable
+``frgs resume`` reads the generic training-checkpoint container and dispatches the stable
 ``instance_segmentation.garfvdb`` method ID to the GARfVDB resume handler. If the reconstruction moved, pass its new
 path explicitly. Portable ``.garfvdb`` products are inference artifacts and cannot be resumed:
 

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -16,8 +16,10 @@ First reconstruct the scene, then train GARfVDB against the same posed-image dat
        --reconstruction-path safety-park.ply \
        --out-path safety-park.garfvdb
 
-The reconstruction must have been produced by fVDB Reality Capture and contain its ``normalization_transform``
-metadata. Training checkpoints and metrics are written beneath ``frgs_logs`` by default.
+The reconstruction must have been produced by fVDB Reality Capture and contain its ``normalization_transform`` and
+``camera_to_world_matrices`` metadata. GARfVDB applies the reconstruction's final camera poses after scene alignment,
+including any pose adjustments learned during reconstruction. Training checkpoints and metrics are written beneath
+``frgs_logs`` by default.
 
 Scene transforms and mask supervision
 -------------------------------------

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -22,7 +22,7 @@ metadata. Training checkpoints and metrics are written beneath ``frgs_logs`` by 
 Scene transforms and mask supervision
 -------------------------------------
 
-GARfVDB uses the standard Reality Capture scene-transform pipeline for alignment, point filtering, image
+GARfVDB uses fVDB Reality Capture's scene-transform pipeline for alignment, point filtering, image
 downsampling, image filtering, and cropping. Its SAM2 step is appended as the terminal transform because its mask
 rasters and grouping scales describe the final image dimensions and scene coordinate system.
 

--- a/docs/tutorials/instance_segmentation.rst
+++ b/docs/tutorials/instance_segmentation.rst
@@ -2,7 +2,7 @@ GARfVDB instance segmentation
 =============================
 
 GARfVDB learns a scale-conditioned instance feature field from an existing Gaussian reconstruction. The Gaussian
-splat is an input and rendering carrier; the resulting product is a separate, portable instance-segmentation field.
+splat is an input and rendering base; the resulting product is a separate, portable instance-segmentation field.
 
 Train from an existing reconstruction
 -------------------------------------
@@ -39,7 +39,7 @@ Portable artifact
 * ``manifest.json`` — schema identity and version, configuration, ordered grid metadata, and payload checksums.
 * ``encoder.nvdb`` — the ordered multiresolution grid topology and learned per-voxel features.
 * ``network.safetensors`` — dense network parameters and scale-quantile lookup tensors.
-* ``carrier.ply`` — the exact filtered Gaussian scene carrier and its reconstruction metadata.
+* ``gaussians.ply`` — the exact filtered Gaussians and their reconstruction metadata.
 
 The bundle contains no PyTorch pickle payload. It can be moved and loaded without the original dataset or
 reconstruction. Training and resume still require the source image paths recorded in the checkpoint.

--- a/fvdb_reality_capture/__init__.py
+++ b/fvdb_reality_capture/__init__.py
@@ -4,7 +4,8 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from . import dev, foundation_models, radiance_fields, sfm_scene, tools, transforms
+from . import checkpoints, dev, foundation_models, radiance_fields, sfm_scene, tools, transforms
+from . import instance_segmentation
 from .tools import download_example_data
 
 try:
@@ -14,8 +15,10 @@ except PackageNotFoundError:
 
 __all__ = [
     "__version__",
+    "checkpoints",
     "dev",
     "foundation_models",
+    "instance_segmentation",
     "radiance_fields",
     "sfm_scene",
     "tools",

--- a/fvdb_reality_capture/checkpoints.py
+++ b/fvdb_reality_capture/checkpoints.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 
-"""Method-neutral, versioned training-checkpoint envelope I/O."""
+"""Method-neutral, versioned training-checkpoint container I/O."""
 
 from __future__ import annotations
 
@@ -34,7 +34,7 @@ class TrainingCheckpoint:
     schema_version: int = TRAINING_CHECKPOINT_SCHEMA_VERSION
 
     def to_dict(self) -> dict[str, Any]:
-        """Return the serialized checkpoint envelope."""
+        """Return the serialized checkpoint container."""
         return {
             "schema": TRAINING_CHECKPOINT_SCHEMA,
             "schema_version": self.schema_version,
@@ -50,7 +50,7 @@ def create_training_checkpoint(
     *,
     method_version: str,
 ) -> TrainingCheckpoint:
-    """Create a current-version checkpoint envelope around method-owned state."""
+    """Create a current-version checkpoint container around method-owned state."""
     if not isinstance(method, str) or not method:
         raise TrainingCheckpointError("Checkpoint method must be a non-empty string")
     if not isinstance(state, dict):
@@ -83,14 +83,14 @@ _LEGACY_CHECKPOINT_ADAPTERS: list[LegacyCheckpointAdapter] = []
 
 
 def register_legacy_checkpoint_adapter(adapter: LegacyCheckpointAdapter) -> None:
-    """Register a method-owned reader for a pre-envelope checkpoint format."""
+    """Register a method-owned reader for a pre-container checkpoint format."""
     if adapter in _LEGACY_CHECKPOINT_ADAPTERS:
         raise ValueError("Legacy checkpoint adapter is already registered")
     _LEGACY_CHECKPOINT_ADAPTERS.append(adapter)
 
 
 def parse_training_checkpoint(root: Any) -> TrainingCheckpoint:
-    """Validate an envelope or ask registered method-owned legacy adapters."""
+    """Validate an container or ask registered method-owned legacy adapters."""
     if not isinstance(root, dict):
         raise TrainingCheckpointError(f"Checkpoint root must be a dictionary, got {type(root).__name__}")
 

--- a/fvdb_reality_capture/checkpoints.py
+++ b/fvdb_reality_capture/checkpoints.py
@@ -90,7 +90,7 @@ def register_legacy_checkpoint_adapter(adapter: LegacyCheckpointAdapter) -> None
 
 
 def parse_training_checkpoint(root: Any) -> TrainingCheckpoint:
-    """Validate an container or ask registered method-owned legacy adapters."""
+    """Validate a container or ask registered method-owned legacy adapters."""
     if not isinstance(root, dict):
         raise TrainingCheckpointError(f"Checkpoint root must be a dictionary, got {type(root).__name__}")
 

--- a/fvdb_reality_capture/checkpoints.py
+++ b/fvdb_reality_capture/checkpoints.py
@@ -1,0 +1,163 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Method-neutral, versioned training-checkpoint envelope I/O."""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import torch
+
+TRAINING_CHECKPOINT_SCHEMA = "fvdb_reality_capture.training_checkpoint"
+TRAINING_CHECKPOINT_SCHEMA_VERSION = 1
+
+
+class TrainingCheckpointError(ValueError):
+    """Raised when a training checkpoint is invalid or unsupported."""
+
+
+class TrainingCheckpointVersionError(TrainingCheckpointError):
+    """Raised when no reader exists for a checkpoint schema version."""
+
+
+@dataclass(frozen=True)
+class TrainingCheckpoint:
+    """Validated method-neutral checkpoint metadata and method-owned state."""
+
+    method: str
+    method_version: str
+    state: dict[str, Any]
+    schema_version: int = TRAINING_CHECKPOINT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the serialized checkpoint envelope."""
+        return {
+            "schema": TRAINING_CHECKPOINT_SCHEMA,
+            "schema_version": self.schema_version,
+            "method": self.method,
+            "method_version": self.method_version,
+            "state": self.state,
+        }
+
+
+def create_training_checkpoint(
+    method: str,
+    state: dict[str, Any],
+    *,
+    method_version: str,
+) -> TrainingCheckpoint:
+    """Create a current-version checkpoint envelope around method-owned state."""
+    if not isinstance(method, str) or not method:
+        raise TrainingCheckpointError("Checkpoint method must be a non-empty string")
+    if not isinstance(state, dict):
+        raise TrainingCheckpointError(f"Checkpoint state must be a dictionary, got {type(state).__name__}")
+    if not isinstance(method_version, str) or not method_version:
+        raise TrainingCheckpointError("Checkpoint method_version must be a non-empty string")
+    return TrainingCheckpoint(method=method, method_version=method_version, state=state)
+
+
+def _read_training_checkpoint_v1(root: Mapping[str, Any]) -> TrainingCheckpoint:
+    method = root.get("method")
+    method_version = root.get("method_version")
+    state = root.get("state")
+    if not isinstance(method, str) or not method:
+        raise TrainingCheckpointError("Checkpoint method must be a non-empty string")
+    if not isinstance(method_version, str) or not method_version:
+        raise TrainingCheckpointError("Checkpoint method_version must be a non-empty string")
+    if not isinstance(state, dict):
+        raise TrainingCheckpointError(f"Checkpoint state must be a dictionary, got {type(state).__name__}")
+    return TrainingCheckpoint(method=method, method_version=method_version, state=state)
+
+
+_CHECKPOINT_READERS: dict[int, Callable[[Mapping[str, Any]], TrainingCheckpoint]] = {
+    1: _read_training_checkpoint_v1,
+}
+SUPPORTED_TRAINING_CHECKPOINT_SCHEMA_VERSIONS = tuple(sorted(_CHECKPOINT_READERS))
+
+LegacyCheckpointAdapter: TypeAlias = Callable[[Mapping[str, Any]], TrainingCheckpoint | None]
+_LEGACY_CHECKPOINT_ADAPTERS: list[LegacyCheckpointAdapter] = []
+
+
+def register_legacy_checkpoint_adapter(adapter: LegacyCheckpointAdapter) -> None:
+    """Register a method-owned reader for a pre-envelope checkpoint format."""
+    if adapter in _LEGACY_CHECKPOINT_ADAPTERS:
+        raise ValueError("Legacy checkpoint adapter is already registered")
+    _LEGACY_CHECKPOINT_ADAPTERS.append(adapter)
+
+
+def parse_training_checkpoint(root: Any) -> TrainingCheckpoint:
+    """Validate an envelope or ask registered method-owned legacy adapters."""
+    if not isinstance(root, dict):
+        raise TrainingCheckpointError(f"Checkpoint root must be a dictionary, got {type(root).__name__}")
+
+    if root.get("schema") == TRAINING_CHECKPOINT_SCHEMA:
+        schema_version = root.get("schema_version")
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool) or schema_version < 1:
+            raise TrainingCheckpointVersionError(
+                f"Training checkpoint has an invalid or missing schema_version: {schema_version!r}"
+            )
+        reader = _CHECKPOINT_READERS.get(schema_version)
+        if reader is None:
+            supported = ", ".join(str(version) for version in SUPPORTED_TRAINING_CHECKPOINT_SCHEMA_VERSIONS)
+            detail = (
+                "The checkpoint was written by a newer fvdb-reality-capture release."
+                if schema_version > TRAINING_CHECKPOINT_SCHEMA_VERSION
+                else "This release has no reader for that older checkpoint version."
+            )
+            raise TrainingCheckpointVersionError(
+                f"Unsupported training checkpoint schema_version {schema_version}; supported versions: "
+                f"{supported}. {detail}"
+            )
+        return reader(root)
+
+    if "schema" in root:
+        raise TrainingCheckpointError(
+            f"Unsupported checkpoint schema {root.get('schema')!r}; expected {TRAINING_CHECKPOINT_SCHEMA!r}"
+        )
+
+    for adapter in _LEGACY_CHECKPOINT_ADAPTERS:
+        checkpoint = adapter(root)
+        if checkpoint is not None:
+            return checkpoint
+
+    raise TrainingCheckpointError(
+        "Checkpoint is not a versioned fvdb-reality-capture training checkpoint and has no supported legacy format"
+    )
+
+
+def load_training_checkpoint(
+    path: str | pathlib.Path,
+    *,
+    map_location: str | torch.device = "cpu",
+    expected_method: str | None = None,
+) -> TrainingCheckpoint:
+    """Load and validate a training checkpoint from disk."""
+    checkpoint_path = pathlib.Path(path)
+    if checkpoint_path.is_dir():
+        raise TrainingCheckpointError(f"Training checkpoint path is a directory, not a checkpoint file: {path}")
+    if not checkpoint_path.is_file():
+        raise FileNotFoundError(f"Training checkpoint does not exist: {checkpoint_path}")
+    root = torch.load(checkpoint_path, map_location=map_location, weights_only=False)
+    checkpoint = parse_training_checkpoint(root)
+    if expected_method is not None and checkpoint.method != expected_method:
+        raise TrainingCheckpointError(f"Checkpoint method is {checkpoint.method!r}; expected {expected_method!r}")
+    return checkpoint
+
+
+__all__ = [
+    "LegacyCheckpointAdapter",
+    "SUPPORTED_TRAINING_CHECKPOINT_SCHEMA_VERSIONS",
+    "TRAINING_CHECKPOINT_SCHEMA",
+    "TRAINING_CHECKPOINT_SCHEMA_VERSION",
+    "TrainingCheckpoint",
+    "TrainingCheckpointError",
+    "TrainingCheckpointVersionError",
+    "create_training_checkpoint",
+    "load_training_checkpoint",
+    "parse_training_checkpoint",
+    "register_legacy_checkpoint_adapter",
+]

--- a/fvdb_reality_capture/cli/frgs/__init__.py
+++ b/fvdb_reality_capture/cli/frgs/__init__.py
@@ -9,6 +9,7 @@ from fvdb_reality_capture.cli import BaseCommand
 from ._convert import Convert
 from ._download import Download
 from ._evaluate import Evaluate
+from ._instance_segmentation import InstanceSegmentation
 from ._mesh_basic import MeshBasic
 from ._mesh_dlnr import MeshDLNR
 from ._points import Points
@@ -23,6 +24,7 @@ def frgs():
         Download
         | Reconstruct
         | ReconstructMCMC
+        | InstanceSegmentation
         | Convert
         | ShowData
         | Show

--- a/fvdb_reality_capture/cli/frgs/__init__.py
+++ b/fvdb_reality_capture/cli/frgs/__init__.py
@@ -9,7 +9,7 @@ from fvdb_reality_capture.cli import BaseCommand
 from ._convert import Convert
 from ._download import Download
 from ._evaluate import Evaluate
-from ._instance_segmentation import InstanceSegmentation
+from ._segment_instances import SegmentInstances
 from ._mesh_basic import MeshBasic
 from ._mesh_dlnr import MeshDLNR
 from ._points import Points
@@ -24,7 +24,7 @@ def frgs():
         Download
         | Reconstruct
         | ReconstructMCMC
-        | InstanceSegmentation
+        | SegmentInstances
         | Convert
         | ShowData
         | Show

--- a/fvdb_reality_capture/cli/frgs/_common.py
+++ b/fvdb_reality_capture/cli/frgs/_common.py
@@ -7,40 +7,29 @@ from typing import Literal
 
 import torch
 from fvdb import CameraModel, GaussianSplat3d
-from fvdb.types import DeviceIdentifier, to_Mat33fBatch, to_Mat44fBatch, to_Vec2iBatch
+from fvdb.types import to_Mat33fBatch, to_Mat44fBatch, to_Vec2iBatch
 
-from fvdb_reality_capture.radiance_fields import GaussianSplatReconstruction
+from fvdb_reality_capture.radiance_fields import GaussianSplatReconstruction, load_splats_from_file
 from fvdb_reality_capture.sfm_scene import SfmScene
 from fvdb_reality_capture.tools import export_splats_to_usd
 
 DatasetType = Literal["colmap", "simple_directory", "e57"]
 NearFarUnits = Literal["absolute", "camera_extent", "median_depth"]
 
-
-def load_splats_from_file(path: pathlib.Path, device: DeviceIdentifier) -> tuple[GaussianSplat3d, dict]:
-    """
-    Load a PLY or a checkpoint file and metadata.
-    The metadata may contain camera information (if it was a PLY saved during training).
-    If so, we will add the camera views to the viewer.
-
-    Args:
-        path (pathlib.Path): Path to the PLY or checkpoint file.
-        device (DeviceIdentifier): Device to load the model onto.
-    Returns:
-        model (GaussianSplat3d): The loaded Gaussian Splat model.
-        metadata (dict): The metadata associated with the model.
-    """
-    if path.suffix.lower() == ".ply":
-        model, metadata = GaussianSplat3d.from_ply(path, device)
-    elif path.suffix.lower() in (".pt", ".pth"):
-        checkpoint = torch.load(path, map_location=device, weights_only=False)
-        runner = GaussianSplatReconstruction.from_state_dict(checkpoint, device=device)
-        model = runner.model
-        metadata = runner.reconstruction_metadata
-    else:
-        raise ValueError("Input path must end in .ply, .pt, or .pth")
-
-    return model, metadata
+# ``load_splats_from_file`` is implemented in the library layer (``radiance_fields``) because the
+# GARfVDB trainer's public resume API also needs it and must not depend on CLI internals. It is
+# re-exported here so all of the CLI load/save helpers remain importable from one place. Listing it in
+# ``__all__`` marks the re-export as intentional so it is not stripped by an unused-import pass.
+__all__ = [
+    "DatasetType",
+    "NearFarUnits",
+    "load_camera_metadata",
+    "load_sfm_scene",
+    "load_splats_from_file",
+    "near_far_for_units",
+    "save_model_from_runner",
+    "save_model_from_splats",
+]
 
 
 def load_sfm_scene(path: pathlib.Path, dataset_type: DatasetType) -> SfmScene:

--- a/fvdb_reality_capture/cli/frgs/_convert.py
+++ b/fvdb_reality_capture/cli/frgs/_convert.py
@@ -10,6 +10,8 @@ import point_cloud_utils as pcu
 import torch
 import tyro
 from fvdb import GaussianSplat3d
+from fvdb_reality_capture.checkpoints import load_training_checkpoint
+from fvdb_reality_capture.radiance_fields.checkpoint import GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD
 
 from fvdb_reality_capture.cli import BaseCommand
 from fvdb_reality_capture.radiance_fields import GaussianSplatReconstruction
@@ -123,8 +125,12 @@ class Convert(BaseCommand):
             model, metadata = GaussianSplat3d.from_ply(self.in_path)
             logger.info(f"Loaded Gaussian Splat model with {model.num_gaussians} splats from {self.in_path}")
         elif in_file_type in (".pt", ".pth"):
-            checkpoint = torch.load(self.in_path, map_location="cpu", weights_only=False)
-            runner = GaussianSplatReconstruction.from_state_dict(checkpoint)
+            checkpoint = load_training_checkpoint(
+                self.in_path,
+                map_location="cpu",
+                expected_method=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+            )
+            runner = GaussianSplatReconstruction.from_state_dict(checkpoint.state)
             model = runner.model
             metadata = runner.reconstruction_metadata
             logger.info(f"Loaded Gaussian Splat model with {model.num_gaussians} splats from {self.in_path}")

--- a/fvdb_reality_capture/cli/frgs/_evaluate.py
+++ b/fvdb_reality_capture/cli/frgs/_evaluate.py
@@ -69,8 +69,8 @@ class Evaluate(BaseCommand):
     # Whether to save the rendered images. Defaults to True.
     save_images: Annotated[bool, arg(aliases=["-s"])] = True
 
-    # Device to use for computation. Defaults to "cuda".
-    device: str | torch.device = "cuda"
+    # Device to use for computation. Defaults to "cuda:0".
+    device: str | torch.device = "cuda:0"
 
     def execute(self) -> None:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s : %(message)s")

--- a/fvdb_reality_capture/cli/frgs/_evaluate.py
+++ b/fvdb_reality_capture/cli/frgs/_evaluate.py
@@ -11,6 +11,9 @@ import torch
 import tyro
 from tyro.conf import arg
 
+from fvdb_reality_capture.checkpoints import load_training_checkpoint
+from fvdb_reality_capture.radiance_fields.checkpoint import GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD
+
 from fvdb_reality_capture.cli import BaseCommand
 from fvdb_reality_capture.radiance_fields import (
     GaussianSplatReconstruction,
@@ -80,7 +83,11 @@ class Evaluate(BaseCommand):
             self.log_path = self.checkpoint_path.parent / "eval"
 
         logger.info(f"Evaluating checkpoint: {self.checkpoint_path}")
-        checkpoint_state = torch.load(self.checkpoint_path, map_location=self.device, weights_only=False)
+        checkpoint_state = load_training_checkpoint(
+            self.checkpoint_path,
+            map_location=self.device,
+            expected_method=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+        ).state
         writer_config = GaussianSplatReconstructionWriterConfig(
             save_images=self.save_images,
             save_metrics=True,

--- a/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
+++ b/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
@@ -101,7 +101,7 @@ class InstanceSegmentation(BaseCommand):
             raise ValueError("frgs instance-segmentation requires --cfg.model.use-grid")
 
         if self.viewer:
-            # Vulkan must be initialized before any CUDA payloads (the carrier/model) are loaded.
+            # Vulkan must be initialized before any CUDA payloads (the Gaussian model) are loaded.
             import fvdb.viz as fviz
 
             logger.info("Starting live training viewer on %s:%d", self.viewer_ip_address, self.viewer_port)
@@ -109,8 +109,8 @@ class InstanceSegmentation(BaseCommand):
 
         logger.info("Loading dataset from %s", self.dataset_path)
         sfm_scene = load_sfm_scene(self.dataset_path, self.dataset_type)
-        logger.info("Loading Gaussian carrier from %s", self.reconstruction_path)
-        carrier, metadata = load_splats_from_file(self.reconstruction_path, self.device)
+        logger.info("Loading Gaussian model from %s", self.reconstruction_path)
+        gaussians, metadata = load_splats_from_file(self.reconstruction_path, self.device)
         normalization_transform = metadata.get("normalization_transform")
         if normalization_transform is None:
             raise ValueError(
@@ -119,7 +119,7 @@ class InstanceSegmentation(BaseCommand):
             )
 
         self.tx.device = self.device
-        transformed_scene = self.tx.build_scene_transforms(carrier, normalization_transform)(sfm_scene)
+        transformed_scene = self.tx.build_scene_transforms(gaussians, normalization_transform)(sfm_scene)
         writer = GARfVDBWriter(
             run_name=self.run_name,
             save_path=self.io.log_path,
@@ -128,7 +128,7 @@ class InstanceSegmentation(BaseCommand):
         )
         trainer = GARfVDBTrainer.new(
             sfm_scene=transformed_scene,
-            gs_model=carrier,
+            gs_model=gaussians,
             gs_model_path=self.reconstruction_path,
             writer=writer,
             config=self.cfg,

--- a/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
+++ b/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
@@ -1,0 +1,119 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import pathlib
+from dataclasses import dataclass, field
+from typing import Annotated
+
+import torch
+from tyro.conf import Positional, arg
+
+from fvdb_reality_capture.cli import BaseCommand
+from fvdb_reality_capture.instance_segmentation import (
+    GARfVDBTrainer,
+    GARfVDBTrainingConfig,
+    GARfVDBTransformConfig,
+)
+from fvdb_reality_capture.instance_segmentation.training.segmentation_writer import (
+    GARfVDBWriter,
+    GARfVDBWriterConfig,
+)
+
+from ._common import DatasetType, load_sfm_scene, load_splats_from_file
+
+
+@dataclass
+class InstanceSegmentationWriterConfig(GARfVDBWriterConfig):
+    """Configure GARfVDB metrics, images, and training checkpoints."""
+
+    log_path: pathlib.Path | None = pathlib.Path("frgs_logs")
+    """Base directory for run logs. Set to ``None`` to disable disk logging."""
+
+    log_every: int = 10
+    """Log metrics every N training steps."""
+
+
+@dataclass
+class InstanceSegmentation(BaseCommand):
+    """Train a GARfVDB scale-conditioned instance feature field from an existing reconstruction.
+
+    Example:
+        frgs instance-segmentation ./colmap_dataset \
+            --reconstruction-path scene.ply \
+            --out-path scene.garfvdb
+    """
+
+    dataset_path: Positional[pathlib.Path]
+    """Dataset containing the images and camera poses used by the reconstruction."""
+
+    reconstruction_path: Annotated[pathlib.Path, arg(aliases=["-r"])]
+    """Existing Reality Capture PLY or reconstruction checkpoint."""
+
+    out_path: Annotated[pathlib.Path, arg(aliases=["-o"])] = pathlib.Path("out.garfvdb")
+    """Portable output bundle. The path must end in ``.garfvdb``."""
+
+    run_name: Annotated[str | None, arg(aliases=["-n"])] = None
+    dataset_type: Annotated[DatasetType, arg(aliases=["-dt"])] = "colmap"
+    use_every_n_as_val: Annotated[int, arg(aliases=["-vn"])] = -1
+    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda"
+    verbose: Annotated[bool, arg(aliases=["-v"])] = False
+    cache_dataset: bool = True
+
+    cfg: GARfVDBTrainingConfig = field(default_factory=GARfVDBTrainingConfig)
+    tx: GARfVDBTransformConfig = field(default_factory=GARfVDBTransformConfig)
+    io: InstanceSegmentationWriterConfig = field(default_factory=InstanceSegmentationWriterConfig)
+
+    def execute(self) -> None:
+        logging.basicConfig(
+            level=logging.DEBUG if self.verbose else logging.INFO,
+            format="%(levelname)s : %(message)s",
+        )
+        logger = logging.getLogger(__name__)
+        if self.out_path.suffix != ".garfvdb":
+            raise ValueError("GARfVDB output path must end in .garfvdb")
+        if self.out_path.exists():
+            raise FileExistsError(f"Output path already exists: {self.out_path}")
+        if not self.reconstruction_path.exists():
+            raise FileNotFoundError(f"Reconstruction does not exist: {self.reconstruction_path}")
+        if not self.cfg.model.use_grid:
+            raise ValueError("frgs instance-segmentation requires --cfg.model.use-grid")
+
+        logger.info("Loading dataset from %s", self.dataset_path)
+        sfm_scene = load_sfm_scene(self.dataset_path, self.dataset_type)
+        logger.info("Loading Gaussian carrier from %s", self.reconstruction_path)
+        carrier, metadata = load_splats_from_file(self.reconstruction_path, self.device)
+        normalization_transform = metadata.get("normalization_transform")
+        if normalization_transform is None:
+            raise ValueError(
+                "Reconstruction metadata does not contain normalization_transform. "
+                "Use a PLY or checkpoint produced by fvdb-reality-capture."
+            )
+
+        self.tx.device = self.device
+        transformed_scene = self.tx.build_scene_transforms(carrier, normalization_transform)(sfm_scene)
+        writer = GARfVDBWriter(
+            run_name=self.run_name,
+            save_path=self.io.log_path,
+            config=self.io,
+            exist_ok=False,
+        )
+        trainer = GARfVDBTrainer.new(
+            sfm_scene=transformed_scene,
+            gs_model=carrier,
+            gs_model_path=self.reconstruction_path,
+            writer=writer,
+            config=self.cfg,
+            device=self.device,
+            use_every_n_as_val=self.use_every_n_as_val,
+            viewer_update_interval_epochs=-1,
+            log_interval_steps=self.io.log_every,
+            cache_dataset=self.cache_dataset,
+            reconstruction_metadata=metadata,
+        )
+        trainer.train()
+        logger.info("Saving portable GARfVDB bundle to %s", self.out_path)
+        trainer.to_product().save(self.out_path)
+
+
+__all__ = ["InstanceSegmentation", "InstanceSegmentationWriterConfig"]

--- a/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
+++ b/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
@@ -117,9 +117,20 @@ class InstanceSegmentation(BaseCommand):
                 "Reconstruction metadata does not contain normalization_transform. "
                 "Use a PLY or checkpoint produced by fvdb-reality-capture."
             )
+        reconstruction_camera_to_world_matrices = metadata.get("camera_to_world_matrices")
+        if reconstruction_camera_to_world_matrices is None:
+            raise ValueError(
+                "Reconstruction metadata does not contain camera_to_world_matrices. "
+                "Use a PLY or checkpoint produced by fvdb-reality-capture."
+            )
 
         self.tx.device = self.device
-        transformed_scene = self.tx.build_scene_transforms(gaussians, normalization_transform)(sfm_scene)
+        transformed_scene = self.tx.build_scene_transforms(
+            gaussians,
+            normalization_transform,
+            reconstruction_camera_to_world_matrices=reconstruction_camera_to_world_matrices,
+            reconstruction_image_ids=metadata.get("image_ids"),
+        )(sfm_scene)
         writer = GARfVDBWriter(
             run_name=self.run_name,
             save_path=self.io.log_path,

--- a/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
+++ b/fvdb_reality_capture/cli/frgs/_instance_segmentation.py
@@ -56,9 +56,30 @@ class InstanceSegmentation(BaseCommand):
     run_name: Annotated[str | None, arg(aliases=["-n"])] = None
     dataset_type: Annotated[DatasetType, arg(aliases=["-dt"])] = "colmap"
     use_every_n_as_val: Annotated[int, arg(aliases=["-vn"])] = -1
-    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda"
+    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda:0"
     verbose: Annotated[bool, arg(aliases=["-v"])] = False
     cache_dataset: bool = True
+
+    viewer: bool = False
+    """Launch a live fvdb viewer during training with interactive grouping-scale, overlay-opacity,
+    and show/hide controls for the segmentation feature overlay."""
+    viewer_port: int = 8080
+    """Port to expose the live training viewer server on (only used when --viewer is set)."""
+    viewer_ip_address: str = "127.0.0.1"
+    """IP address to expose the live training viewer server on (only used when --viewer is set)."""
+    viewer_scale_fraction: float = 0.1
+    """Initial grouping scale as a fraction in [0, 1] of the model's maximum scale (viewer slider seed)."""
+    viewer_mask_blend: float = 0.5
+    """Initial feature-overlay opacity in [0, 1] (viewer slider seed)."""
+    viewer_lock_pca_colors: bool = False
+    """Initial state of the viewer's "Lock PCA colors" toggle, which freezes the feature coloring so it
+    does not flicker as the camera moves (toggleable live)."""
+    viewer_overlay_width: int = 1440
+    """Live training viewer overlay width in pixels."""
+    viewer_overlay_height: int = 720
+    """Live training viewer overlay height in pixels."""
+    viewer_overlay_downsample: int = 2
+    """Live training viewer render downsample factor."""
 
     cfg: GARfVDBTrainingConfig = field(default_factory=GARfVDBTrainingConfig)
     tx: GARfVDBTransformConfig = field(default_factory=GARfVDBTransformConfig)
@@ -78,6 +99,13 @@ class InstanceSegmentation(BaseCommand):
             raise FileNotFoundError(f"Reconstruction does not exist: {self.reconstruction_path}")
         if not self.cfg.model.use_grid:
             raise ValueError("frgs instance-segmentation requires --cfg.model.use-grid")
+
+        if self.viewer:
+            # Vulkan must be initialized before any CUDA payloads (the carrier/model) are loaded.
+            import fvdb.viz as fviz
+
+            logger.info("Starting live training viewer on %s:%d", self.viewer_ip_address, self.viewer_port)
+            fviz.init(ip_address=self.viewer_ip_address, port=self.viewer_port, verbose=self.verbose)
 
         logger.info("Loading dataset from %s", self.dataset_path)
         sfm_scene = load_sfm_scene(self.dataset_path, self.dataset_type)
@@ -110,6 +138,13 @@ class InstanceSegmentation(BaseCommand):
             log_interval_steps=self.io.log_every,
             cache_dataset=self.cache_dataset,
             reconstruction_metadata=metadata,
+            enable_viewer=self.viewer,
+            viewer_scale_fraction=self.viewer_scale_fraction,
+            viewer_mask_blend=self.viewer_mask_blend,
+            viewer_lock_pca_colors=self.viewer_lock_pca_colors,
+            viewer_overlay_width=self.viewer_overlay_width,
+            viewer_overlay_height=self.viewer_overlay_height,
+            viewer_overlay_downsample=self.viewer_overlay_downsample,
         )
         trainer.train()
         logger.info("Saving portable GARfVDB bundle to %s", self.out_path)

--- a/fvdb_reality_capture/cli/frgs/_mesh_basic.py
+++ b/fvdb_reality_capture/cli/frgs/_mesh_basic.py
@@ -94,8 +94,8 @@ class MeshBasic(BaseCommand):
     # Path to save the extracted mesh (default is "mesh.ply").
     output_path: Annotated[pathlib.Path, arg(aliases=["-o"])] = pathlib.Path("mesh.ply")
 
-    # Device to use for computation (default is "cuda").
-    device: Annotated[str, arg(aliases=["-d"])] = "cuda"
+    # Device to use for computation (default is "cuda:0").
+    device: Annotated[str, arg(aliases=["-d"])] = "cuda:0"
 
     """
     Extract a mesh from a Gaussian Splat reconstruction.

--- a/fvdb_reality_capture/cli/frgs/_mesh_dlnr.py
+++ b/fvdb_reality_capture/cli/frgs/_mesh_dlnr.py
@@ -89,8 +89,8 @@ class MeshDLNR(BaseCommand):
     # Path to save the extracted mesh (default is "mesh.ply").
     output_path: Annotated[pathlib.Path, arg(aliases=["-o"])] = pathlib.Path("mesh.ply")
 
-    # Device to use for computation (default is "cuda").
-    device: Annotated[str, arg(aliases=["-d"])] = "cuda"
+    # Device to use for computation (default is "cuda:0").
+    device: Annotated[str, arg(aliases=["-d"])] = "cuda:0"
 
     """
     Extract a mesh from a Gaussian Splat reconstruction.

--- a/fvdb_reality_capture/cli/frgs/_points.py
+++ b/fvdb_reality_capture/cli/frgs/_points.py
@@ -82,8 +82,8 @@ class Points(BaseCommand):
     # Path to save the extracted mesh (default is "mesh.ply").
     output_path: Annotated[pathlib.Path, arg(aliases=["-o"])] = pathlib.Path("points.ply")
 
-    # Device to use for computation (default is "cuda").
-    device: Annotated[str, arg(aliases=["-d"])] = "cuda"
+    # Device to use for computation (default is "cuda:0").
+    device: Annotated[str, arg(aliases=["-d"])] = "cuda:0"
 
     def execute(self) -> None:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s : %(message)s")

--- a/fvdb_reality_capture/cli/frgs/_reconstruct.py
+++ b/fvdb_reality_capture/cli/frgs/_reconstruct.py
@@ -121,8 +121,8 @@ class Reconstruct(BaseCommand):
 
     # Which device to use for reconstruction. Must be a cuda device. You can pass in a specific device index via
     # cuda:N where N is the device index, or "cuda" to use the default cuda device.
-    # CPU is not supported. Default is "cuda".
-    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda"
+    # CPU is not supported. Default is "cuda:0".
+    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda:0"
 
     # If set, show verbose debug messages.
     verbose: Annotated[bool, arg(aliases=["-v"])] = False

--- a/fvdb_reality_capture/cli/frgs/_reconstruct.py
+++ b/fvdb_reality_capture/cli/frgs/_reconstruct.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 import fvdb.viz as fviz
-import numpy as np
 import torch
 import tqdm
 from fvdb import GaussianSplat3d
@@ -31,13 +30,8 @@ from fvdb_reality_capture.radiance_fields import (
 from fvdb_reality_capture.sfm_scene import SfmScene
 from fvdb_reality_capture.transforms import (
     BaseTransform,
-    Compose,
-    CropScene,
-    CropSceneToPoints,
-    DownsampleImages,
-    FilterImagesWithLowPoints,
     NormalizeScene,
-    PercentileFilterPoints,
+    SceneTransformConfig as BaseSceneTransformConfig,
 )
 
 from ._common import (
@@ -49,48 +43,22 @@ from ._common import (
 
 
 @dataclass
-class SceneTransformConfig:
+class SceneTransformConfig(BaseSceneTransformConfig):
     """
     Configure how an SfmScene is transformed before optimization.
     """
 
-    # Downsample images by this factor
     image_downsample_factor: int = 4
-    # JPEG quality to use when resaving images after downsampling
-    rescale_jpeg_quality: int = 95
-    # Percentile of points to filter out based on their distance from the median point
-    points_percentile_filter: float = 0.0
+    """Downsample images by this factor."""
+
     # Type of normalization to apply to the scene
     normalization_type: Literal["none", "pca", "ecef2enu", "similarity"] = "pca"
-    # Optional bounding box (in the normalized space) to crop the scene to (xmin, xmax, ymin, ymax, zmin, zmax)
-    crop_bbox: tuple[float, float, float, float, float, float] | None = None
-    # Whether to crop the scene to the bounding box or not
-    crop_to_points: bool = False
-    # Minimum number of 3D points that must be visible in an image for it to be included in the optimization
-    min_points_per_image: int = 5
-    # Bounding box to which we crop the scene (in the original space) (xmin, xmax, ymin, ymax, zmin, zmax)
-    crop_bbox: tuple[float, float, float, float, float, float] | None = None
 
     @property
     def scene_transform(self) -> BaseTransform:
-        # Dataset transform
-        transforms = [
-            NormalizeScene(normalization_type=self.normalization_type),
-            PercentileFilterPoints(
-                percentile_min=np.full((3,), self.points_percentile_filter),
-                percentile_max=np.full((3,), 100.0 - self.points_percentile_filter),
-            ),
-            DownsampleImages(
-                image_downsample_factor=self.image_downsample_factor,
-                rescaled_jpeg_quality=self.rescale_jpeg_quality,
-            ),
-            FilterImagesWithLowPoints(min_num_points=self.min_points_per_image),
-        ]
-        if self.crop_bbox is not None:
-            transforms.append(CropScene(self.crop_bbox))
-        if self.crop_to_points:
-            transforms.append(CropSceneToPoints(margin=0.0))
-        return Compose(*transforms)
+        return self.build_scene_transform(
+            alignment_transform=NormalizeScene(normalization_type=self.normalization_type),
+        )
 
 
 @dataclass

--- a/fvdb_reality_capture/cli/frgs/_resume.py
+++ b/fvdb_reality_capture/cli/frgs/_resume.py
@@ -11,14 +11,33 @@ import torch
 import tyro
 from tyro.conf import arg
 
+from fvdb_reality_capture.checkpoints import (
+    TrainingCheckpoint,
+    load_training_checkpoint,
+)
 from fvdb_reality_capture.cli import BaseCommand
+from fvdb_reality_capture.instance_segmentation import (
+    GARFVDB_TRAINING_METHOD,
+    GARfVDBTrainer,
+)
+from fvdb_reality_capture.instance_segmentation.training.segmentation_writer import (
+    GARfVDBWriter,
+    GARfVDBWriterConfig,
+)
 from fvdb_reality_capture.radiance_fields import (
+    GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
     GaussianSplatReconstruction,
     GaussianSplatReconstructionWriter,
     GaussianSplatReconstructionWriterConfig,
 )
 
 from ._common import save_model_from_runner
+from ._resume_registry import (
+    ResumeContext,
+    ResumeHandler,
+    get_resume_handler,
+    register_resume_handler,
+)
 
 
 @dataclass
@@ -38,9 +57,9 @@ class WriterConfig(GaussianSplatReconstructionWriterConfig):
 @dataclass
 class Resume(BaseCommand):
     """
-    Resume reconstructing a 3D Gaussian Splat radiance field from a checkpoint. This command loads a model
-    checkpoint and continues reconstruction from that point. The dataset used to create the checkpoint
-    must be at the same path as when the checkpoint was created.
+    Resume a Reality Capture training run. The versioned checkpoint envelope dispatches to the registered method
+    handler. Source dataset paths recorded by the checkpoint must remain available at the same path as when the
+    checkpoint was created.
 
     Example usage:
 
@@ -48,7 +67,7 @@ class Resume(BaseCommand):
         frgs resume checkpoint.pt -o out_resumed.ply
     """
 
-    # Path to the checkpoint file containing the Gaussian Splat radiance field.
+    # Path to a versioned Reality Capture training checkpoint.
     checkpoint_path: tyro.conf.Positional[pathlib.Path]
 
     # Configure saving and logging metrics, images, and checkpoints.
@@ -75,10 +94,12 @@ class Resume(BaseCommand):
     # If set, show verbose debug messages.
     verbose: Annotated[bool, arg(aliases=["-v"])] = False
 
-    # Path to save the output PLY file.
-    # Defaults to `out.ply` in the current working directory.
-    # Path must end in .ply, .usdc, or .usdz.
-    out_path: Annotated[pathlib.Path, arg(aliases=["-o"])] = pathlib.Path("out_resumed.ply")
+    # Output path. Defaults to out_resumed.ply for reconstruction checkpoints and
+    # out_resumed.garfvdb for GARfVDB checkpoints.
+    out_path: Annotated[pathlib.Path | None, arg(aliases=["-o"])] = None
+
+    reconstruction_path: Annotated[pathlib.Path | None, arg(aliases=["-r"])] = None
+    """Override the reconstruction referenced by a GARfVDB checkpoint if it moved."""
 
     def execute(self) -> None:
         log_level = logging.DEBUG if self.verbose else logging.INFO
@@ -86,28 +107,96 @@ class Resume(BaseCommand):
         logger = logging.getLogger(__name__)
 
         logger.info(f"Loading checkpoint at {self.checkpoint_path}")
-        checkpoint_state = torch.load(self.checkpoint_path, map_location=self.device, weights_only=False)
+        checkpoint = load_training_checkpoint(self.checkpoint_path, map_location=self.device)
+        handler = get_resume_handler(checkpoint.method)
+        out_path = self.out_path or pathlib.Path(handler.default_output_name)
+        logger.info("Dispatching checkpoint method %s", checkpoint.method)
+        handler.callback(checkpoint, self, out_path)
 
-        writer = GaussianSplatReconstructionWriter(
-            run_name=self.run_name, save_path=self.io.log_path, config=self.io, exist_ok=False
+
+def _resume_garfvdb(checkpoint: TrainingCheckpoint, command: ResumeContext, out_path: pathlib.Path) -> None:
+    if command.update_viz_every > 0:
+        raise ValueError("Live GARfVDB resume visualization is unsupported; resume first, then use frgs show.")
+    writer_config = GARfVDBWriterConfig(
+        save_images=command.io.save_images,
+        save_checkpoints=command.io.save_checkpoints,
+        save_metrics=command.io.save_metrics,
+        metrics_file_buffer_size=command.io.metrics_file_buffer_size,
+        use_tensorboard=command.io.use_tensorboard,
+        save_images_to_tensorboard=command.io.save_images_to_tensorboard,
+    )
+    writer = GARfVDBWriter(
+        run_name=command.run_name,
+        save_path=command.io.log_path,
+        config=writer_config,
+        exist_ok=False,
+    )
+    trainer = GARfVDBTrainer.from_checkpoint_state(
+        checkpoint.state,
+        writer=writer,
+        device=command.device,
+        reconstruction_path=command.reconstruction_path,
+    )
+    trainer.train()
+    logging.getLogger(__name__).info("Saving resumed GARfVDB product to %s", out_path)
+    trainer.to_product().save(out_path)
+
+
+def _resume_gaussian_splat(checkpoint: TrainingCheckpoint, command: ResumeContext, out_path: pathlib.Path) -> None:
+    writer_config = GaussianSplatReconstructionWriterConfig(
+        save_images=command.io.save_images,
+        save_checkpoints=command.io.save_checkpoints,
+        save_plys=command.io.save_plys,
+        save_metrics=command.io.save_metrics,
+        metrics_file_buffer_size=command.io.metrics_file_buffer_size,
+        use_tensorboard=command.io.use_tensorboard,
+        save_images_to_tensorboard=command.io.save_images_to_tensorboard,
+    )
+    writer = GaussianSplatReconstructionWriter(
+        run_name=command.run_name,
+        save_path=command.io.log_path,
+        config=writer_config,
+        exist_ok=False,
+    )
+    if command.update_viz_every > 0:
+        logging.getLogger(__name__).info(
+            "Starting viewer server on %s:%d",
+            command.viewer_ip_address,
+            command.viewer_port,
         )
-        if self.update_viz_every > 0:
-            logger.info(f"Starting viewer server on {self.viewer_ip_address}:{self.viewer_port}")
-            fviz.init(ip_address=self.viewer_ip_address, port=self.viewer_port, verbose=self.verbose)
-            viz_scene = fviz.get_scene("Gaussian Splat Reconstruction Visualization")
-        else:
-            viz_scene = None
-
-        runner = GaussianSplatReconstruction.from_state_dict(
-            checkpoint_state,
-            device=self.device,
-            writer=writer,
-            viz_scene=viz_scene,
-            log_interval_steps=self.io.log_every,
-            viz_update_interval_epochs=self.update_viz_every,
+        fviz.init(
+            ip_address=command.viewer_ip_address,
+            port=command.viewer_port,
+            verbose=command.verbose,
         )
+        viz_scene = fviz.get_scene("Gaussian Splat Reconstruction Visualization")
+    else:
+        viz_scene = None
 
-        runner.optimize()
+    runner = GaussianSplatReconstruction.from_state_dict(
+        checkpoint.state,
+        device=command.device,
+        writer=writer,
+        viz_scene=viz_scene,
+        log_interval_steps=command.io.log_every,
+        viz_update_interval_epochs=command.update_viz_every,
+    )
+    runner.optimize()
+    logging.getLogger(__name__).info("Saving final model to %s", out_path)
+    save_model_from_runner(out_path, runner)
 
-        logger.info(f"Saving final model to {self.out_path}")
-        save_model_from_runner(self.out_path, runner)
+
+register_resume_handler(
+    ResumeHandler(
+        method=GARFVDB_TRAINING_METHOD,
+        default_output_name="out_resumed.garfvdb",
+        callback=_resume_garfvdb,
+    )
+)
+register_resume_handler(
+    ResumeHandler(
+        method=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+        default_output_name="out_resumed.ply",
+        callback=_resume_gaussian_splat,
+    )
+)

--- a/fvdb_reality_capture/cli/frgs/_resume.py
+++ b/fvdb_reality_capture/cli/frgs/_resume.py
@@ -57,7 +57,7 @@ class WriterConfig(GaussianSplatReconstructionWriterConfig):
 @dataclass
 class Resume(BaseCommand):
     """
-    Resume a Reality Capture training run. The versioned checkpoint envelope dispatches to the registered method
+    Resume a Reality Capture training run. The versioned checkpoint container dispatches to the registered method
     handler. Source dataset paths recorded by the checkpoint must remain available at the same path as when the
     checkpoint was created.
 

--- a/fvdb_reality_capture/cli/frgs/_resume.py
+++ b/fvdb_reality_capture/cli/frgs/_resume.py
@@ -88,8 +88,8 @@ class Resume(BaseCommand):
 
     # Which device to use for reconstruction. Must be a cuda device. You can pass in a specific device index via
     # cuda:N where N is the device index, or "cuda" to use the default cuda device.
-    # CPU is not supported. Default is "cuda".
-    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda"
+    # CPU is not supported. Default is "cuda:0".
+    device: Annotated[str | torch.device, arg(aliases=["-d"])] = "cuda:0"
 
     # If set, show verbose debug messages.
     verbose: Annotated[bool, arg(aliases=["-v"])] = False

--- a/fvdb_reality_capture/cli/frgs/_resume_registry.py
+++ b/fvdb_reality_capture/cli/frgs/_resume_registry.py
@@ -1,0 +1,94 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI-owned dispatch registry for resumable training methods."""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+from fvdb_reality_capture.checkpoints import TrainingCheckpoint
+
+
+class ResumeWriterOptions(Protocol):
+    save_images: bool
+    save_checkpoints: bool
+    save_plys: bool
+    save_metrics: bool
+    metrics_file_buffer_size: int
+    use_tensorboard: bool
+    save_images_to_tensorboard: bool
+    log_path: pathlib.Path | None
+    log_every: int
+
+
+class ResumeContext(Protocol):
+    """Options available to method-specific resume callbacks."""
+
+    io: ResumeWriterOptions
+    run_name: str | None
+    update_viz_every: float
+    viewer_port: int
+    viewer_ip_address: str
+    device: str | torch.device
+    verbose: bool
+    reconstruction_path: pathlib.Path | None
+
+
+ResumeCallback = Callable[[TrainingCheckpoint, ResumeContext, pathlib.Path], None]
+
+
+class UnknownCheckpointMethodError(ValueError):
+    """Raised when no CLI resume handler is registered for a checkpoint method."""
+
+
+@dataclass(frozen=True)
+class ResumeHandler:
+    """Resume implementation registered for one stable checkpoint method ID."""
+
+    method: str
+    default_output_name: str
+    callback: ResumeCallback
+
+
+_RESUME_HANDLERS: dict[str, ResumeHandler] = {}
+
+
+def register_resume_handler(handler: ResumeHandler) -> None:
+    """Register a method-specific resume implementation."""
+    if not handler.method:
+        raise ValueError("Resume handler method must be non-empty")
+    if handler.method in _RESUME_HANDLERS:
+        raise ValueError(f"A resume handler is already registered for {handler.method!r}")
+    _RESUME_HANDLERS[handler.method] = handler
+
+
+def get_resume_handler(method: str) -> ResumeHandler:
+    """Return the handler for *method* or raise a diagnostic error."""
+    handler = _RESUME_HANDLERS.get(method)
+    if handler is None:
+        registered = ", ".join(sorted(_RESUME_HANDLERS)) or "none"
+        raise UnknownCheckpointMethodError(
+            f"No resume handler is registered for checkpoint method {method!r}. Registered methods: {registered}"
+        )
+    return handler
+
+
+def registered_resume_methods() -> tuple[str, ...]:
+    """Return stable method IDs with registered resume handlers."""
+    return tuple(sorted(_RESUME_HANDLERS))
+
+
+__all__ = [
+    "ResumeContext",
+    "ResumeHandler",
+    "UnknownCheckpointMethodError",
+    "get_resume_handler",
+    "register_resume_handler",
+    "registered_resume_methods",
+]

--- a/fvdb_reality_capture/cli/frgs/_segment_instances.py
+++ b/fvdb_reality_capture/cli/frgs/_segment_instances.py
@@ -24,7 +24,7 @@ from ._common import DatasetType, load_sfm_scene, load_splats_from_file
 
 
 @dataclass
-class InstanceSegmentationWriterConfig(GARfVDBWriterConfig):
+class SegmentInstancesWriterConfig(GARfVDBWriterConfig):
     """Configure GARfVDB metrics, images, and training checkpoints."""
 
     log_path: pathlib.Path | None = pathlib.Path("frgs_logs")
@@ -35,11 +35,11 @@ class InstanceSegmentationWriterConfig(GARfVDBWriterConfig):
 
 
 @dataclass
-class InstanceSegmentation(BaseCommand):
+class SegmentInstances(BaseCommand):
     """Train a GARfVDB scale-conditioned instance feature field from an existing reconstruction.
 
     Example:
-        frgs instance-segmentation ./colmap_dataset \
+        frgs segment-instances ./colmap_dataset \
             --reconstruction-path scene.ply \
             --out-path scene.garfvdb
     """
@@ -83,7 +83,7 @@ class InstanceSegmentation(BaseCommand):
 
     cfg: GARfVDBTrainingConfig = field(default_factory=GARfVDBTrainingConfig)
     tx: GARfVDBTransformConfig = field(default_factory=GARfVDBTransformConfig)
-    io: InstanceSegmentationWriterConfig = field(default_factory=InstanceSegmentationWriterConfig)
+    io: SegmentInstancesWriterConfig = field(default_factory=SegmentInstancesWriterConfig)
 
     def execute(self) -> None:
         logging.basicConfig(
@@ -98,7 +98,7 @@ class InstanceSegmentation(BaseCommand):
         if not self.reconstruction_path.exists():
             raise FileNotFoundError(f"Reconstruction does not exist: {self.reconstruction_path}")
         if not self.cfg.model.use_grid:
-            raise ValueError("frgs instance-segmentation requires --cfg.model.use-grid")
+            raise ValueError("frgs segment-instances requires --cfg.model.use-grid")
 
         if self.viewer:
             # Vulkan must be initialized before any CUDA payloads (the Gaussian model) are loaded.
@@ -162,4 +162,4 @@ class InstanceSegmentation(BaseCommand):
         trainer.to_product().save(self.out_path)
 
 
-__all__ = ["InstanceSegmentation", "InstanceSegmentationWriterConfig"]
+__all__ = ["SegmentInstances", "SegmentInstancesWriterConfig"]

--- a/fvdb_reality_capture/cli/frgs/_show.py
+++ b/fvdb_reality_capture/cli/frgs/_show.py
@@ -16,6 +16,8 @@ from fvdb.types import to_Mat33fBatch, to_Mat44fBatch, to_Vec2fBatch
 from tyro.conf import arg
 
 from fvdb_reality_capture.cli import BaseCommand
+from fvdb_reality_capture.instance_segmentation import is_garfvdb_bundle
+from fvdb_reality_capture.instance_segmentation.viewer import show_garfvdb_bundle
 
 from ._common import load_splats_from_file
 
@@ -23,8 +25,8 @@ from ._common import load_splats_from_file
 @dataclass
 class Show(BaseCommand):
     """
-    Visualize a Gaussian splat radiance field in a saved PLY or checkpoint file. This will plot the splats in an interactive viewer
-    shown in a browser window.
+    Visualize a saved Reality Capture product in an interactive browser viewer. Supported inputs are Gaussian PLY/checkpoint
+    files and portable GARfVDB bundles.
 
     # Example usage:
 
@@ -36,7 +38,7 @@ class Show(BaseCommand):
 
     """
 
-    # Path to the input PLY or checkpoint file. Must end in .ply, .pt, or .pth.
+    # Path to a PLY, checkpoint, or .garfvdb bundle.
     input_path: tyro.conf.Positional[pathlib.Path]
 
     # The port to expose the viewer server on.
@@ -51,10 +53,40 @@ class Show(BaseCommand):
     # Device to use for computation (default is "cuda").
     device: str | torch.device = "cuda"
 
+    scale_fraction: float = 0.1
+    """GARfVDB grouping scale as a fraction in ``[0, 1]`` of the artifact's maximum scale."""
+
+    mask_blend: float = 0.5
+    """GARfVDB feature-overlay opacity."""
+
+    overlay_width: int = 1440
+    """GARfVDB overlay width in pixels."""
+
+    overlay_height: int = 720
+    """GARfVDB overlay height in pixels."""
+
+    overlay_downsample: int = 2
+    """GARfVDB render downsample factor."""
+
     @torch.no_grad()
     def execute(self) -> None:
         logging.basicConfig(level=logging.INFO, format="%(levelname)s : %(message)s")
         logger = logging.getLogger(__name__)
+
+        if self.input_path.suffix == ".garfvdb" or is_garfvdb_bundle(self.input_path):
+            show_garfvdb_bundle(
+                self.input_path,
+                viewer_port=self.viewer_port,
+                viewer_ip_address=self.viewer_ip_address,
+                verbose=self.verbose,
+                device=self.device,
+                scale_fraction=self.scale_fraction,
+                mask_blend=self.mask_blend,
+                overlay_width=self.overlay_width,
+                overlay_height=self.overlay_height,
+                overlay_downsample=self.overlay_downsample,
+            )
+            return
 
         logger.info(f"Starting viewer server on {self.viewer_ip_address}:{self.viewer_port}")
         fviz.init(ip_address=self.viewer_ip_address, port=self.viewer_port, verbose=self.verbose)

--- a/fvdb_reality_capture/cli/frgs/_show.py
+++ b/fvdb_reality_capture/cli/frgs/_show.py
@@ -50,14 +50,19 @@ class Show(BaseCommand):
     # If True, then the viewer will log verbosely.
     verbose: Annotated[bool, arg(aliases=["-v"])] = False
 
-    # Device to use for computation (default is "cuda").
-    device: str | torch.device = "cuda"
+    # Device to use for computation (default is "cuda:0").
+    device: str | torch.device = "cuda:0"
 
     scale_fraction: float = 0.1
-    """GARfVDB grouping scale as a fraction in ``[0, 1]`` of the artifact's maximum scale."""
+    """Initial GARfVDB grouping scale as a fraction in ``[0, 1]`` of the artifact's maximum scale.
+    Adjustable live via the viewer's grouping-scale slider."""
 
     mask_blend: float = 0.5
-    """GARfVDB feature-overlay opacity."""
+    """Initial GARfVDB feature-overlay opacity in ``[0, 1]``. Adjustable live via the viewer's opacity slider."""
+
+    lock_pca_colors: bool = False
+    """Initial state of the viewer's "Lock PCA colors" toggle, which freezes the feature coloring so it does
+    not flicker as the camera moves. Toggleable live in the viewer."""
 
     overlay_width: int = 1440
     """GARfVDB overlay width in pixels."""
@@ -82,6 +87,7 @@ class Show(BaseCommand):
                 device=self.device,
                 scale_fraction=self.scale_fraction,
                 mask_blend=self.mask_blend,
+                lock_pca_colors=self.lock_pca_colors,
                 overlay_width=self.overlay_width,
                 overlay_height=self.overlay_height,
                 overlay_downsample=self.overlay_downsample,

--- a/fvdb_reality_capture/cli/frgs/_show.py
+++ b/fvdb_reality_capture/cli/frgs/_show.py
@@ -45,7 +45,7 @@ class Show(BaseCommand):
     # The port to expose the viewer server on.
     viewer_port: Annotated[int, arg(aliases=["-p"])] = 8080
 
-    # The port to expose the viewer server on.
+    # The IP address to expose the viewer server on.
     viewer_ip_address: Annotated[str, arg(aliases=["-ip"])] = "127.0.0.1"
 
     # If True, then the viewer will log verbosely.

--- a/fvdb_reality_capture/cli/frgs/_show_data.py
+++ b/fvdb_reality_capture/cli/frgs/_show_data.py
@@ -93,7 +93,7 @@ class ShowData(BaseCommand):
     # The port to expose the viewer server on.
     viewer_port: Annotated[int, arg(aliases=["-p"])] = 8080
 
-    # The port to expose the viewer server on.
+    # The IP address to expose the viewer server on.
     viewer_ip_address: Annotated[str, arg(aliases=["-ip"])] = "127.0.0.1"
 
     # If True, then the viewer will log verbosely.

--- a/fvdb_reality_capture/foundation_models/dlnr.py
+++ b/fvdb_reality_capture/foundation_models/dlnr.py
@@ -23,13 +23,13 @@ class DLNRModel:
         https://openaccess.thecvf.com/content/CVPR2023/papers/Zhao_High-Frequency_Stereo_Matching_Network_CVPR_2023_paper.pdf
     """
 
-    def __init__(self, backbone="middleburry", device: torch.device | str = "cuda"):
+    def __init__(self, backbone="middleburry", device: torch.device | str = "cuda:0"):
         """
         Initialize a DLNR model for evaluation.
 
         Args:
             backbone (str): Backbone to use for the DLNR model. Options are "middleburry" or "sceneflow".
-            device (torch.device | str): Device to load the model on (default is "cuda").
+            device (torch.device | str): Device to load the model on (default is "cuda:0").
         """
         middleburry_weights_url = (
             "https://fvdb-data.s3.us-east-2.amazonaws.com/fvdb-reality-capture/DLNR_Middlebury.pth"

--- a/fvdb_reality_capture/foundation_models/openclip.py
+++ b/fvdb_reality_capture/foundation_models/openclip.py
@@ -58,7 +58,7 @@ class OpenCLIPModel:
         model_type: str = "ViT-B-16",
         pretrained: str = "laion2b_s34b_b88k",
         dtype: torch.dtype = torch.float16,
-        device: torch.device | str = "cuda",
+        device: torch.device | str = "cuda:0",
     ):
         """
         Initialize the OpenCLIP model.

--- a/fvdb_reality_capture/foundation_models/sam1.py
+++ b/fvdb_reality_capture/foundation_models/sam1.py
@@ -63,7 +63,7 @@ class SAM1Model:
         box_nms_thresh: float = 0.7,
         min_mask_region_area: int = 100,
         output_mode: Literal["multi_scale"] = "multi_scale",
-        device: torch.device | str = "cuda",
+        device: torch.device | str = "cuda:0",
     ):
         """
         Initialize the SAM1 model.

--- a/fvdb_reality_capture/foundation_models/sam2.py
+++ b/fvdb_reality_capture/foundation_models/sam2.py
@@ -42,7 +42,7 @@ class SAM2Model:
         box_nms_thresh: float = 0.7,
         min_mask_region_area: int = 0,
         output_mode: Literal["flat", "multi_scale"] = "flat",
-        device: torch.device | str = "cuda",
+        device: torch.device | str = "cuda:0",
     ):
         """
         Initialize the SAM2 model.

--- a/fvdb_reality_capture/foundation_models/sam2.py
+++ b/fvdb_reality_capture/foundation_models/sam2.py
@@ -50,7 +50,9 @@ class SAM2Model:
         Args:
             checkpoint: Checkpoint size (large, small, tiny, base_plus).
             points_per_side: Grid density for point prompts.
-            points_per_batch: Points per batch; only used when output_mode="multi_scale".
+            points_per_batch: Number of point prompts run through the mask decoder per forward
+                pass. Higher values reduce the number of decoder invocations (faster) at the cost
+                of more GPU memory. Used by both "flat" and "multi_scale" modes.
             pred_iou_thresh: Minimum predicted IoU for keeping a mask.
             stability_score_thresh: Minimum stability score for keeping a mask.
             stability_score_offset: Offset for stability score; multi_scale only.
@@ -94,6 +96,7 @@ class SAM2Model:
             self._mask_generator = SAM2AutomaticMaskGenerator(
                 self._sam2_base,
                 points_per_side=points_per_side,
+                points_per_batch=points_per_batch,
                 pred_iou_thresh=pred_iou_thresh,
                 stability_score_thresh=stability_score_thresh,
             )

--- a/fvdb_reality_capture/instance_segmentation/__init__.py
+++ b/fvdb_reality_capture/instance_segmentation/__init__.py
@@ -1,0 +1,33 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scale-conditioned instance segmentation for fVDB Reality Capture."""
+
+from .artifact import (
+    ARTIFACT_SCHEMA_VERSION,
+    GARfVDBArtifactError,
+    GARfVDBArtifactVersionError,
+    is_garfvdb_bundle,
+)
+from .checkpoint import GARFVDB_TRAINING_METHOD
+from .config import GARfVDBConfig, GARfVDBTrainingConfig, GARfVDBTransformConfig
+from .garfvdb import GARfVDB
+from .scene_attribute import GARFVDB_MASK_ATTRIBUTE_NAME, GARfVDBMaskAttribute
+from .scene_transforms import GenerateGARfVDBMasks
+from .training.segmentation import GARfVDBTrainer
+
+__all__ = [
+    "GARfVDB",
+    "GARFVDB_TRAINING_METHOD",
+    "ARTIFACT_SCHEMA_VERSION",
+    "GARfVDBArtifactError",
+    "GARfVDBArtifactVersionError",
+    "GARfVDBConfig",
+    "GARFVDB_MASK_ATTRIBUTE_NAME",
+    "GARfVDBMaskAttribute",
+    "GenerateGARfVDBMasks",
+    "GARfVDBTrainer",
+    "GARfVDBTrainingConfig",
+    "GARfVDBTransformConfig",
+    "is_garfvdb_bundle",
+]

--- a/fvdb_reality_capture/instance_segmentation/artifact.py
+++ b/fvdb_reality_capture/instance_segmentation/artifact.py
@@ -260,7 +260,7 @@ if ARTIFACT_SCHEMA_VERSION not in _ARTIFACT_READERS:
     raise RuntimeError("The current GARfVDB artifact schema has no registered reader")
 
 
-def load_garfvdb_bundle(path: str | pathlib.Path, device: str | torch.device = "cuda") -> GARfVDB:
+def load_garfvdb_bundle(path: str | pathlib.Path, device: str | torch.device = "cuda:0") -> GARfVDB:
     """Load a portable GARfVDB bundle using its version-specific reader."""
     bundle_path = pathlib.Path(path)
     _require_bundle_suffix(bundle_path)

--- a/fvdb_reality_capture/instance_segmentation/artifact.py
+++ b/fvdb_reality_capture/instance_segmentation/artifact.py
@@ -33,7 +33,7 @@ ARTIFACT_SCHEMA_VERSION = 1
 MANIFEST_NAME = "manifest.json"
 ENCODER_NAME = "encoder.nvdb"
 NETWORK_NAME = "network.safetensors"
-CARRIER_NAME = "carrier.ply"
+GAUSSIANS_NAME = "gaussians.ply"
 
 
 class GARfVDBArtifactError(ValueError):
@@ -95,7 +95,7 @@ def save_garfvdb_bundle(product: GARfVDB, path: str | pathlib.Path) -> pathlib.P
     try:
         encoder_path = temporary_path / ENCODER_NAME
         network_path = temporary_path / NETWORK_NAME
-        carrier_path = temporary_path / CARRIER_NAME
+        gaussians_path = temporary_path / GAUSSIANS_NAME
 
         grid = product.model.encoder_gridbatch
         features = grid.jagged_like(product.model.encoder_gridbatch_features_data.detach())
@@ -108,7 +108,7 @@ def save_garfvdb_bundle(product: GARfVDB, path: str | pathlib.Path) -> pathlib.P
         )
 
         save_file(product.model.network_state_dict(), network_path)
-        product.carrier.save_ply(str(carrier_path), product.reconstruction_metadata)
+        product.gaussians.save_ply(str(gaussians_path), product.reconstruction_metadata)
 
         voxel_counts = grid.num_voxels.detach().cpu().tolist()
         manifest: dict[str, Any] = {
@@ -128,9 +128,9 @@ def save_garfvdb_bundle(product: GARfVDB, path: str | pathlib.Path) -> pathlib.P
                 "feature_dtype": str(product.model.encoder_gridbatch_features_data.dtype),
             },
             "network": {"file": NETWORK_NAME},
-            "carrier": {
-                "file": CARRIER_NAME,
-                "num_gaussians": product.carrier.num_gaussians,
+            "gaussians": {
+                "file": GAUSSIANS_NAME,
+                "num_gaussians": product.gaussians.num_gaussians,
             },
             "versions": {
                 "fvdb_reality_capture": _package_version("fvdb_reality_capture"),
@@ -140,7 +140,7 @@ def save_garfvdb_bundle(product: GARfVDB, path: str | pathlib.Path) -> pathlib.P
             "checksums": {
                 ENCODER_NAME: _sha256(encoder_path),
                 NETWORK_NAME: _sha256(network_path),
-                CARRIER_NAME: _sha256(carrier_path),
+                GAUSSIANS_NAME: _sha256(gaussians_path),
             },
         }
         (temporary_path / MANIFEST_NAME).write_text(
@@ -201,7 +201,7 @@ def _load_garfvdb_bundle_v1(
 
     encoder_path = _payload_path(bundle_path, manifest, "encoder")
     network_path = _payload_path(bundle_path, manifest, "network")
-    carrier_path = _payload_path(bundle_path, manifest, "carrier")
+    gaussians_path = _payload_path(bundle_path, manifest, "gaussians")
 
     model_config = GARfVDBConfig(**manifest.get("model_config", {}))
     if not model_config.use_grid:
@@ -237,13 +237,13 @@ def _load_garfvdb_bundle_v1(
     ):
         raise GARfVDBArtifactError("NanoVDB transforms do not match the manifest")
 
-    carrier, reconstruction_metadata = GaussianSplat3d.from_ply(carrier_path, device)
-    if carrier.num_gaussians != manifest.get("carrier", {}).get("num_gaussians"):
-        raise GARfVDBArtifactError("Carrier Gaussian count does not match the manifest")
+    gaussians, reconstruction_metadata = GaussianSplat3d.from_ply(gaussians_path, device)
+    if gaussians.num_gaussians != manifest.get("gaussians", {}).get("num_gaussians"):
+        raise GARfVDBArtifactError("Gaussian count does not match the manifest")
 
     network_state = load_file(network_path, device=str(torch.device(device)))
     model = GARfVDBModel.from_artifact_components(
-        gs_model=carrier,
+        gs_model=gaussians,
         model_config=model_config,
         encoder_gridbatch=grid,
         encoder_features=features.jdata,

--- a/fvdb_reality_capture/instance_segmentation/artifact.py
+++ b/fvdb_reality_capture/instance_segmentation/artifact.py
@@ -17,8 +17,9 @@ from typing import TYPE_CHECKING, Any
 
 import fvdb
 import torch
-from fvdb import GaussianSplat3d
 from safetensors.torch import load_file, save_file
+
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 
 from .config import GARfVDBConfig
 from .model import GARfVDBModel

--- a/fvdb_reality_capture/instance_segmentation/artifact.py
+++ b/fvdb_reality_capture/instance_segmentation/artifact.py
@@ -1,0 +1,293 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Portable GARfVDB artifact I/O."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import tempfile
+from dataclasses import asdict
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING, Any
+
+import fvdb
+import torch
+from fvdb import GaussianSplat3d
+from safetensors.torch import load_file, save_file
+
+from .config import GARfVDBConfig
+from .model import GARfVDBModel
+
+if TYPE_CHECKING:
+    from .garfvdb import GARfVDB
+
+
+ARTIFACT_SCHEMA = "fvdb_reality_capture.garfvdb"
+ARTIFACT_SCHEMA_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+ENCODER_NAME = "encoder.nvdb"
+NETWORK_NAME = "network.safetensors"
+CARRIER_NAME = "carrier.ply"
+
+
+class GARfVDBArtifactError(ValueError):
+    """Raised when a GARfVDB artifact is missing, corrupt, or incompatible."""
+
+
+class GARfVDBArtifactVersionError(GARfVDBArtifactError):
+    """Raised when no reader is available for a bundle's schema version."""
+
+
+def is_garfvdb_bundle(path: str | pathlib.Path) -> bool:
+    """Return whether *path* looks like a GARfVDB bundle without loading payloads."""
+    bundle_path = pathlib.Path(path)
+    manifest_path = bundle_path / MANIFEST_NAME
+    if not bundle_path.is_dir() or not manifest_path.is_file():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return manifest.get("schema") == ARTIFACT_SCHEMA
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _package_version(package: str) -> str:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _grid_names(grid_count: int) -> list[str]:
+    return [f"encoder_{index:02d}" for index in range(grid_count)]
+
+
+def _require_bundle_suffix(path: pathlib.Path) -> None:
+    if path.suffix != ".garfvdb":
+        raise ValueError(f"GARfVDB bundle path must end in '.garfvdb': {path}")
+
+
+def save_garfvdb_bundle(product: GARfVDB, path: str | pathlib.Path) -> pathlib.Path:
+    """Save a portable, pickle-free GARfVDB inference bundle."""
+    output_path = pathlib.Path(path)
+    _require_bundle_suffix(output_path)
+    if output_path.exists():
+        raise FileExistsError(f"Output GARfVDB bundle already exists: {output_path}")
+    if not product.model.model_config.use_grid:
+        raise ValueError("Portable GARfVDB artifacts require GARfVDBConfig.use_grid=True")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = pathlib.Path(tempfile.mkdtemp(prefix=f".{output_path.name}.", dir=output_path.parent))
+    try:
+        encoder_path = temporary_path / ENCODER_NAME
+        network_path = temporary_path / NETWORK_NAME
+        carrier_path = temporary_path / CARRIER_NAME
+
+        grid = product.model.encoder_gridbatch
+        features = grid.jagged_like(product.model.encoder_gridbatch_features_data.detach())
+        names = _grid_names(grid.grid_count)
+        grid.save_nanovdb(
+            str(encoder_path),
+            data=features,
+            names=names,
+            compressed=True,
+        )
+
+        save_file(product.model.network_state_dict(), network_path)
+        product.carrier.save_ply(str(carrier_path), product.reconstruction_metadata)
+
+        voxel_counts = grid.num_voxels.detach().cpu().tolist()
+        manifest: dict[str, Any] = {
+            "schema": ARTIFACT_SCHEMA,
+            "schema_version": ARTIFACT_SCHEMA_VERSION,
+            "method": "garfvdb",
+            "model_config": asdict(product.model.model_config),
+            "encoder": {
+                "file": ENCODER_NAME,
+                "grid_names": names,
+                "grid_count": grid.grid_count,
+                "total_voxels": grid.total_voxels,
+                "voxel_counts": voxel_counts,
+                "voxel_sizes": grid.voxel_sizes.detach().cpu().tolist(),
+                "origins": grid.origins.detach().cpu().tolist(),
+                "feature_dim": product.model.model_config.grid_feature_dim,
+                "feature_dtype": str(product.model.encoder_gridbatch_features_data.dtype),
+            },
+            "network": {"file": NETWORK_NAME},
+            "carrier": {
+                "file": CARRIER_NAME,
+                "num_gaussians": product.carrier.num_gaussians,
+            },
+            "versions": {
+                "fvdb_reality_capture": _package_version("fvdb_reality_capture"),
+                "fvdb_core": _package_version("fvdb-core"),
+                "safetensors": _package_version("safetensors"),
+            },
+            "checksums": {
+                ENCODER_NAME: _sha256(encoder_path),
+                NETWORK_NAME: _sha256(network_path),
+                CARRIER_NAME: _sha256(carrier_path),
+            },
+        }
+        (temporary_path / MANIFEST_NAME).write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary_path, output_path)
+    except Exception:
+        shutil.rmtree(temporary_path, ignore_errors=True)
+        raise
+    return output_path
+
+
+def _load_manifest(path: pathlib.Path) -> dict[str, Any]:
+    manifest_path = path / MANIFEST_NAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise GARfVDBArtifactError(f"GARfVDB manifest is missing: {manifest_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise GARfVDBArtifactError(f"GARfVDB manifest is not valid JSON: {manifest_path}") from exc
+
+    if manifest.get("schema") != ARTIFACT_SCHEMA:
+        raise GARfVDBArtifactError(
+            f"Unsupported artifact schema {manifest.get('schema')!r}; expected {ARTIFACT_SCHEMA!r}."
+        )
+    schema_version = manifest.get("schema_version")
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool) or schema_version < 1:
+        raise GARfVDBArtifactVersionError(
+            f"GARfVDB manifest has an invalid or missing schema_version: {schema_version!r}."
+        )
+    return manifest
+
+
+def _payload_path(bundle: pathlib.Path, manifest: dict[str, Any], section: str) -> pathlib.Path:
+    try:
+        filename = manifest[section]["file"]
+    except (KeyError, TypeError) as exc:
+        raise GARfVDBArtifactError(f"Manifest section {section!r} does not define a payload file.") from exc
+    if not isinstance(filename, str) or pathlib.Path(filename).name != filename:
+        raise GARfVDBArtifactError(f"Unsafe payload filename in manifest: {filename!r}")
+    path = bundle / filename
+    if not path.is_file():
+        raise GARfVDBArtifactError(f"GARfVDB payload is missing: {path}")
+    expected_checksum = manifest.get("checksums", {}).get(filename)
+    if not isinstance(expected_checksum, str) or _sha256(path) != expected_checksum:
+        raise GARfVDBArtifactError(f"GARfVDB payload checksum does not match: {path}")
+    return path
+
+
+def _load_garfvdb_bundle_v1(
+    bundle_path: pathlib.Path,
+    manifest: dict[str, Any],
+    device: str | torch.device,
+) -> GARfVDB:
+    """Read and validate schema version 1 payloads."""
+    from .garfvdb import GARfVDB
+
+    encoder_path = _payload_path(bundle_path, manifest, "encoder")
+    network_path = _payload_path(bundle_path, manifest, "network")
+    carrier_path = _payload_path(bundle_path, manifest, "carrier")
+
+    model_config = GARfVDBConfig(**manifest.get("model_config", {}))
+    if not model_config.use_grid:
+        raise GARfVDBArtifactError("Portable GARfVDB artifacts require model_config.use_grid=True")
+
+    grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device=device)
+    encoder_manifest = manifest.get("encoder", {})
+    expected_names = encoder_manifest.get("grid_names")
+    canonical_names = _grid_names(model_config.num_grids)
+    if expected_names != canonical_names:
+        raise GARfVDBArtifactError(f"Manifest grid names are not canonical: {expected_names!r} != {canonical_names!r}")
+    if names != canonical_names:
+        raise GARfVDBArtifactError(f"NanoVDB grid names are not canonical: {names!r} != {canonical_names!r}")
+    if grid.grid_count != encoder_manifest.get("grid_count") or grid.grid_count != model_config.num_grids:
+        raise GARfVDBArtifactError("NanoVDB grid count does not match the manifest/model configuration")
+    if grid.total_voxels != encoder_manifest.get("total_voxels"):
+        raise GARfVDBArtifactError("NanoVDB total voxel count does not match the manifest")
+    if grid.num_voxels.detach().cpu().tolist() != encoder_manifest.get("voxel_counts"):
+        raise GARfVDBArtifactError("NanoVDB per-grid voxel counts do not match the manifest")
+    if encoder_manifest.get("feature_dim") != model_config.grid_feature_dim:
+        raise GARfVDBArtifactError("NanoVDB feature dimension does not match the model configuration")
+    if features.jdata.shape != (grid.total_voxels, model_config.grid_feature_dim):
+        raise GARfVDBArtifactError(
+            "NanoVDB feature data has the wrong shape: "
+            f"expected {(grid.total_voxels, model_config.grid_feature_dim)}, got {tuple(features.jdata.shape)}"
+        )
+    if str(features.dtype) != encoder_manifest.get("feature_dtype"):
+        raise GARfVDBArtifactError("NanoVDB feature dtype does not match the manifest")
+    expected_voxel_sizes = torch.as_tensor(encoder_manifest.get("voxel_sizes"), dtype=grid.voxel_sizes.dtype)
+    expected_origins = torch.as_tensor(encoder_manifest.get("origins"), dtype=grid.origins.dtype)
+    if not torch.allclose(grid.voxel_sizes.cpu(), expected_voxel_sizes) or not torch.allclose(
+        grid.origins.cpu(), expected_origins
+    ):
+        raise GARfVDBArtifactError("NanoVDB transforms do not match the manifest")
+
+    carrier, reconstruction_metadata = GaussianSplat3d.from_ply(carrier_path, device)
+    if carrier.num_gaussians != manifest.get("carrier", {}).get("num_gaussians"):
+        raise GARfVDBArtifactError("Carrier Gaussian count does not match the manifest")
+
+    network_state = load_file(network_path, device=str(torch.device(device)))
+    model = GARfVDBModel.from_artifact_components(
+        gs_model=carrier,
+        model_config=model_config,
+        encoder_gridbatch=grid,
+        encoder_features=features.jdata,
+        network_state=network_state,
+        device=device,
+    )
+    return GARfVDB(model=model, reconstruction_metadata=reconstruction_metadata)
+
+
+_ARTIFACT_READERS = {
+    1: _load_garfvdb_bundle_v1,
+}
+SUPPORTED_ARTIFACT_SCHEMA_VERSIONS = tuple(sorted(_ARTIFACT_READERS))
+if ARTIFACT_SCHEMA_VERSION not in _ARTIFACT_READERS:
+    raise RuntimeError("The current GARfVDB artifact schema has no registered reader")
+
+
+def load_garfvdb_bundle(path: str | pathlib.Path, device: str | torch.device = "cuda") -> GARfVDB:
+    """Load a portable GARfVDB bundle using its version-specific reader."""
+    bundle_path = pathlib.Path(path)
+    _require_bundle_suffix(bundle_path)
+    if not bundle_path.is_dir():
+        raise FileNotFoundError(f"GARfVDB bundle does not exist: {bundle_path}")
+    manifest = _load_manifest(bundle_path)
+    schema_version = manifest["schema_version"]
+    reader = _ARTIFACT_READERS.get(schema_version)
+    if reader is None:
+        supported = ", ".join(str(value) for value in SUPPORTED_ARTIFACT_SCHEMA_VERSIONS)
+        if schema_version > ARTIFACT_SCHEMA_VERSION:
+            detail = "The bundle was written by a newer version of fvdb-reality-capture."
+        else:
+            detail = "This release no longer has a reader for that older bundle version."
+        raise GARfVDBArtifactVersionError(
+            f"Unsupported GARfVDB schema_version {schema_version}; supported versions: {supported}. {detail}"
+        )
+    return reader(bundle_path, manifest, device)
+
+
+__all__ = [
+    "ARTIFACT_SCHEMA",
+    "ARTIFACT_SCHEMA_VERSION",
+    "GARfVDBArtifactError",
+    "GARfVDBArtifactVersionError",
+    "SUPPORTED_ARTIFACT_SCHEMA_VERSIONS",
+    "is_garfvdb_bundle",
+    "load_garfvdb_bundle",
+    "save_garfvdb_bundle",
+]

--- a/fvdb_reality_capture/instance_segmentation/artifact.py
+++ b/fvdb_reality_capture/instance_segmentation/artifact.py
@@ -207,7 +207,10 @@ def _load_garfvdb_bundle_v1(
     if not model_config.use_grid:
         raise GARfVDBArtifactError("Portable GARfVDB artifacts require model_config.use_grid=True")
 
-    grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device=device)
+    try:
+        grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device=device)
+    except Exception as exc:  # corrupt / incompatible NanoVDB encoder payload
+        raise GARfVDBArtifactError(f"Failed to load the NanoVDB encoder payload {encoder_path}: {exc}") from exc
     encoder_manifest = manifest.get("encoder", {})
     expected_names = encoder_manifest.get("grid_names")
     canonical_names = _grid_names(model_config.num_grids)

--- a/fvdb_reality_capture/instance_segmentation/checkpoint.py
+++ b/fvdb_reality_capture/instance_segmentation/checkpoint.py
@@ -6,7 +6,7 @@
 GARFVDB_TRAINING_METHOD = "instance_segmentation.garfvdb"
 
 # Single source of truth for the GARfVDB training-checkpoint format version. The trainer's
-# ``state_dict``/``from_state_dict`` and the disk writer's envelope ``method_version`` both derive from
+# ``state_dict``/``from_state_dict`` and the disk writer's container ``method_version`` both derive from
 # this constant so the two can never drift.
 GARFVDB_TRAINING_METHOD_VERSION = "0.1.0"
 

--- a/fvdb_reality_capture/instance_segmentation/checkpoint.py
+++ b/fvdb_reality_capture/instance_segmentation/checkpoint.py
@@ -1,0 +1,16 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""GARfVDB training-checkpoint method identity."""
+
+GARFVDB_TRAINING_METHOD = "instance_segmentation.garfvdb"
+
+# Single source of truth for the GARfVDB training-checkpoint format version. The trainer's
+# ``state_dict``/``from_state_dict`` and the disk writer's envelope ``method_version`` both derive from
+# this constant so the two can never drift.
+GARFVDB_TRAINING_METHOD_VERSION = "0.1.0"
+
+__all__ = [
+    "GARFVDB_TRAINING_METHOD",
+    "GARFVDB_TRAINING_METHOD_VERSION",
+]

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass, field
 
 import torch
-from fvdb import GaussianSplat3d
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 
 from fvdb_reality_capture.instance_segmentation.scene_transforms import (
     GenerateGARfVDBMasks,

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -95,6 +95,10 @@ class GARfVDBTrainingConfig:
 class GARfVDBTransformConfig(SceneTransformConfig):
     """Configuration for SfmScene transforms applied before segmentation training."""
 
+    image_downsample_factor: int = 4
+    """Factor by which to downsample images before mask generation and training. Defaults to 4 to match
+    the ``frgs reconstruct`` default."""
+
     compute_segmentation_masks: bool = True
     """Whether to compute SAM2 segmentation masks."""
 

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -3,9 +3,11 @@
 #
 from dataclasses import dataclass, field
 
+import numpy as np
 import torch
 
 from fvdb_reality_capture.instance_segmentation.scene_transforms import (
+    ApplyReconstructionCameraPoses,
     GenerateGARfVDBMasks,
 )
 from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
@@ -118,26 +120,39 @@ class GARfVDBTransformConfig(SceneTransformConfig):
     device: torch.device | str = "cuda:0"
     """Device for SAM2 model inference."""
 
-    def build_scene_transforms(self, gs3d: GaussianSplat3d, normalization_transform: torch.Tensor | None):
+    def build_scene_transforms(
+        self,
+        gs3d: GaussianSplat3d,
+        normalization_transform: torch.Tensor | None,
+        reconstruction_camera_to_world_matrices: torch.Tensor | np.ndarray | None = None,
+        reconstruction_image_ids: torch.Tensor | np.ndarray | None = None,
+    ):
         alignment_transform = (
             TransformScene(normalization_transform.cpu().numpy()) if normalization_transform is not None else Identity()
         )
-        terminal_transforms = (
-            [
-                UndistortImages(),
-                GenerateGARfVDBMasks(
-                    gs3d=gs3d,
-                    checkpoint="large",
-                    points_per_side=self.sam2_points_per_side,
-                    points_per_batch=self.sam2_points_per_batch,
-                    pred_iou_thresh=self.sam2_pred_iou_thresh,
-                    stability_score_thresh=self.sam2_stability_score_thresh,
-                    device=self.device,
-                ),
-            ]
-            if self.compute_segmentation_masks
-            else []
-        )
+        terminal_transforms = []
+        if reconstruction_camera_to_world_matrices is not None:
+            terminal_transforms.append(
+                ApplyReconstructionCameraPoses(
+                    reconstruction_camera_to_world_matrices,
+                    image_ids=reconstruction_image_ids,
+                )
+            )
+        if self.compute_segmentation_masks:
+            terminal_transforms.extend(
+                [
+                    UndistortImages(),
+                    GenerateGARfVDBMasks(
+                        gs3d=gs3d,
+                        checkpoint="large",
+                        points_per_side=self.sam2_points_per_side,
+                        points_per_batch=self.sam2_points_per_batch,
+                        pred_iou_thresh=self.sam2_pred_iou_thresh,
+                        stability_score_thresh=self.sam2_stability_score_thresh,
+                        device=self.device,
+                    ),
+                ]
+            )
         return self.build_scene_transform(
             alignment_transform=alignment_transform,
             terminal_transforms=terminal_transforms,

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -1,0 +1,139 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from dataclasses import dataclass, field
+
+import torch
+from fvdb import GaussianSplat3d
+from fvdb_reality_capture.instance_segmentation.scene_transforms import GenerateGARfVDBMasks
+from fvdb_reality_capture.transforms import (
+    Identity,
+    SceneTransformConfig,
+    TransformScene,
+    UndistortImages,
+)
+
+
+@dataclass
+class GARfVDBConfig:
+    """Configuration parameters for the GARfVDB segmentation model."""
+
+    depth_samples: int = 24
+    """Number of depth samples per ray for feature computation."""
+
+    use_grid: bool = True
+    """Use 3D feature grids (GARField-style). First-class training and products require ``True``."""
+
+    use_grid_conv: bool = False
+    """If True, apply sparse convolutions to grid features."""
+
+    enc_feats_one_idx_per_ray: bool = False
+    """If True, stochastically sample one feature per ray instead of weighted averaging."""
+
+    num_grids: int = 24
+    """Number of feature grids at different resolutions."""
+
+    grid_feature_dim: int = 8
+    """Feature dimension per grid."""
+
+    mlp_hidden_dim: int = 256
+    """Hidden layer dimension in the MLP."""
+
+    mlp_num_layers: int = 4
+    """Number of hidden layers in the MLP."""
+
+    mlp_output_dim: int = 256
+    """Output dimension of the MLP (feature embedding size)."""
+
+
+@dataclass
+class GARfVDBTrainingConfig:
+    """Configuration parameters for the segmentation training process."""
+
+    seed: int = 42
+    """Random seed for reproducibility."""
+
+    max_steps: int | None = None
+    """Maximum number of training steps. If None, uses max_epochs."""
+
+    max_epochs: int = 100
+    """Maximum number of training epochs."""
+
+    sample_pixels_per_image: int = 256
+    """Number of pixels to sample per image for training."""
+
+    batch_size: int = 8
+    """Number of images per training batch."""
+
+    accumulate_grad_steps: int = 1
+    """Number of gradient accumulation steps."""
+
+    scale_lr_with_batch_size: bool = True
+    """Scale learning rate by sqrt(batch_size) to compensate for fewer optimizer steps per epoch
+    when using larger batches. Disabled when batch_size <= 1."""
+
+    grad_clip_max_norm: float | None = 1.0
+    """Maximum gradient norm for clipping. Set to None to disable gradient clipping."""
+
+    model: GARfVDBConfig = field(default_factory=GARfVDBConfig)
+    """Model architecture configuration."""
+
+    log_test_images: bool = False
+    """Whether to log test images during training."""
+
+    eval_at_percent: list[int] = field(default_factory=lambda: [10, 20, 30, 40, 50, 75, 100])
+    """Percentages of total epochs at which to run evaluation."""
+
+    save_at_percent: list[int] = field(default_factory=lambda: [10, 20, 100])
+    """Percentages of total epochs at which to save checkpoints."""
+
+
+@dataclass
+class GARfVDBTransformConfig(SceneTransformConfig):
+    """Configuration for SfmScene transforms applied before segmentation training."""
+
+    compute_segmentation_masks: bool = True
+    """Whether to compute SAM2 segmentation masks."""
+
+    sam2_points_per_side: int = 40
+    """SAM2 grid density for automatic mask generation."""
+
+    sam2_pred_iou_thresh: float = 0.80
+    """SAM2 predicted IoU threshold for mask filtering."""
+
+    sam2_stability_score_thresh: float = 0.80
+    """SAM2 stability score threshold for mask filtering."""
+
+    device: torch.device | str = "cuda"
+    """Device for SAM2 model inference."""
+
+    def build_scene_transforms(self, gs3d: GaussianSplat3d, normalization_transform: torch.Tensor | None):
+        alignment_transform = (
+            TransformScene(normalization_transform.cpu().numpy()) if normalization_transform is not None else Identity()
+        )
+        terminal_transforms = (
+            [
+                UndistortImages(),
+                GenerateGARfVDBMasks(
+                    gs3d=gs3d,
+                    checkpoint="large",
+                    points_per_side=self.sam2_points_per_side,
+                    pred_iou_thresh=self.sam2_pred_iou_thresh,
+                    stability_score_thresh=self.sam2_stability_score_thresh,
+                    device=self.device,
+                )
+            ]
+            if self.compute_segmentation_masks
+            else []
+        )
+        return self.build_scene_transform(
+            alignment_transform=alignment_transform,
+            terminal_transforms=terminal_transforms,
+        )
+
+
+__all__ = [
+    "GARfVDBConfig",
+    "GARfVDBTrainingConfig",
+    "GARfVDBTransformConfig",
+]

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass, field
 
 import torch
 from fvdb import GaussianSplat3d
-from fvdb_reality_capture.instance_segmentation.scene_transforms import GenerateGARfVDBMasks
+
+from fvdb_reality_capture.instance_segmentation.scene_transforms import (
+    GenerateGARfVDBMasks,
+)
 from fvdb_reality_capture.transforms import (
     Identity,
     SceneTransformConfig,
@@ -62,7 +65,7 @@ class GARfVDBTrainingConfig:
     sample_pixels_per_image: int = 256
     """Number of pixels to sample per image for training."""
 
-    batch_size: int = 8
+    batch_size: int = 1
     """Number of images per training batch."""
 
     accumulate_grad_steps: int = 1
@@ -98,6 +101,10 @@ class GARfVDBTransformConfig(SceneTransformConfig):
     sam2_points_per_side: int = 40
     """SAM2 grid density for automatic mask generation."""
 
+    sam2_points_per_batch: int = 128
+    """Number of SAM2 point prompts run through the mask decoder per forward pass. Higher values
+    speed up mask generation at the cost of more GPU memory; does not change the generated masks."""
+
     sam2_pred_iou_thresh: float = 0.80
     """SAM2 predicted IoU threshold for mask filtering."""
 
@@ -118,10 +125,11 @@ class GARfVDBTransformConfig(SceneTransformConfig):
                     gs3d=gs3d,
                     checkpoint="large",
                     points_per_side=self.sam2_points_per_side,
+                    points_per_batch=self.sam2_points_per_batch,
                     pred_iou_thresh=self.sam2_pred_iou_thresh,
                     stability_score_thresh=self.sam2_stability_score_thresh,
                     device=self.device,
-                )
+                ),
             ]
             if self.compute_segmentation_masks
             else []

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -4,11 +4,11 @@
 from dataclasses import dataclass, field
 
 import torch
-from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 
 from fvdb_reality_capture.instance_segmentation.scene_transforms import (
     GenerateGARfVDBMasks,
 )
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 from fvdb_reality_capture.transforms import (
     Identity,
     SceneTransformConfig,
@@ -59,7 +59,7 @@ class GARfVDBTrainingConfig:
     max_steps: int | None = None
     """Maximum number of training steps. If None, uses max_epochs."""
 
-    max_epochs: int = 100
+    max_epochs: int = 50
     """Maximum number of training epochs."""
 
     sample_pixels_per_image: int = 256

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -111,7 +111,7 @@ class GARfVDBTransformConfig(SceneTransformConfig):
     sam2_stability_score_thresh: float = 0.80
     """SAM2 stability score threshold for mask filtering."""
 
-    device: torch.device | str = "cuda"
+    device: torch.device | str = "cuda:0"
     """Device for SAM2 model inference."""
 
     def build_scene_transforms(self, gs3d: GaussianSplat3d, normalization_transform: torch.Tensor | None):

--- a/fvdb_reality_capture/instance_segmentation/config.py
+++ b/fvdb_reality_capture/instance_segmentation/config.py
@@ -67,6 +67,12 @@ class GARfVDBTrainingConfig:
     sample_pixels_per_image: int = 256
     """Number of pixels to sample per image for training."""
 
+    scale_bias_strength: float = 0.0
+    """Bias training pixel sampling toward pixels whose covering mask has a small 3D scale.
+    0.0 samples uniformly. Values above 0.0 weight each pixel by 1 / scale**strength, which favors
+    small objects and fine structure. This is a scale bias, not a boundary-distance bias.
+    Applies to training only; validation always samples uniformly."""
+
     batch_size: int = 1
     """Number of images per training batch."""
 

--- a/fvdb_reality_capture/instance_segmentation/garfvdb.py
+++ b/fvdb_reality_capture/instance_segmentation/garfvdb.py
@@ -1,0 +1,123 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public GARfVDB inference product."""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Mapping
+from typing import Any
+
+import fvdb
+import torch
+from fvdb import GaussianSplat3d
+
+from .model import GARfVDBModel
+from .training.dataset import GARfVDBInput
+
+
+class GARfVDB:
+    """A portable scale-conditioned instance feature field and its Gaussian carrier."""
+
+    def __init__(self, model: GARfVDBModel, reconstruction_metadata: Mapping[str, Any] | None = None) -> None:
+        if not model.model_config.use_grid:
+            raise ValueError("The first-class GARfVDB product requires GARfVDBConfig.use_grid=True")
+        self._model = model
+        self._reconstruction_metadata = dict(reconstruction_metadata or {})
+
+    @property
+    def model(self) -> GARfVDBModel:
+        """The underlying PyTorch GARfVDB model."""
+        return self._model
+
+    @property
+    def carrier(self) -> GaussianSplat3d:
+        """The exact filtered Gaussian carrier used by the feature field."""
+        return self._model.gs_model
+
+    @property
+    def encoder_grids(self) -> fvdb.GridBatch:
+        """The ordered multiresolution encoder grid batch."""
+        return self._model.encoder_gridbatch
+
+    @property
+    def reconstruction_metadata(self) -> dict[str, Any]:
+        """A shallow copy of camera and reconstruction metadata bundled with the carrier."""
+        return dict(self._reconstruction_metadata)
+
+    @property
+    def max_grouping_scale(self) -> float:
+        """Maximum supported grouping scale in scene units."""
+        return float(self._model.max_grouping_scale.item())
+
+    def _validate_scale(self, scale: float) -> None:
+        if scale < 0.0 or scale > self.max_grouping_scale:
+            raise ValueError(f"scale must be in [0, {self.max_grouping_scale}], got {scale}")
+
+    @torch.no_grad()
+    def render_features(
+        self,
+        camera_to_world: torch.Tensor,
+        projection: torch.Tensor,
+        image_size: tuple[int, int],
+        scale: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Render scale-conditioned features and alpha.
+
+        Args:
+            camera_to_world: Camera-to-world matrix with shape ``(4, 4)`` or ``(B, 4, 4)``.
+            projection: Camera intrinsic matrix with shape ``(3, 3)`` or ``(B, 3, 3)``.
+            image_size: ``(width, height)`` shared by the batch.
+            scale: Grouping scale in scene units.
+        """
+        self._validate_scale(scale)
+        device = self._model.device
+        camera_to_world = torch.as_tensor(camera_to_world, dtype=torch.float32, device=device)
+        projection = torch.as_tensor(projection, dtype=torch.float32, device=device)
+        if camera_to_world.ndim == 2:
+            camera_to_world = camera_to_world.unsqueeze(0)
+        if projection.ndim == 2:
+            projection = projection.unsqueeze(0)
+        if camera_to_world.ndim != 3 or camera_to_world.shape[-2:] != (4, 4):
+            raise ValueError("camera_to_world must have shape (4, 4) or (B, 4, 4)")
+        if projection.ndim != 3 or projection.shape[-2:] != (3, 3):
+            raise ValueError("projection must have shape (3, 3) or (B, 3, 3)")
+        if projection.shape[0] != camera_to_world.shape[0]:
+            raise ValueError("camera_to_world and projection batch sizes must match")
+        width, height = image_size
+        if width <= 0 or height <= 0:
+            raise ValueError(f"image_size must be positive, got {image_size}")
+        world_to_camera = torch.linalg.inv(camera_to_world).contiguous()
+        model_input = GARfVDBInput(
+            {
+                "projection": projection.contiguous(),
+                "camera_to_world": camera_to_world.contiguous(),
+                "world_to_camera": world_to_camera,
+                "image_w": [width] * camera_to_world.shape[0],
+                "image_h": [height] * camera_to_world.shape[0],
+            }
+        )
+        return self._model.get_mask_output(model_input, scale)
+
+    @torch.no_grad()
+    def gaussian_affinities(self, scale: float) -> torch.Tensor:
+        """Return per-Gaussian affinities aligned with :attr:`carrier`."""
+        self._validate_scale(scale)
+        return self._model.get_gaussian_affinity_output(scale)
+
+    def save(self, path: str | pathlib.Path) -> pathlib.Path:
+        """Save this product as a portable ``.garfvdb`` directory."""
+        from .artifact import save_garfvdb_bundle
+
+        return save_garfvdb_bundle(self, path)
+
+    @classmethod
+    def load(cls, path: str | pathlib.Path, device: str | torch.device = "cuda") -> "GARfVDB":
+        """Load and validate a portable ``.garfvdb`` directory."""
+        from .artifact import load_garfvdb_bundle
+
+        return load_garfvdb_bundle(path, device=device)
+
+
+__all__ = ["GARfVDB"]

--- a/fvdb_reality_capture/instance_segmentation/garfvdb.py
+++ b/fvdb_reality_capture/instance_segmentation/garfvdb.py
@@ -18,7 +18,7 @@ from .training.dataset import GARfVDBInput
 
 
 class GARfVDB:
-    """A portable scale-conditioned instance feature field and its Gaussian carrier."""
+    """A portable scale-conditioned instance feature field and its Gaussian model."""
 
     def __init__(self, model: GARfVDBModel, reconstruction_metadata: Mapping[str, Any] | None = None) -> None:
         if not model.model_config.use_grid:
@@ -32,8 +32,8 @@ class GARfVDB:
         return self._model
 
     @property
-    def carrier(self) -> GaussianSplat3d:
-        """The exact filtered Gaussian carrier used by the feature field."""
+    def gaussians(self) -> GaussianSplat3d:
+        """The exact filtered Gaussian model used by the feature field."""
         return self._model.gs_model
 
     @property
@@ -43,7 +43,7 @@ class GARfVDB:
 
     @property
     def reconstruction_metadata(self) -> dict[str, Any]:
-        """A shallow copy of camera and reconstruction metadata bundled with the carrier."""
+        """A shallow copy of camera and reconstruction metadata bundled with the gaussians."""
         return dict(self._reconstruction_metadata)
 
     @property
@@ -102,7 +102,7 @@ class GARfVDB:
 
     @torch.no_grad()
     def gaussian_affinities(self, scale: float) -> torch.Tensor:
-        """Return per-Gaussian affinities aligned with :attr:`carrier`."""
+        """Return per-Gaussian affinities aligned with :attr:`gaussians`."""
         self._validate_scale(scale)
         return self._model.get_gaussian_affinity_output(scale)
 

--- a/fvdb_reality_capture/instance_segmentation/garfvdb.py
+++ b/fvdb_reality_capture/instance_segmentation/garfvdb.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import fvdb
 import torch
-from fvdb import GaussianSplat3d
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 
 from .model import GARfVDBModel
 from .training.dataset import GARfVDBInput

--- a/fvdb_reality_capture/instance_segmentation/garfvdb.py
+++ b/fvdb_reality_capture/instance_segmentation/garfvdb.py
@@ -113,7 +113,7 @@ class GARfVDB:
         return save_garfvdb_bundle(self, path)
 
     @classmethod
-    def load(cls, path: str | pathlib.Path, device: str | torch.device = "cuda") -> "GARfVDB":
+    def load(cls, path: str | pathlib.Path, device: str | torch.device = "cuda:0") -> "GARfVDB":
         """Load and validate a portable ``.garfvdb`` directory."""
         from .artifact import load_garfvdb_bundle
 

--- a/fvdb_reality_capture/instance_segmentation/loss.py
+++ b/fvdb_reality_capture/instance_segmentation/loss.py
@@ -1,0 +1,320 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING
+
+import torch
+from torch.nn import functional as F
+
+if TYPE_CHECKING:
+    from fvdb_reality_capture.instance_segmentation.model import GARfVDBModel
+
+
+def chunked_norm(
+    features_flat: torch.Tensor,
+    mask_0: torch.Tensor,
+    mask_1: torch.Tensor,
+    chunk_size: int = 10000,
+) -> torch.Tensor:
+    """Calculate L2 norms between feature pairs efficiently using chunked processing.
+
+    Pre-allocates the result tensor and processes pairs in chunks to avoid
+    memory spikes when computing norms for large numbers of feature pairs.
+
+    Args:
+        features_flat: Feature tensor of shape ``[N, feature_dim]``.
+        mask_0: Index tensor for first element of pairs.
+        mask_1: Index tensor for second element of pairs.
+        chunk_size: Number of pairs to process at once.
+
+    Returns:
+        L2 norms of shape ``[total_pairs]`` for all feature pairs.
+    """
+    total_pairs = len(mask_0)
+    device = features_flat.device
+
+    # Pre-allocate result tensor
+    all_norms = torch.empty(total_pairs, dtype=torch.float32, device=device)
+
+    # Process in chunks to avoid memory spikes
+    for i in range(0, total_pairs, chunk_size):
+        end_idx = min(i + chunk_size, total_pairs)
+
+        # Get chunks of indices
+        chunk_mask_0 = mask_0[i:end_idx]
+        chunk_mask_1 = mask_1[i:end_idx]
+
+        # Get corresponding features
+        chunk_feats_0 = features_flat[chunk_mask_0]
+        chunk_feats_1 = features_flat[chunk_mask_1]
+
+        chunk_norms = torch.norm(chunk_feats_0 - chunk_feats_1, p=2, dim=-1)
+
+        # Store directly in pre-allocated tensor
+        all_norms[i:end_idx] = chunk_norms
+
+        del chunk_feats_0, chunk_feats_1, chunk_norms
+
+    return all_norms
+
+
+def _sum_loss_per_view(
+    per_pair_data: tuple[torch.Tensor, torch.Tensor],
+    num_views: int,
+    samples_per_img: int,
+) -> torch.Tensor:
+    """Sum per-pair loss values into per-view totals.
+
+    Args:
+        per_pair_data: Tuple of (pair_losses, pair_row_indices) where pair_row_indices
+            are the row indices from ``torch.where`` for each pair.
+        num_views: Number of views (B).
+        samples_per_img: Number of samples per image (R).
+
+    Returns:
+        Per-view loss sums of shape ``[num_views]``.
+    """
+    pair_losses, pair_row_indices = per_pair_data
+    view_ids = pair_row_indices // samples_per_img
+    per_view = []
+    for v in range(num_views):
+        v_mask = view_ids == v
+        per_view.append(pair_losses[v_mask].to(torch.float32).sum())
+    return torch.stack(per_view)
+
+
+def calculate_loss(
+    model: GARfVDBModel,
+    enc_feats: torch.Tensor,
+    input: dict[str, torch.Tensor],
+    return_loss_images: bool = False,
+) -> dict[str, torch.Tensor]:
+    """
+    Calculate contrastive loss for GARfVDB instance grouping/segmentation.
+
+    This function computes a multi-component contrastive loss that encourages points
+    belonging to the same instance to have similar features while pushing apart
+    features from different instances.
+
+    Args:
+        model (GARfVDBModel): The model instance used to compute MLP outputs and access
+            configuration parameters like max_grouping_scale.
+        enc_feats (torch.Tensor): Encoded features tensor of shape [batch_size*samples_per_img, feat_dim]
+            containing the feature representations for each point/pixel.
+        input (Dict[str, torch.Tensor]): Input dictionary containing:
+            - "image": Input images of shape [B, H, W, C] or [B, num_samples, C]
+            - "mask_ids": Instance mask IDs of shape matching image spatial dims, where
+                        each unique ID represents a different instance (-1 for invalid/background)
+            - "scales": Scale values for hierarchical feature computation
+        return_loss_images (bool, optional): Whether to compute and return loss visualization
+            images in addition to the total loss. Since this is memory intensive, we use float16
+            when computing loss across the whole image for memory efficiency.
+            Defaults to False.
+
+    Returns:
+        Dict[str, torch.Tensor]: Dictionary containing:
+            - "total_loss": Normalized total contrastive loss value (scalar).
+            - "instance_loss_1_img": (if return_loss_images=True) Visualization of loss 1
+              per pixel/point, normalized to [0, 1].
+            - "instance_loss_2_img": (if return_loss_images=True) Visualization of loss 2
+              per pixel/point, normalized to [0, 1].
+            - "instance_loss_4_img": (if return_loss_images=True) Visualization of loss 4
+              per pixel/point, normalized to [0, 1].
+
+    Loss Components:
+        1. **Instance Loss 1**: Pulls together features of points with the same mask ID
+           at the same scale. Computed as L2 distance between positive pairs.
+
+        2. **Instance Loss 2**: Hierarchical consistency loss that also pulls together
+           features of points with the same mask ID but at larger scales to enforce
+           multi-scale consistency.
+
+        4. **Instance Loss 4**: Pushes apart features of points with different mask IDs
+           using a margin-based hinge loss (ReLU(margin - distance)).
+
+    Implementation Details:
+        - Uses block masking to prevent cross-image comparisons in batched inputs.
+        - Only considers upper triangular pairs to avoid double-counting.
+        - Excludes diagonal pairs (same point with itself) from grouping supervision.
+        - Filters out invalid pairs where mask_ids == -1.
+        - Loss visualization images are computed by scattering loss values back to
+          their corresponding spatial locations in the input image.
+    """
+
+    return_loss_dict = {}
+
+    # Accommodate 'image' inputs of shape [B, num_samples, C] and [B, H, W, C]
+    samples_per_img = math.prod(input["image"].shape[1:-1])
+
+    num_chunks = enc_feats.shape[0]
+
+    input_id1 = input_id2 = input["mask_ids"].flatten()
+
+    logging.debug(
+        f"calc_loss shapes: enc_feats={enc_feats.shape}, input_id1={input_id1.shape}, mask_ids={input['mask_ids'].shape}"
+    )
+
+    # Expand labels for pairwise comparison
+    labels1_expanded = input_id1.unsqueeze(1).expand(-1, input_id1.shape[0])
+    labels2_expanded = input_id2.unsqueeze(0).expand(input_id2.shape[0], -1)
+
+    # Masks for positive/negative pairs across the entire matrix
+    mask_full_positive = labels1_expanded == labels2_expanded
+    mask_full_negative = ~mask_full_positive
+
+    logging.debug(
+        f"num_chunks = {num_chunks}, input_id1.shape[0] = {input_id1.shape[0]}, samples_per_img = {samples_per_img}"
+    )
+
+    # Block-diagonal matrix to consider only pairs within the same image (no cross-image pairs)
+    block_mask = torch.kron(
+        torch.eye(num_chunks, device=labels1_expanded.device, dtype=torch.bool),
+        torch.ones(
+            (samples_per_img, samples_per_img),
+            device=labels1_expanded.device,
+            dtype=torch.bool,
+        ),
+    )
+
+    logging.debug(f"block_mask.shape = {block_mask.shape}")
+
+    # Only consider upper triangle to avoid double-counting
+    block_mask = torch.triu(block_mask, diagonal=0)
+    # Only consider pairs where both points are valid (-1 indicates invalid/no mask)
+    block_mask = block_mask * (labels1_expanded != -1) * (labels2_expanded != -1)
+
+    # Exclude diagonal elements (same-point pairs are trivially similar)
+    diag_mask = torch.eye(block_mask.shape[0], device=block_mask.device, dtype=torch.bool)
+
+    scales = input["scales"]
+
+    # --- Grouping supervision ---
+    # Get instance features: [batch_size, samples_per_img, feat_dim]
+    instance_features = model.get_mlp_output(enc_feats, scales)
+
+    # Flatten for masking: [batch_size * samples_per_img, feat_dim]
+    instance_features_flat = instance_features.reshape(-1, instance_features.shape[-1])
+
+    # 1. If (A, s_A) and (A', s_A) are in the same group, supervise the features to be similar.
+    mask = torch.where(mask_full_positive * block_mask * (~diag_mask))
+
+    logging.debug(f"mask0 shape: {mask[0].shape}")
+    logging.debug(f"mask1 shape: {mask[1].shape}")
+
+    if mask[0].shape[0] > 1000000:
+        instance_loss_1 = chunked_norm(instance_features_flat, mask[0], mask[1], chunk_size=10000)
+    else:
+        instance_loss_1 = torch.norm(instance_features_flat[mask[0]] - instance_features_flat[mask[1]], p=2, dim=-1)
+
+    if not (mask[0] // samples_per_img == mask[1] // samples_per_img).all():
+        logging.error("Loss Function: There's a camera cross-talk issue")
+
+    instance_loss_1_sum = instance_loss_1.nansum()
+    return_loss_dict["instance_loss_1"] = instance_loss_1_sum
+    return_loss_dict["instance_loss_1_per_pair"] = (instance_loss_1, mask[0])
+    logging.debug(f"Loss 1: {instance_loss_1_sum.item()}, using {mask[0].shape[0]} pairs")
+    del instance_loss_1_sum
+
+    if return_loss_images:
+        with torch.no_grad():
+            loss_1_img = torch.zeros(input["image"].shape[:-1], device=instance_loss_1.device)
+            # Accumulate loss values at pixel locations
+            loss_1_img.view(-1).scatter_reduce_(0, mask[0], instance_loss_1, reduce="sum", include_self=True)
+            # Normalize to [0, 1]
+            loss_1_img = loss_1_img / torch.max(loss_1_img)
+            return_loss_dict["instance_loss_1_img"] = loss_1_img.detach()
+            del loss_1_img
+    del instance_loss_1
+
+    # 2. If (A, s_A) and (A', s_A) are in the same group, also supervise them to be similar at s > s_A.
+    scale_diff = torch.max(torch.zeros_like(scales), (model.max_grouping_scale - scales))
+    larger_scale = scales + scale_diff * torch.rand(size=(1,), device=scales.device)
+
+    # Get larger scale features and flatten.
+    larger_scale_instance_features = model.get_mlp_output(enc_feats, larger_scale)
+    larger_scale_instance_features_flat = larger_scale_instance_features.reshape(
+        -1, larger_scale_instance_features.shape[-1]
+    )
+
+    if mask[0].shape[0] > 1000000:
+        instance_loss_2 = chunked_norm(larger_scale_instance_features_flat, mask[0], mask[1], chunk_size=10000)
+    else:
+        instance_loss_2 = torch.norm(
+            larger_scale_instance_features_flat[mask[0]] - larger_scale_instance_features_flat[mask[1]], p=2, dim=-1
+        )
+    instance_loss_2_nansum = instance_loss_2.nansum()
+    return_loss_dict["instance_loss_2"] = instance_loss_2_nansum
+    return_loss_dict["instance_loss_2_per_pair"] = (instance_loss_2, mask[0])
+    logging.debug(f"Loss 2: {instance_loss_2_nansum.item()}, using {mask[0].shape[0]} pairs")
+    del instance_loss_2_nansum
+
+    if return_loss_images:
+        with torch.no_grad():
+            loss_2_img = torch.zeros(input["image"].shape[:-1], device=instance_loss_2.device)
+            loss_2_img.view(-1).scatter_reduce_(0, mask[0], instance_loss_2, reduce="sum", include_self=True)
+            loss_2_img = loss_2_img / loss_2_img.max()
+            return_loss_dict["instance_loss_2_img"] = loss_2_img.detach()
+            del loss_2_img
+    del instance_loss_2
+
+    # 4. Supervise A, B to be dissimilar at scales s_A, s_B respectively.
+    mask = torch.where(mask_full_negative * block_mask)
+
+    margin = 1.0
+
+    if mask[0].shape[0] > 1000000:
+        instance_loss_4 = F.relu(margin - chunked_norm(instance_features_flat, mask[0], mask[1], chunk_size=10000))
+    else:
+        instance_loss_4 = F.relu(
+            margin - torch.norm(instance_features_flat[mask[0]] - instance_features_flat[mask[1]], p=2, dim=-1)
+        )
+    instance_loss_4_nansum = instance_loss_4.to(torch.float32).nansum()
+    return_loss_dict["instance_loss_4"] = instance_loss_4_nansum
+    return_loss_dict["instance_loss_4_per_pair"] = (instance_loss_4, mask[0])
+    logging.debug(f"Loss 4: {instance_loss_4_nansum.item()}, using {mask[0].shape[0]} pairs")
+    del instance_loss_4_nansum
+
+    if return_loss_images:
+        with torch.no_grad():
+            loss_4_img = torch.zeros(
+                input["image"].shape[:-1], device=instance_loss_4.device, dtype=instance_loss_4.dtype
+            )
+            loss_4_img.view(-1).scatter_reduce_(0, mask[0], instance_loss_4, reduce="sum", include_self=True)
+            loss_4_img = loss_4_img / loss_4_img.max()
+            return_loss_dict["instance_loss_4_img"] = loss_4_img.detach()
+            del loss_4_img
+    del instance_loss_4
+
+    # Per-view loss normalization: compute normalized loss per view, then average.
+    # This ensures each view contributes equally regardless of its instance distribution
+    # (views with more instances produce more pairs, which would otherwise dominate).
+    if num_chunks > 1:
+        per_view_pair_counts = torch.zeros(num_chunks, device=block_mask.device, dtype=torch.float32)
+        for v in range(num_chunks):
+            s = v * samples_per_img
+            e = (v + 1) * samples_per_img
+            per_view_pair_counts[v] = block_mask[s:e, s:e].sum().float()
+
+        per_view_pair_counts = per_view_pair_counts.clamp(min=1.0)
+
+        per_view_total = torch.zeros(num_chunks, device=block_mask.device, dtype=torch.float32)
+        for loss_key in ("instance_loss_1", "instance_loss_2", "instance_loss_4"):
+            per_view_total += _sum_loss_per_view(return_loss_dict[loss_key + "_per_pair"], num_chunks, samples_per_img)
+
+        return_loss_dict["total_loss"] = (per_view_total / per_view_pair_counts).mean()
+    else:
+        pair_count = torch.sum(block_mask).float().clamp(min=1.0)
+        return_loss_dict["total_loss"] = (
+            return_loss_dict["instance_loss_1"]
+            + return_loss_dict["instance_loss_2"]
+            + return_loss_dict["instance_loss_4"]
+        ) / pair_count
+
+    for key in [k for k in return_loss_dict if k.endswith("_per_pair")]:
+        del return_loss_dict[key]
+
+    return return_loss_dict

--- a/fvdb_reality_capture/instance_segmentation/loss.py
+++ b/fvdb_reality_capture/instance_segmentation/loss.py
@@ -80,11 +80,8 @@ def _sum_loss_per_view(
     """
     pair_losses, pair_row_indices = per_pair_data
     view_ids = pair_row_indices // samples_per_img
-    per_view = []
-    for v in range(num_views):
-        v_mask = view_ids == v
-        per_view.append(pair_losses[v_mask].to(torch.float32).sum())
-    return torch.stack(per_view)
+    per_view = torch.zeros(num_views, device=pair_losses.device, dtype=torch.float32)
+    return per_view.index_add_(0, view_ids, pair_losses.to(torch.float32))
 
 
 def calculate_loss(
@@ -216,7 +213,7 @@ def calculate_loss(
     instance_loss_1_sum = instance_loss_1.nansum()
     return_loss_dict["instance_loss_1"] = instance_loss_1_sum
     return_loss_dict["instance_loss_1_per_pair"] = (instance_loss_1, mask[0])
-    logging.debug(f"Loss 1: {instance_loss_1_sum.item()}, using {mask[0].shape[0]} pairs")
+    logging.debug("Loss 1: %s, using %d pairs", instance_loss_1_sum.detach(), mask[0].shape[0])
     del instance_loss_1_sum
 
     if return_loss_images:
@@ -249,7 +246,7 @@ def calculate_loss(
     instance_loss_2_nansum = instance_loss_2.nansum()
     return_loss_dict["instance_loss_2"] = instance_loss_2_nansum
     return_loss_dict["instance_loss_2_per_pair"] = (instance_loss_2, mask[0])
-    logging.debug(f"Loss 2: {instance_loss_2_nansum.item()}, using {mask[0].shape[0]} pairs")
+    logging.debug("Loss 2: %s, using %d pairs", instance_loss_2_nansum.detach(), mask[0].shape[0])
     del instance_loss_2_nansum
 
     if return_loss_images:
@@ -275,7 +272,7 @@ def calculate_loss(
     instance_loss_4_nansum = instance_loss_4.to(torch.float32).nansum()
     return_loss_dict["instance_loss_4"] = instance_loss_4_nansum
     return_loss_dict["instance_loss_4_per_pair"] = (instance_loss_4, mask[0])
-    logging.debug(f"Loss 4: {instance_loss_4_nansum.item()}, using {mask[0].shape[0]} pairs")
+    logging.debug("Loss 4: %s, using %d pairs", instance_loss_4_nansum.detach(), mask[0].shape[0])
     del instance_loss_4_nansum
 
     if return_loss_images:
@@ -289,30 +286,21 @@ def calculate_loss(
             del loss_4_img
     del instance_loss_4
 
-    # Per-view loss normalization: compute normalized loss per view, then average.
+    # Per-view loss normalization: normalize each view by its own pair count, then average.
     # This ensures each view contributes equally regardless of its instance distribution
     # (views with more instances produce more pairs, which would otherwise dominate).
-    if num_chunks > 1:
-        per_view_pair_counts = torch.zeros(num_chunks, device=block_mask.device, dtype=torch.float32)
-        for v in range(num_chunks):
-            s = v * samples_per_img
-            e = (v + 1) * samples_per_img
-            per_view_pair_counts[v] = block_mask[s:e, s:e].sum().float()
+    # With a single view this reduces to total pairs loss / total pair count.
+    #
+    # block_mask is block-diagonal by view, so summing its row sums within each view's
+    # block of rows gives that view's pair count without slicing the mask per view.
+    per_view_pair_counts = block_mask.sum(dim=1).view(num_chunks, samples_per_img).sum(dim=1).float()
+    per_view_pair_counts = per_view_pair_counts.clamp(min=1.0)
 
-        per_view_pair_counts = per_view_pair_counts.clamp(min=1.0)
+    per_view_total = torch.zeros(num_chunks, device=block_mask.device, dtype=torch.float32)
+    for loss_key in ("instance_loss_1", "instance_loss_2", "instance_loss_4"):
+        per_view_total += _sum_loss_per_view(return_loss_dict[loss_key + "_per_pair"], num_chunks, samples_per_img)
 
-        per_view_total = torch.zeros(num_chunks, device=block_mask.device, dtype=torch.float32)
-        for loss_key in ("instance_loss_1", "instance_loss_2", "instance_loss_4"):
-            per_view_total += _sum_loss_per_view(return_loss_dict[loss_key + "_per_pair"], num_chunks, samples_per_img)
-
-        return_loss_dict["total_loss"] = (per_view_total / per_view_pair_counts).mean()
-    else:
-        pair_count = torch.sum(block_mask).float().clamp(min=1.0)
-        return_loss_dict["total_loss"] = (
-            return_loss_dict["instance_loss_1"]
-            + return_loss_dict["instance_loss_2"]
-            + return_loss_dict["instance_loss_4"]
-        ) / pair_count
+    return_loss_dict["total_loss"] = (per_view_total / per_view_pair_counts).mean()
 
     for key in [k for k in return_loss_dict if k.endswith("_per_pair")]:
         del return_loss_dict[key]

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -8,7 +8,7 @@ import fvdb
 import numpy as np
 import torch
 import torch.cuda.nvtx as nvtx
-from fvdb import GaussianSplat3d
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 from fvdb_reality_capture.instance_segmentation.config import GARfVDBConfig
 from fvdb_reality_capture.instance_segmentation.training.dataset import GARfVDBInput
 from fvdb_reality_capture.instance_segmentation.util import rgb_to_sh

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -1,17 +1,21 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
+
+from __future__ import annotations
+
 import logging
-from typing import Any, Callable, Literal, Mapping, cast
+from typing import Any, Callable, Literal, Mapping
 
 import fvdb
 import numpy as np
 import torch
 import torch.cuda.nvtx as nvtx
-from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
+
 from fvdb_reality_capture.instance_segmentation.config import GARfVDBConfig
 from fvdb_reality_capture.instance_segmentation.training.dataset import GARfVDBInput
 from fvdb_reality_capture.instance_segmentation.util import rgb_to_sh, sh_to_rgb
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 
 
 class SparseConvWithSkips(torch.nn.Module):

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -1,0 +1,820 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import logging
+from typing import Any, Callable, Literal, Mapping, cast
+
+import fvdb
+import numpy as np
+import torch
+import torch.cuda.nvtx as nvtx
+from fvdb import GaussianSplat3d
+from fvdb_reality_capture.instance_segmentation.config import GARfVDBConfig
+from fvdb_reality_capture.instance_segmentation.training.dataset import GARfVDBInput
+from fvdb_reality_capture.instance_segmentation.util import rgb_to_sh
+
+
+class SparseConvWithSkips(torch.nn.Module):
+    """Sparse convolutional network with skip connections for sparse grids.
+
+    Attributes:
+        kernel_size: Convolution kernel size.
+        relu: ReLU activation function.
+    """
+
+    def __init__(self, num_grids: int, feature_dim: int) -> None:
+        """Initialize the sparse convolutional network.
+
+        Args:
+            num_grids: Number of grids to create convolutional layers for.
+        """
+        super().__init__()
+
+        self.kernel_size = 3
+        self.relu = torch.nn.ReLU()
+
+        # Create 3 convolutional layers per grid with Xavier initialization
+        for i in range(num_grids):
+            for j in range(3):
+                self.add_module(
+                    f"conv_{i}_{j}", fvdb.nn.SparseConv3d(feature_dim, feature_dim, self.kernel_size, bias=False)
+                )
+                torch.nn.init.xavier_uniform_(self.get_submodule(f"conv_{i}_{j}").weight)
+
+    @nvtx.range("SparseConvWithSkips.forward")
+    def forward(self, data: fvdb.JaggedTensor, grid_batch: fvdb.GridBatch) -> fvdb.JaggedTensor:
+        result = []
+
+        for i in range(len(data)):
+            in_data = data[i]
+            in_grid = grid_batch[i]
+
+            plan = fvdb.ConvolutionPlan.from_grid_batch(kernel_size=self.kernel_size, stride=1, source_grid=in_grid)
+
+            x = self.get_submodule(f"conv_{i}_0")(in_data, plan)
+
+            out_grid = plan.target_grid
+
+            x = self.relu(x, out_grid)
+
+            x = self.get_submodule(f"conv_{i}_1")(x, plan)
+            x = self.relu(x, out_grid)
+
+            # Third conv layer with residual skip connection
+            x = self.get_submodule(f"conv_{i}_2")(x, plan)
+            x.data.jdata += in_data.jdata
+
+            result.append(x)
+
+        return fvdb.JaggedTensor(result)
+
+
+class GARfVDBModel(torch.nn.Module):
+    """A PyTorch module that implements a segmentation method using Gaussian Splatting and ƒVDB.
+
+    This model implements a segmentation method inspired by GARField which uses a trained Gaussian
+    Splatting model as the renderable radiance field instead of a NeRF.  The encoded features are
+    sampled from a batch of fVDB grids and then optionally passed through a sparse convolutional
+    network before being concatenated with a scale value and passed to an MLP.  The MLP output is
+    then used to predict a mask for each pixel.
+
+    The model consists of several key components:
+    1. A Gaussian Splatting model for 3D scene representation
+    2. Feature encoding grids or per-gaussian features
+    3. An optional sparse convolutional network for encoded feature processing [currently WIP]
+    4. An MLP for feature transformation
+
+    Attributes:
+        device (torch.device): The device to run the model on (CPU/GPU)
+        model_config (GARfVDBConfig): Configuration parameters for the model
+        gs_model (GaussianSplat3d): The underlying Gaussian Splatting model
+        quantile_transformer (Callable): Function to normalize scales
+        encoder_grids (Optional[fvdb.nn.VDBTensor]): Feature encoding grids when use_grid is True
+        encoder_convnet (Optional[SparseConvWithSkips]): Sparse convolutional encoder network
+        mlp (torch.nn.Sequential): MLP for feature transformation
+    """
+
+    ### Attributes ###
+    mlp: torch.nn.Sequential
+    encoder_gridbatch_features_data: torch.nn.Parameter | torch.Tensor
+    encoder_gridbatch: fvdb.GridBatch
+    encoder_convnet: SparseConvWithSkips | None
+
+    @staticmethod
+    def _state_dict_post_hook(module, state_dict, prefix, local_metadata):
+        """State dict post hook to also provide the encoder gridbatch.
+
+        Returns:
+            dict: The state dictionary of the model with the encoder gridbatch if it is used.
+        """
+        if module.model_config.use_grid:
+            state_dict[f"{prefix}encoder_gridbatch"] = module.encoder_gridbatch.cpu()
+
+    def __init__(
+        self,
+        gs_model: GaussianSplat3d,
+        scale_stats: torch.Tensor | None,
+        model_config: GARfVDBConfig = GARfVDBConfig(),
+        device: str | torch.device = torch.device("cuda"),
+        *,
+        encoder_gridbatch: fvdb.GridBatch | None = None,
+        encoder_features: torch.Tensor | None = None,
+        max_scale: torch.Tensor | None = None,
+        quantile_values: torch.Tensor | None = None,
+        output_quantiles: torch.Tensor | None = None,
+    ):
+        """Initialize the GARfVDBModel from gsplat checkpoint and scale statistics from the entire training dataset.
+
+        Args:
+            gs_model: GaussianSplat3D model
+            scale_stats: [N] Tensor of scale statistics from the entire training dataset.
+                May be ``None`` when loading precomputed quantile buffers.
+            model_config: Model configuration
+            device: Device to use
+        """
+
+        super().__init__()
+        # Because the encoder gridbatch is not a tensor that would be returned by the state_dict method,
+        # we need to register a post hook to add it to the state dict.
+        self.register_state_dict_post_hook(self._state_dict_post_hook)
+
+        self.device = torch.device(device)
+        self.model_config = model_config
+        self.gs_model = gs_model
+        if self.model_config.use_grid and (self.model_config.num_grids < 4 or self.model_config.num_grids % 2 != 0):
+            raise ValueError("GARfVDBConfig.num_grids must be an even integer greater than or equal to 4")
+
+        # Quantile lookup tensors are buffers so the portable inference artifact does not
+        # need the training-time mask statistics.
+        if scale_stats is not None:
+            fitted_max_scale, fitted_quantile_values, fitted_output_quantiles = self._fit_quantiles(
+                scale_stats, device=self.device
+            )
+            max_scale = fitted_max_scale
+            quantile_values = fitted_quantile_values
+            output_quantiles = fitted_output_quantiles
+        elif max_scale is None or quantile_values is None or output_quantiles is None:
+            raise ValueError(
+                "Provide scale_stats when training, or max_scale, quantile_values, and output_quantiles when loading."
+            )
+
+        self.register_buffer("_max_scale", max_scale.detach().to(self.device))
+        self.register_buffer("_quantile_values", quantile_values.detach().to(self.device))
+        self.register_buffer("_output_quantiles", output_quantiles.detach().to(self.device))
+
+        # --- Encoded Features ---
+        # When use_grid=True: Use GARField-style encoding with 3D feature grids at
+        # multiple scales. Features are sampled using Gaussian means and weighted
+        # by transmittance. When use_grid=False: Store features per-Gaussian and
+        # render directly.
+        if self.model_config.use_grid:
+            if encoder_gridbatch is not None:
+                if encoder_features is None:
+                    raise ValueError("encoder_features is required when encoder_gridbatch is provided")
+                if encoder_gridbatch.grid_count != self.model_config.num_grids:
+                    raise ValueError(
+                        f"Expected {self.model_config.num_grids} encoder grids, got {encoder_gridbatch.grid_count}."
+                    )
+                if encoder_features.shape != (
+                    encoder_gridbatch.total_voxels,
+                    self.model_config.grid_feature_dim,
+                ):
+                    raise ValueError(
+                        "Encoder feature shape does not match the loaded NanoVDB topology: "
+                        f"expected {(encoder_gridbatch.total_voxels, self.model_config.grid_feature_dim)}, "
+                        f"got {tuple(encoder_features.shape)}."
+                    )
+                self.encoder_gridbatch = encoder_gridbatch.to(self.device)
+                self.encoder_gridbatch_features_data = torch.nn.Parameter(
+                    encoder_features.detach().to(self.device).contiguous()
+                )
+                num_grids = [self.model_config.num_grids // 2, self.model_config.num_grids // 2]
+            else:
+                # GARField encoder uses two sets of grids with exponentially-spaced resolutions:
+                # - 12 grids from 16 to 256 voxels per axis (coarse to medium)
+                # - 12 grids from 256 to 2048 voxels per axis (medium to fine)
+                # Each grid has 8 feature channels
+                resolution_range = [(16, 256), (256, 2048)]
+                num_grids = [self.model_config.num_grids // 2, self.model_config.num_grids // 2]
+                # Get the spatial extent of the Gaussian means
+                means = self.gs_model.means.detach()
+                extent = means.max(dim=0).values - means.min(dim=0).values
+                max_extent = extent.max().item()
+
+                # Calculate the worldspace voxel sizes for each grid across the specified ranges
+                voxel_sizes = []
+                for res_range, n_grids in zip(resolution_range, num_grids):
+                    growth_rate = np.exp((np.log(res_range[1]) - np.log(res_range[0])) / (n_grids - 1))
+                    for i in range(n_grids):
+                        res = np.round(res_range[0] * (growth_rate**i))
+                        voxel_sizes.append([max_extent / res for _ in range(3)])
+
+                # Create the encoder grids
+                points = fvdb.JaggedTensor([means for _ in range(len(voxel_sizes))])
+                self.encoder_gridbatch = fvdb.GridBatch.from_points(
+                    points=points,
+                    voxel_sizes=voxel_sizes,  # type: ignore
+                )
+                # The original GARField encoder grids store features at voxel corners
+                self.encoder_gridbatch = self.encoder_gridbatch.dual_grid()
+
+                # Initialize the encoded features
+                enc_features = (
+                    torch.randn(
+                        [self.encoder_gridbatch.total_voxels, self.model_config.grid_feature_dim], device=device
+                    )
+                    * 1e-3
+                )
+                # Store as a parameter to make it a leaf tensor
+                self.encoder_gridbatch_features_data = torch.nn.Parameter(enc_features)
+
+            if self.model_config.use_grid_conv:
+                self.encoder_convnet = SparseConvWithSkips(
+                    num_grids=sum(num_grids), feature_dim=self.model_config.grid_feature_dim
+                ).to(device)
+
+        else:
+            # Initialize the per-gaussian features and register as a parameter
+            self.gs_features = torch.nn.Parameter(
+                torch.zeros(
+                    [self.gs_model.means.shape[0], 1, self.model_config.num_grids * self.model_config.grid_feature_dim],
+                    device=device,
+                )
+            )
+
+            # Create reusable GaussianSplat3d for rendering - sh0 will be updated from gs_features
+            self._gs_model_for_render = fvdb.GaussianSplat3d.from_tensors(
+                means=self.gs_model.means.detach(),
+                quats=self.gs_model.quats.detach(),
+                log_scales=self.gs_model.log_scales.detach(),
+                logit_opacities=self.gs_model.logit_opacities.detach(),
+                sh0=self.gs_features.detach(),  # placeholder, will be overwritten
+                shN=torch.zeros(
+                    [self.gs_model.means.shape[0], 0, self.model_config.num_grids * self.model_config.grid_feature_dim],
+                    device=device,
+                ),
+            )
+
+        # --- MLP ---
+        # GARField-style MLP ("instance net") with configurable hidden layers.
+        # NOTE: GARField had used 4 hidden layers with 256 units each, 256 output channels
+        # Input: concatenation of multi-scale encoder features and spatial scale encoding
+        if self.model_config.use_grid:
+            i_channels = self.model_config.grid_feature_dim * np.sum(num_grids) + 1
+        else:
+            i_channels = self.model_config.num_grids * self.model_config.grid_feature_dim + 1
+        o_channels = self.model_config.mlp_output_dim
+        n_neurons = self.model_config.mlp_hidden_dim
+        hidden_layers = self.model_config.mlp_num_layers
+
+        # Create MLP
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(i_channels, n_neurons, bias=True),
+            torch.nn.ReLU(),
+            *[
+                layer
+                for _ in range(hidden_layers)
+                for layer in (torch.nn.Linear(n_neurons, n_neurons, bias=True), torch.nn.ReLU())
+            ],
+            torch.nn.Linear(n_neurons, o_channels, bias=False),
+        ).to(device)
+
+        # Initialize MLP: Kaiming for ReLU layers, Xavier for final layer, zero biases
+        mlp_layers = [layer for layer in self.mlp if isinstance(layer, torch.nn.Linear)]
+        for i, layer in enumerate(mlp_layers):
+            is_final_layer = i == len(mlp_layers) - 1
+            if is_final_layer:
+                torch.nn.init.xavier_uniform_(layer.weight)
+            else:
+                torch.nn.init.kaiming_uniform_(layer.weight, nonlinearity="relu")
+            if layer.bias is not None:
+                torch.nn.init.zeros_(layer.bias)
+
+    ### Properties ###
+    @property
+    def enc_features(self) -> fvdb.JaggedTensor:
+        """Get the encoded features.
+
+        Returns:
+            fvdb.JaggedTensor: The encoded features
+        """
+        return self.encoder_gridbatch.jagged_like(self.encoder_gridbatch_features_data)
+
+    @property
+    def max_grouping_scale(self) -> torch.Tensor:
+        """Get the maximum grouping scale.
+
+        Returns:
+            torch.Tensor: The maximum grouping world space scale
+        """
+        return self._max_scale
+
+    @property
+    def quantile_transformer(self) -> Callable[[torch.Tensor], torch.Tensor]:
+        """The scale quantile transformer.
+
+        Returns:
+            Callable: The quantile transformer
+        """
+        return self._transform_scale
+
+    @staticmethod
+    def create_from_state_dict(
+        state_dict: dict[str, Any],
+        model_config: GARfVDBConfig,
+        gs_model: GaussianSplat3d,
+        scale_stats: torch.Tensor,
+    ) -> "GARfVDBModel":
+        """Load the model from the given state dictionary.
+
+        Args:
+            state_dict: State dictionary of the model
+            model_config: Model configuration
+            gs_model: GaussianSplat3d model
+            scale_stats: Scale statistics
+
+        Returns:
+            GARfVDBModel: The loaded model
+        """
+        if model_config.use_grid:
+            model = GARfVDBModel(
+                gs_model,
+                scale_stats,
+                model_config,
+                gs_model.device,
+                encoder_gridbatch=state_dict["encoder_gridbatch"],
+                encoder_features=state_dict["encoder_gridbatch_features_data"],
+            )
+        else:
+            model = GARfVDBModel(gs_model, scale_stats, model_config, gs_model.device)
+            model.gs_features = torch.nn.Parameter(state_dict["gs_features"])
+
+        network_state = {
+            key: value
+            for key, value in state_dict.items()
+            if isinstance(value, torch.Tensor) and key not in {"encoder_gridbatch_features_data", "gs_features"}
+        }
+        model.load_state_dict(network_state, strict=False)
+        return model
+
+    @staticmethod
+    def _fit_quantiles(
+        scales: torch.Tensor,
+        device: torch.device,
+        distribution: Literal["uniform", "normal"] = "normal",
+        n_quantiles: int = 1000,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Fit the lookup tensors used to normalize grouping scales."""
+        scales = scales.flatten()
+        positive_scales = scales[scales > 0]
+        if positive_scales.numel() == 0:
+            raise ValueError("At least one positive grouping scale is required")
+        max_scale = torch.max(positive_scales)
+        scales = positive_scales[positive_scales < max_scale]
+        if scales.numel() == 0:
+            scales = positive_scales
+
+        n_quantiles = min(n_quantiles, max(2, scales.numel()))
+        quantile_levels = torch.linspace(0, 1, n_quantiles, device=scales.device, dtype=scales.dtype)
+        quantile_values = torch.quantile(scales.detach(), quantile_levels).to(device)
+        quantile_levels = quantile_levels.to(device)
+        if distribution == "normal":
+            clamped_levels = quantile_levels.clamp(1e-7, 1 - 1e-7)
+            output_quantiles = torch.erfinv(2 * clamped_levels - 1) * (2**0.5)
+        else:
+            output_quantiles = quantile_levels
+        return max_scale.to(device), quantile_values, output_quantiles
+
+    def _transform_scale(self, x: torch.Tensor) -> torch.Tensor:
+        """Transform scales using the persisted piecewise-linear quantile lookup."""
+        original_shape = x.shape
+        x_flat = x.reshape(-1)
+
+        indices = torch.searchsorted(self._quantile_values, x_flat).clamp(1, self._quantile_values.numel() - 1)
+
+        lower_q = self._quantile_values[indices - 1]
+        upper_q = self._quantile_values[indices]
+
+        denom = upper_q - lower_q
+        denom = torch.where(denom > 0, denom, torch.ones_like(denom))
+        weight = ((x_flat - lower_q) / denom).clamp(0, 1)
+
+        lower_out = self._output_quantiles[indices - 1]
+        upper_out = self._output_quantiles[indices]
+        transformed = lower_out + weight * (upper_out - lower_out)
+
+        return transformed.reshape(original_shape)
+
+    def network_state_dict(self) -> dict[str, torch.Tensor]:
+        """Return dense model tensors, excluding the NanoVDB encoder feature payload."""
+        return {
+            key: value.detach().cpu().contiguous()
+            for key, value in self.state_dict().items()
+            if isinstance(value, torch.Tensor) and key not in {"encoder_gridbatch_features_data", "gs_features"}
+        }
+
+    @classmethod
+    def from_artifact_components(
+        cls,
+        *,
+        gs_model: GaussianSplat3d,
+        model_config: GARfVDBConfig,
+        encoder_gridbatch: fvdb.GridBatch,
+        encoder_features: torch.Tensor,
+        network_state: Mapping[str, torch.Tensor],
+        device: str | torch.device,
+    ) -> "GARfVDBModel":
+        """Construct an inference model from NanoVDB and safetensors payloads."""
+        required = {"_max_scale", "_quantile_values", "_output_quantiles"}
+        missing = required.difference(network_state)
+        if missing:
+            raise ValueError(f"Network payload is missing required scale tensors: {sorted(missing)}")
+        model = cls(
+            gs_model=gs_model,
+            scale_stats=None,
+            model_config=model_config,
+            device=device,
+            encoder_gridbatch=encoder_gridbatch,
+            encoder_features=encoder_features,
+            max_scale=network_state["_max_scale"],
+            quantile_values=network_state["_quantile_values"],
+            output_quantiles=network_state["_output_quantiles"],
+        )
+        incompatible = model.load_state_dict(dict(network_state), strict=False)
+        unexpected = [key for key in incompatible.unexpected_keys if key != "encoder_gridbatch_features_data"]
+        missing_network = [key for key in incompatible.missing_keys if key != "encoder_gridbatch_features_data"]
+        if unexpected or missing_network:
+            raise ValueError(
+                f"Network payload does not match GARfVDBConfig; missing={missing_network}, unexpected={unexpected}."
+            )
+        model.eval()
+        return model
+
+    @nvtx.range("GARfVDBModel.get_encoded_features")
+    def get_encoded_features(self, input: GARfVDBInput) -> torch.Tensor:
+        """Get the per-pixel encoder features for the given input images or pixel samples.
+
+        Args:
+            input: GARfVDBInput data
+
+        Returns:
+            Encoded feature tensor [B, R, S, F] or [B, H, W, S, F]
+        """
+        img_w = input["image_w"][0]
+        img_h = input["image_h"][0]
+        if not self.model_config.use_grid:
+            # Update sh0 with current gs_features before rendering
+            self._gs_model_for_render.sh0 = self.gs_features
+
+            intrinsics = input["projection"]
+            world_to_cam = input["world_to_camera"]
+            pixel_coords = input.get("pixel_coords", None)  # [B, rays_per_image, 2]
+
+            if pixel_coords is not None:
+                B, rays_per_image = pixel_coords.shape[:2]
+                flat_pixel_coords = pixel_coords.reshape(-1, 2)
+                offsets = torch.arange(0, B + 1, device=pixel_coords.device, dtype=torch.long) * rays_per_image
+                pixels_to_render = fvdb.JaggedTensor.from_data_and_offsets(flat_pixel_coords, offsets)
+
+                features, _ = self._gs_model_for_render.sparse_render_images(
+                    pixels_to_render=pixels_to_render,
+                    world_to_camera_matrices=world_to_cam,
+                    projection_matrices=intrinsics,
+                    image_width=img_w,
+                    image_height=img_h,
+                    near=0.01,
+                    far=1e10,
+                )
+                feature_size = features.eshape[-1]
+
+                cam_batch_size, num_rays_per_cam = pixel_coords.shape[:2]
+                # reshape features to [B, R, S, F]
+                return features.jdata.reshape(len(features), num_rays_per_cam, -1, feature_size)
+
+            else:
+                features, _ = self._gs_model_for_render.render_images(
+                    image_width=img_w,
+                    image_height=img_h,
+                    world_to_camera_matrices=world_to_cam,
+                    projection_matrices=intrinsics,
+                    near=0.01,
+                    far=1e10,
+                    sh_degree_to_use=0,
+                )
+                feature_size = features.shape[-1]
+                # reshape features to [B, H, W, S, F]
+                return features.reshape(len(features), img_h, img_w, -1, feature_size)
+        else:
+            intrinsics: torch.Tensor = input["projection"]
+            world_to_cam: torch.Tensor = input["world_to_camera"]
+            pixel_coords: torch.Tensor | None = input.get("pixel_coords", None)  # [B, rays_per_image, 2]
+
+            # Render the IDs of the gaussians that contribute to each pixel, which we will use to sample the feature grids
+            with torch.no_grad():
+                if pixel_coords is not None:
+                    B, rays_per_image = pixel_coords.shape[:2]
+                    flat_pixel_coords = pixel_coords.reshape(-1, 2)
+                    offsets = torch.arange(0, B + 1, device=pixel_coords.device, dtype=torch.long) * rays_per_image
+                    pixels_to_render = fvdb.JaggedTensor.from_data_and_offsets(flat_pixel_coords, offsets)
+
+                    ids, weights = self.gs_model.sparse_render_contributing_gaussian_ids(
+                        pixels_to_render=pixels_to_render,
+                        top_k_contributors=self.model_config.depth_samples,
+                        world_to_camera_matrices=world_to_cam,
+                        projection_matrices=intrinsics,
+                        image_width=img_w,
+                        image_height=img_h,
+                        near=0.01,
+                        far=1e10,
+                    )
+
+                else:
+                    ids, weights = self.gs_model.render_contributing_gaussian_ids(
+                        top_k_contributors=self.model_config.depth_samples,
+                        image_width=img_w,
+                        image_height=img_h,
+                        world_to_camera_matrices=world_to_cam,
+                        projection_matrices=intrinsics,
+                        near=0.01,
+                        far=1e10,
+                    )
+
+                # TODO: Investigate NaN values in contributing gaussian weights
+                if torch.isnan(weights.jdata).any():
+                    logging.warning("NaN values detected in contributing gaussian weights")
+                    raise ValueError("NaN values in contributing gaussian weights")
+
+            if self.model_config.enc_feats_one_idx_per_ray:
+                # Stochastically pick the depth_sample for each pixel based on the weights as probabilities
+                # Convert weights to probabilities if they aren't already normalized
+
+                # # Check for rays where all weights are 0
+                # zero_mask = torch.tensor(weights.lshape) == 0  # [C,[R]]
+                # if zero_mask.jdata.any():
+                #     logging.warning(f"WARNING: Found {zero_mask.jdata.sum().item()} rays with all 0 weights")
+                #     # For each ray with all zeros, set the first depth sample to 1e-10
+                #     weights = torch.where(
+                #         zero_mask.unsqueeze(-1),  # [B, R, 1] or [B, H, W, 1]
+                #         torch.cat([torch.full_like(weights[..., :1], 1e-10), weights[..., 1:]], dim=-1),
+                #         weights,
+                #     )
+                # Sample one index per ray based on probabilities
+                # NOTE:  This probability would be much simpler if the division were just broadcastable
+                probs = []
+                for per_cam_weights, per_cam_weight_sum in zip(weights, weights.jsum(dim=0, keepdim=True)):
+                    cam_probs = []
+
+                    for per_ray_weights, per_ray_weight_sum in zip(per_cam_weights, per_cam_weight_sum):
+                        if len(per_ray_weights) == 0:
+                            cam_probs.append(torch.empty([0, per_ray_weights.eshape[-1]]))
+                        else:
+                            cam_probs.append(fvdb.relu(per_ray_weights.jdata / (per_ray_weight_sum.jdata + 1e-10)))
+                    probs.append(cam_probs)
+                probs = fvdb.JaggedTensor(probs)
+                # shape: [B, R]
+                depth_sample_indices = []
+                for per_cam_probs in probs:
+                    depth_sample_indices_cam = []
+                    for per_ray_probs in per_cam_probs:
+                        if len(per_ray_probs) == 0:
+                            depth_sample_indices_cam.append(torch.empty([0]))
+                        else:
+                            depth_sample_indices_cam.append(torch.multinomial(per_ray_probs.jdata, num_samples=1))
+                    depth_sample_indices.append(depth_sample_indices_cam)
+
+                depth_sample_indices = fvdb.JaggedTensor(depth_sample_indices)
+                # get 1 id per ray based on the depth_sample_indices
+                single_ids = []
+                for per_cam_ids, per_cam_depth_sample_indices in zip(ids, depth_sample_indices):
+
+                    cam_ids = []
+                    for per_ray_ids, per_ray_depth_sample_indices in zip(per_cam_ids, per_cam_depth_sample_indices):
+                        if len(per_ray_ids) == 0:
+                            cam_ids.append(torch.empty([0]))
+                        else:
+                            cam_ids.append(per_ray_ids.jdata[per_ray_depth_sample_indices.jdata])
+                            # cam_ids.append(
+                            #     torch.gather(per_ray_ids.jdata, dim=1, index=per_ray_depth_sample_indices.jdata)
+                            # )
+                    single_ids.append(cam_ids)
+                ids = fvdb.JaggedTensor(single_ids)
+                # ids = torch.gather(ids.squeeze(-1), dim=2, index=depth_sample_indices)  # [B, R, 1] or [B, H, W, 1]
+
+            # Filter out invalid IDs (-1 indicates no valid gaussian for that position)
+            valid_mask = ids.jdata >= 0
+            valid_ids = ids.jdata[valid_mask]
+
+            # Get unique among valid IDs only
+            unique_valid_ids, valid_inverse = torch.unique(valid_ids, return_inverse=True)
+
+            # Look up gaussian positions for valid unique IDs only
+            unique_world_pts = self.gs_model.means[unique_valid_ids]
+
+            # sample the encoder grids at the unique world points
+            grid_count = self.encoder_gridbatch.grid_count
+            num_unique_pts = len(unique_valid_ids)
+
+            if num_unique_pts > 0:
+                tiled_pts = unique_world_pts.repeat(grid_count, 1)  # [grid_count * num_unique_pts, 3]
+                offsets = (
+                    torch.arange(0, grid_count + 1, device=unique_world_pts.device, dtype=torch.long) * num_unique_pts
+                )
+                enc_grid_sample_pts = fvdb.JaggedTensor.from_data_and_offsets(tiled_pts, offsets)
+                with nvtx.range("sample_encoder_grids"):
+                    if self.model_config.use_grid_conv:
+                        conv_output = self.encoder_convnet(self.enc_features, self.encoder_gridbatch)
+                        unique_enc_feats = conv_output.sample_trilinear(enc_grid_sample_pts)
+                    else:
+                        unique_enc_feats = self.encoder_gridbatch.sample_trilinear(
+                            enc_grid_sample_pts, self.enc_features
+                        )
+
+                feat_dim = unique_enc_feats.jdata.shape[-1]
+                # jdata is [grid_count * num_unique_pts, feat_dim]
+                # reshape to [grid_count, num_unique_pts, feat_dim], transpose, flatten
+                unique_cam_enc_feats = (
+                    unique_enc_feats.jdata.reshape(grid_count, num_unique_pts, feat_dim)
+                    .transpose(0, 1)
+                    .reshape(num_unique_pts, grid_count * feat_dim)
+                )  # [num_unique_pts, F]
+
+                # Re-assemble enc_feats: valid positions get looked-up features, invalid get zeros
+                total_samples = ids.jdata.shape[0]
+                feat_dim_total = unique_cam_enc_feats.shape[-1]
+                enc_feats_data = torch.zeros(
+                    total_samples, feat_dim_total, device=ids.jdata.device, dtype=unique_cam_enc_feats.dtype
+                )
+                enc_feats_data[valid_mask] = unique_cam_enc_feats[valid_inverse]
+            else:
+                # Edge case: no valid IDs at all
+                # Determine feature dimension from encoder config
+                feat_dim_total = grid_count * self.enc_features.shape[-1]
+                total_samples = ids.jdata.shape[0]
+                enc_feats_data = torch.zeros(total_samples, feat_dim_total, device=ids.jdata.device)
+
+            enc_feats = ids.jagged_like(enc_feats_data)
+
+            if not self.model_config.enc_feats_one_idx_per_ray:
+                # Weighted sum of the enc_feats and transmittance weights
+                enc_feats.jdata = enc_feats.jdata * weights.jdata.unsqueeze(-1)
+                # When every pixel has exactly 1 contributor, fvdb returns a
+                # 1-level JaggedTensor [C,[R]] instead of 2-level [C,[R,[K]]].
+                # jsum(dim=0) on a 1-level tensor would collapse pixels within
+                # each camera rather than depth samples within each pixel.
+                if isinstance(enc_feats.lshape[0], list):
+                    enc_feats = enc_feats.jsum(dim=0, keepdim=True)
+
+            epsilon = 1e-6
+            enc_feats.jdata = enc_feats.jdata / (torch.linalg.norm(enc_feats.jdata, dim=-1, keepdim=True) + epsilon)
+
+            # Convert enc_feats to regular Tensor
+            feature_size = enc_feats.eshape[-1]
+            if pixel_coords is not None:
+                # reshape enc_feats to [B, R, S, F]
+                cam_batch_size, num_rays_per_cam = pixel_coords.shape[:2]
+                return enc_feats.jdata.reshape(cam_batch_size, num_rays_per_cam, -1, feature_size)
+            else:
+                # reshape enc_feats to [B, H, W, S, F]
+                return enc_feats.jdata.reshape(len(enc_feats), img_h, img_w, -1, feature_size)
+
+    @nvtx.range("GARfVDBModel.get_mlp_output")
+    def get_mlp_output(self, enc_feats: torch.Tensor, scales: torch.Tensor | float) -> torch.Tensor:
+        """Get the MLP output for the given encoder features and scales.
+
+        Args:
+            enc_feats: Encoder features [B, R, S, F] or [B, H, W, S, F]
+            scales: Either a scalar (float/int) for uniform scale across all pixels,
+                    or a tensor [B, R] or [B, H, W] for per-pixel scales
+
+        Returns:
+            MLP output [B, R, F] or [B, H, W, F]
+        """
+        epsilon = 1e-5
+
+        # Process scales through quantile transformer and concatenate with features
+        if isinstance(scales, (int, float)):
+            # transform once and use F.pad to append constant value
+            scale_tensor = torch.tensor([scales], device=enc_feats.device, dtype=enc_feats.dtype)
+            scale_value = self.quantile_transformer(scale_tensor).item()
+            # Pad last dimension with constant scale value: (left_pad, right_pad)
+            in_feats = torch.nn.functional.pad(enc_feats, (0, 1), value=scale_value)
+        else:
+            # transform per-pixel scales (used during training)
+            # scales: [B, R] or [B, H, W] -> scales_quant: [B, R, S, 1] or [B, H, W, S, 1]
+            scales_quant = self.quantile_transformer(scales)
+            scales_quant = scales_quant.unsqueeze(-1).expand(enc_feats.shape[:-1]).unsqueeze(-1)
+            in_feats = torch.cat([enc_feats, scales_quant], dim=-1)
+
+        # Apply MLP
+        gfeats = self.mlp(in_feats)
+        norms = gfeats.norm(dim=-1, keepdim=True)
+        gfeats = gfeats / (norms + epsilon)
+
+        # Reshape back to 3D
+        return gfeats
+
+    def _sample_encoder_grids_at_gaussians(self) -> torch.Tensor:
+        # repeat the gaussian means for each grid
+        num_points = self.gs_model.means.shape[0]
+        grid_count = self.encoder_gridbatch.grid_count
+        repeated_data = self.gs_model.means.repeat(grid_count, 1)
+        # Create offsets: [0, N, 2N, 3N, ..., grid_count*N]
+        offsets = torch.arange(
+            0, (grid_count + 1) * num_points, num_points, device=self.gs_model.means.device, dtype=torch.long
+        )
+        world_pts = fvdb.JaggedTensor.from_data_and_offsets(repeated_data, offsets)
+
+        if self.model_config.use_grid_conv:
+            conv_output = self.encoder_convnet(self.encoder_grids)
+            enc_feats = conv_output.sample_trilinear(world_pts)
+        else:
+            with nvtx.range("encoder_gridbatch.sample_trilinear"):
+                enc_feats = self.encoder_gridbatch.sample_trilinear(world_pts, self.enc_features)
+        # enc_feats.jdata is [grid_count * N, F], we want [N, grid_count * F]
+        num_features = enc_feats.jdata.shape[-1]
+        enc_feats = enc_feats.jdata.view(grid_count, num_points, num_features).permute(1, 0, 2).reshape(num_points, -1)
+        return enc_feats
+
+    @nvtx.range("GARfVDBModel.get_mask_output")
+    def get_mask_output(self, input: GARfVDBInput, scale: float) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get the mask output for the given input and scale
+
+        This is a convenience function used in inference or evaluation to get the mask output for a given scale.
+
+        Args:
+            input: GARfVDBInput data
+            scale: Chosen scale for the masks
+
+        Returns:
+            Mask output [B, H, W, mlp_output_dim]
+        """
+        img_w = input["image_w"][0]
+        img_h = input["image_h"][0]
+
+        intrinsics = input["projection"]
+        world_to_cam = input["world_to_camera"]
+
+        if self.model_config.use_grid:
+            # Obtain per-gaussian features from the encoder grids
+            enc_feats = self._sample_encoder_grids_at_gaussians()
+
+            # Set them as the sh0 features
+            enc_feats_state_dict = self.gs_model.state_dict()
+            enc_feats_state_dict["sh0"] = rgb_to_sh(enc_feats).unsqueeze(1).contiguous()
+            with nvtx.range("GaussianSplat3d.from_state_dict"):
+                gs3d_enc_feats = GaussianSplat3d.from_state_dict(enc_feats_state_dict)
+        else:
+            with nvtx.range("update_gs_features"):
+                # Update sh0 with current gs_features and reuse the model
+                self._gs_model_for_render.sh0 = self.gs_features
+                gs3d_enc_feats = self._gs_model_for_render
+
+        # Render the image
+        with nvtx.range("gs3d_enc_feats.render_images"):
+            img_feats, alpha = gs3d_enc_feats.render_images(
+                image_width=img_w,
+                image_height=img_h,
+                world_to_camera_matrices=world_to_cam,
+                projection_matrices=intrinsics,
+                near=0.01,
+                far=1e10,
+                sh_degree_to_use=0,
+            )
+
+        epsilon = 1e-6
+        img_feats = img_feats / (torch.linalg.norm(img_feats, dim=-1, keepdim=True) + epsilon)
+
+        # Apply MLP
+        gfeats = self.get_mlp_output(img_feats, scale)
+
+        return gfeats, alpha
+
+    def get_gaussian_affinity_output(self, scale: float) -> torch.Tensor:
+        """Get per-Gaussian affinity features for the given scale.
+
+        This is a convenience function used during inference or evaluation to
+        compute per-Gaussian feature embeddings (affinities) by sampling
+        encoder grid features or using the current Gaussian features, normalizing
+        them, and passing them through the MLP at the specified scale.
+
+        Args:
+            scale: Chosen scale for the affinity MLP output.
+
+        Returns:
+            A tensor of per-Gaussian affinity features.
+        """
+        if self.model_config.use_grid:
+            # Obtain per-gaussian features from the encoder grids
+            enc_feats = self._sample_encoder_grids_at_gaussians()
+            enc_feats = rgb_to_sh(enc_feats)
+        else:
+            enc_feats = self.gs_features
+            enc_feats = rgb_to_sh(enc_feats)
+
+        epsilon = 1e-6
+        enc_feats = enc_feats / (torch.linalg.norm(enc_feats, dim=-1, keepdim=True) + epsilon)
+
+        # Apply MLP
+        gfeats = self.get_mlp_output(enc_feats, scale)
+
+        return gfeats

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -115,7 +115,7 @@ class GARfVDBModel(torch.nn.Module):
         gs_model: GaussianSplat3d,
         scale_stats: torch.Tensor | None,
         model_config: GARfVDBConfig = GARfVDBConfig(),
-        device: str | torch.device = torch.device("cuda"),
+        device: str | torch.device = torch.device("cuda:0"),
         *,
         encoder_gridbatch: fvdb.GridBatch | None = None,
         encoder_features: torch.Tensor | None = None,

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -11,7 +11,7 @@ import torch.cuda.nvtx as nvtx
 from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 from fvdb_reality_capture.instance_segmentation.config import GARfVDBConfig
 from fvdb_reality_capture.instance_segmentation.training.dataset import GARfVDBInput
-from fvdb_reality_capture.instance_segmentation.util import rgb_to_sh
+from fvdb_reality_capture.instance_segmentation.util import rgb_to_sh, sh_to_rgb
 
 
 class SparseConvWithSkips(torch.nn.Module):
@@ -806,10 +806,10 @@ class GARfVDBModel(torch.nn.Module):
         if self.model_config.use_grid:
             # Obtain per-gaussian features from the encoder grids
             enc_feats = self._sample_encoder_grids_at_gaussians()
-            enc_feats = rgb_to_sh(enc_feats)
         else:
-            enc_feats = self.gs_features
-            enc_feats = rgb_to_sh(enc_feats)
+            # Per-Gaussian features are stored as degree-zero SH coefficients so they can be
+            # rendered during training. Evaluate those coefficients before applying the MLP.
+            enc_feats = sh_to_rgb(self.gs_features)
 
         epsilon = 1e-6
         enc_feats = enc_feats / (torch.linalg.norm(enc_feats, dim=-1, keepdim=True) + epsilon)

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -247,7 +247,7 @@ class GARfVDBModel(torch.nn.Module):
             )
 
             # Create reusable GaussianSplat3d for rendering - sh0 will be updated from gs_features
-            self._gs_model_for_render = fvdb.GaussianSplat3d.from_tensors(
+            self._gs_model_for_render = GaussianSplat3d.from_tensors(
                 means=self.gs_model.means.detach(),
                 quats=self.gs_model.quats.detach(),
                 log_scales=self.gs_model.log_scales.detach(),

--- a/fvdb_reality_capture/instance_segmentation/model.py
+++ b/fvdb_reality_capture/instance_segmentation/model.py
@@ -652,7 +652,7 @@ class GARfVDBModel(torch.nn.Module):
             else:
                 # Edge case: no valid IDs at all
                 # Determine feature dimension from encoder config
-                feat_dim_total = grid_count * self.enc_features.shape[-1]
+                feat_dim_total = grid_count * self.enc_features.eshape[-1]
                 total_samples = ids.jdata.shape[0]
                 enc_feats_data = torch.zeros(total_samples, feat_dim_total, device=ids.jdata.device)
 
@@ -661,12 +661,18 @@ class GARfVDBModel(torch.nn.Module):
             if not self.model_config.enc_feats_one_idx_per_ray:
                 # Weighted sum of the enc_feats and transmittance weights
                 enc_feats.jdata = enc_feats.jdata * weights.jdata.unsqueeze(-1)
-                # When every pixel has exactly 1 contributor, fvdb returns a
-                # 1-level JaggedTensor [C,[R]] instead of 2-level [C,[R,[K]]].
-                # jsum(dim=0) on a 1-level tensor would collapse pixels within
-                # each camera rather than depth samples within each pixel.
-                if isinstance(enc_feats.lshape[0], list):
-                    enc_feats = enc_feats.jsum(dim=0, keepdim=True)
+
+                # The contributing-gaussian render always returns a 2-level
+                # JaggedTensor [C,[R,[K]]]. A 1-level result means the per-pixel
+                # contribution segments were lost upstream, and jsum(dim=0) would
+                # then collapse pixels within each camera instead of depth samples
+                # within each pixel. Fail rather than train on the wrong features.
+                if not isinstance(enc_feats.lshape[0], list):
+                    raise RuntimeError(
+                        "Contributing-gaussian render returned a 1-level JaggedTensor; expected 2-level "
+                        "[C,[R,[K]]]. Per-pixel contributions cannot be reduced correctly from this shape."
+                    )
+                enc_feats = enc_feats.jsum(dim=0, keepdim=True)
 
             epsilon = 1e-6
             enc_feats.jdata = enc_feats.jdata / (torch.linalg.norm(enc_feats.jdata, dim=-1, keepdim=True) + epsilon)

--- a/fvdb_reality_capture/instance_segmentation/optim.py
+++ b/fvdb_reality_capture/instance_segmentation/optim.py
@@ -1,0 +1,71 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from typing import Literal
+
+import numpy as np
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LRScheduler
+
+
+class ExponentialLRWithRampUpScheduler(LRScheduler):
+    """Exponential decay scheduler with linear or cosine warmup ramp.
+
+    The scheduler first ramps up to ``lr_init`` over ``warmup_steps`` steps,
+    then exponentially decays to ``lr_final`` over the remaining steps until
+    ``max_steps``.
+    """
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        lr_init: float,
+        lr_pre_warmup: float = 1e-8,
+        lr_final: float | None = None,
+        warmup_steps: int = 0,
+        max_steps: int = 100000,
+        ramp: Literal["linear", "cosine"] = "cosine",
+        last_epoch: int = -1,
+    ):
+        """Initialize the scheduler.
+
+        Args:
+            optimizer: The optimizer to schedule.
+            lr_init: Initial learning rate after warmup.
+            lr_pre_warmup: Learning rate before warmup.
+            lr_final: Final learning rate. If not provided, it will be set to lr_init.
+            warmup_steps: Number of warmup steps.
+            max_steps: The maximum number of steps.
+            ramp: The ramp function to use during the warmup.
+            last_epoch: The index of last epoch.
+        """
+        self._lr_init = lr_init
+        self._lr_pre_warmup = lr_pre_warmup
+        self._lr_final = lr_final if lr_final is not None else lr_init
+        self._warmup_steps = warmup_steps
+        self._max_steps = max_steps
+        self._ramp = ramp
+        super().__init__(optimizer, last_epoch)
+
+    @property
+    def max_steps(self):
+        return self._max_steps
+
+    @max_steps.setter
+    def max_steps(self, value: int):
+        self._max_steps = value
+
+    def get_lr(self) -> list[float]:
+        step = self.last_epoch + 1
+        if step < self._warmup_steps:
+            if self._ramp == "cosine":
+                lr = self._lr_pre_warmup + (self._lr_init - self._lr_pre_warmup) * np.sin(
+                    0.5 * np.pi * np.clip(step / self._warmup_steps, 0, 1)
+                )
+            else:
+                lr = self._lr_pre_warmup + (self._lr_init - self._lr_pre_warmup) * step / self._warmup_steps
+        else:
+            t = np.clip((step - self._warmup_steps) / (self._max_steps - self._warmup_steps), 0, 1)
+            lr = np.exp(np.log(self._lr_init) * (1 - t) + np.log(self._lr_final) * t)
+
+        return [lr] * len(self.base_lrs)

--- a/fvdb_reality_capture/instance_segmentation/optim.py
+++ b/fvdb_reality_capture/instance_segmentation/optim.py
@@ -65,7 +65,8 @@ class ExponentialLRWithRampUpScheduler(LRScheduler):
             else:
                 lr = self._lr_pre_warmup + (self._lr_init - self._lr_pre_warmup) * step / self._warmup_steps
         else:
-            t = np.clip((step - self._warmup_steps) / (self._max_steps - self._warmup_steps), 0, 1)
+            denom = max(self._max_steps - self._warmup_steps, 1)
+            t = np.clip((step - self._warmup_steps) / denom, 0, 1)
             lr = np.exp(np.log(self._lr_init) * (1 - t) + np.log(self._lr_final) * t)
 
         return [lr] * len(self.base_lrs)

--- a/fvdb_reality_capture/instance_segmentation/scene_attribute.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_attribute.py
@@ -103,7 +103,8 @@ class GARfVDBMaskAttribute(SceneAttribute):
                 f"Unsupported GARfVDB mask schema_version {data.get('schema_version')!r} in {path}; "
                 f"expected {GARFVDB_MASK_DATA_SCHEMA_VERSION}."
             )
-        required = {"scales", "pixel_to_mask_id", "mask_cdf"}
+        # mask_cdf is not stored on disk; it is recomputed from pixel_to_mask_id at load time by the dataset.
+        required = {"scales", "pixel_to_mask_id"}
         missing = required.difference(data)
         if missing:
             raise ValueError(f"GARfVDB mask artifact {path} is missing fields: {sorted(missing)}")
@@ -112,7 +113,6 @@ class GARfVDBMaskAttribute(SceneAttribute):
         return {
             "scales": data["scales"],
             "pixel_to_mask_id": data["pixel_to_mask_id"],
-            "mask_cdf": data["mask_cdf"],
         }
 
     def state_dict(self) -> dict[str, Any]:

--- a/fvdb_reality_capture/instance_segmentation/scene_attribute.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_attribute.py
@@ -1,0 +1,143 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scene attribute containing GARfVDB mask-supervision artifacts."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import numpy as np
+import torch
+
+from fvdb_reality_capture.sfm_scene import SceneAttribute, scene_attribute
+
+GARFVDB_MASK_ATTRIBUTE_NAME = "garfvdb_masks"
+GARFVDB_MASK_ATTRIBUTE_SCHEMA_VERSION = 1
+GARFVDB_MASK_DATA_SCHEMA_VERSION = 1
+
+
+@scene_attribute
+class GARfVDBMaskAttribute(SceneAttribute):
+    """Per-image GARfVDB supervision produced by a mask-generation transform.
+
+    The attribute owns one path per image. Each file stores the mask IDs, mask
+    sampling CDF, and scene-unit grouping scales needed by GARfVDB training.
+    Other segmentation methods can attach their own attribute types and data
+    contracts without depending on this GARfVDB-specific representation.
+    """
+
+    def __init__(self, paths: list[str | pathlib.Path], provenance: dict[str, Any] | None = None) -> None:
+        self._paths = [str(pathlib.Path(path).absolute()) for path in paths]
+        self._provenance = dict(provenance or {})
+
+    @property
+    def paths(self) -> list[str]:
+        """Return a copy of the ordered per-image artifact paths."""
+        return list(self._paths)
+
+    @property
+    def provenance(self) -> dict[str, Any]:
+        """Return generation metadata such as the carrier hash and SAM2 settings."""
+        return dict(self._provenance)
+
+    @staticmethod
+    def type_name() -> str:
+        return "GARfVDBMaskAttribute"
+
+    def validate(self, attr_name: str, num_points: int, num_images: int, camera_ids: set[int]) -> None:
+        if len(self._paths) != num_images:
+            raise ValueError(
+                f"Attribute {attr_name!r} has {len(self._paths)} mask artifacts but the scene has {num_images} images."
+            )
+
+    def on_filter_images(self, mask: np.ndarray) -> "GARfVDBMaskAttribute":
+        return GARfVDBMaskAttribute(
+            [path for path, keep in zip(self._paths, mask) if keep],
+            provenance=self._provenance,
+        )
+
+    def on_select_images(self, indices: np.ndarray) -> "GARfVDBMaskAttribute":
+        return GARfVDBMaskAttribute(
+            [self._paths[int(index)] for index in indices],
+            provenance=self._provenance,
+        )
+
+    def on_downsample_images(
+        self,
+        attr_name: str,
+        downsample_factor: int,
+        output_cache: Any,
+    ) -> "GARfVDBMaskAttribute":
+        raise ValueError(
+            f"Cannot downsample images after generating {attr_name!r}. "
+            "Place GARfVDB mask generation after all image transforms."
+        )
+
+    def on_crop_scene(self, attr_name: str, bbox: np.ndarray, output_cache: Any) -> "GARfVDBMaskAttribute":
+        raise ValueError(
+            f"Cannot crop the scene after generating {attr_name!r}. "
+            "Place GARfVDB mask generation after all crop transforms."
+        )
+
+    def on_spatial_transform(self, matrix: np.ndarray) -> "GARfVDBMaskAttribute":
+        raise ValueError(
+            "Cannot spatially transform a scene after generating GARfVDB masks because their scales are in scene "
+            "units. Place GARfVDB mask generation after scene alignment and normalization."
+        )
+
+    def load(self, index: int) -> dict[str, torch.Tensor]:
+        """Load and validate the GARfVDB mask data for one scene image."""
+        try:
+            path = pathlib.Path(self._paths[index])
+        except IndexError as exc:
+            raise IndexError(f"GARfVDB mask index {index} is out of range for {len(self._paths)} images") from exc
+        if not path.is_file():
+            raise FileNotFoundError(f"GARfVDB mask artifact does not exist: {path}")
+        data = torch.load(path, map_location="cpu", weights_only=False)
+        if not isinstance(data, dict):
+            raise ValueError(f"GARfVDB mask artifact must contain a dictionary: {path}")
+        if data.get("schema_version") != GARFVDB_MASK_DATA_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported GARfVDB mask schema_version {data.get('schema_version')!r} in {path}; "
+                f"expected {GARFVDB_MASK_DATA_SCHEMA_VERSION}."
+            )
+        required = {"scales", "pixel_to_mask_id", "mask_cdf"}
+        missing = required.difference(data)
+        if missing:
+            raise ValueError(f"GARfVDB mask artifact {path} is missing fields: {sorted(missing)}")
+        if any(not isinstance(data[key], torch.Tensor) for key in required):
+            raise TypeError(f"GARfVDB mask artifact fields must be tensors: {path}")
+        return {
+            "scales": data["scales"],
+            "pixel_to_mask_id": data["pixel_to_mask_id"],
+            "mask_cdf": data["mask_cdf"],
+        }
+
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": GARFVDB_MASK_ATTRIBUTE_SCHEMA_VERSION,
+            "paths": self._paths,
+            "provenance": self._provenance,
+        }
+
+    @staticmethod
+    def from_state_dict(state_dict: dict[str, Any]) -> "GARfVDBMaskAttribute":
+        if state_dict.get("schema_version") != GARFVDB_MASK_ATTRIBUTE_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported GARfVDBMaskAttribute schema_version {state_dict.get('schema_version')!r}; "
+                f"expected {GARFVDB_MASK_ATTRIBUTE_SCHEMA_VERSION}."
+            )
+        return GARfVDBMaskAttribute(
+            paths=state_dict["paths"],
+            provenance=state_dict.get("provenance", {}),
+        )
+
+
+__all__ = [
+    "GARFVDB_MASK_ATTRIBUTE_NAME",
+    "GARFVDB_MASK_ATTRIBUTE_SCHEMA_VERSION",
+    "GARFVDB_MASK_DATA_SCHEMA_VERSION",
+    "GARfVDBMaskAttribute",
+]

--- a/fvdb_reality_capture/instance_segmentation/scene_attribute.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_attribute.py
@@ -95,7 +95,7 @@ class GARfVDBMaskAttribute(SceneAttribute):
             raise IndexError(f"GARfVDB mask index {index} is out of range for {len(self._paths)} images") from exc
         if not path.is_file():
             raise FileNotFoundError(f"GARfVDB mask artifact does not exist: {path}")
-        data = torch.load(path, map_location="cpu", weights_only=False)
+        data = torch.load(path, map_location="cpu", weights_only=True)
         if not isinstance(data, dict):
             raise ValueError(f"GARfVDB mask artifact must contain a dictionary: {path}")
         if data.get("schema_version") != GARFVDB_MASK_DATA_SCHEMA_VERSION:

--- a/fvdb_reality_capture/instance_segmentation/scene_attribute.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_attribute.py
@@ -39,7 +39,7 @@ class GARfVDBMaskAttribute(SceneAttribute):
 
     @property
     def provenance(self) -> dict[str, Any]:
-        """Return generation metadata such as the carrier hash and SAM2 settings."""
+        """Return generation metadata such as the Gaussian means hash and SAM2 settings."""
         return dict(self._provenance)
 
     @staticmethod

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/__init__.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from .image_segmentation_masks import GenerateGARfVDBMasks
+
+__all__ = ["GenerateGARfVDBMasks"]

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/__init__.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from .image_segmentation_masks import GenerateGARfVDBMasks
+from .reconstruction_camera_poses import ApplyReconstructionCameraPoses
 
-__all__ = ["GenerateGARfVDBMasks"]
+__all__ = ["ApplyReconstructionCameraPoses", "GenerateGARfVDBMasks"]

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -10,7 +10,8 @@ import cv2
 import numpy as np
 import torch
 import tqdm
-from fvdb import CameraModel, GaussianSplat3d
+from fvdb_reality_capture.enums import CameraModel
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 
 from fvdb_reality_capture.foundation_models import SAM2Model
 from fvdb_reality_capture.sfm_scene import SfmCache, SfmScene

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -1,0 +1,518 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import hashlib
+import logging
+from typing import Any, Literal
+
+import cv2
+import numpy as np
+import torch
+import tqdm
+from fvdb import CameraModel, GaussianSplat3d
+from fvdb_reality_capture.foundation_models import SAM2Model
+from fvdb_reality_capture.sfm_scene import SfmCache, SfmScene
+from fvdb_reality_capture.transforms import BaseTransform, transform
+
+from ..scene_attribute import (
+    GARFVDB_MASK_ATTRIBUTE_NAME,
+    GARFVDB_MASK_DATA_SCHEMA_VERSION,
+    GARfVDBMaskAttribute,
+)
+
+
+@transform
+class GenerateGARfVDBMasks(BaseTransform):
+    """
+    A transform that uses SAM2 to compute segmentation masks for each image.
+    """
+
+    version = "1.0.0"
+
+    def __init__(
+        self,
+        gs3d: GaussianSplat3d | None = None,
+        checkpoint: Literal["large", "small", "tiny", "base_plus"] = "large",
+        points_per_side=40,
+        pred_iou_thresh=0.80,
+        stability_score_thresh=0.80,
+        device: torch.device | str = "cuda",
+        gs3d_hash: str | None = None,
+    ):
+        """Create a transform that uses SAM2 to compute segmentation masks with scale information for each image.
+
+        Args:
+            gs3d (GaussianSplat3d | None): The GaussianSplat3d model to use for computing scales.
+                If None, the transform can only be used with precomputed cached results (requires gs3d_hash).
+            checkpoint (Literal["large", "small", "tiny", "base_plus"]): The checkpoint to use for the SAM2 model.
+            points_per_side (int): The number of points to use per side for the segmentation mask.
+            pred_iou_thresh (float): The IoU threshold for the segmentation mask.
+            stability_score_thresh (float): The stability score threshold for the segmentation mask.
+            device (torch.device | str): The device to use for the SAM2 model.
+            gs3d_hash (str | None): Precomputed hash of gs3d.means for cache lookup.
+                If provided, this is used instead of computing from gs3d. Useful when restoring
+                from state_dict with precomputed cached results.
+        """
+        self._checkpoint = checkpoint
+        self._gs3d = gs3d
+        self._image_type = "pt"
+        self._points_per_side = points_per_side
+        self._pred_iou_thresh = pred_iou_thresh
+        self._stability_score_thresh = stability_score_thresh
+        self._device = device
+        self._gs3d_hash = gs3d_hash
+
+        # Only initialize SAM2 model if gs3d is provided (needed for computation)
+        self._sam2: SAM2Model | None = None
+        if gs3d is not None:
+            self._sam2 = SAM2Model(
+                checkpoint=checkpoint,
+                points_per_side=points_per_side,
+                pred_iou_thresh=pred_iou_thresh,
+                stability_score_thresh=stability_score_thresh,
+                device=device,
+            )
+
+        self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
+
+    @staticmethod
+    def _smallest_int_dtype(values: torch.Tensor) -> torch.dtype:
+        """Return the smallest signed integer dtype that can hold values in [min_val, max_val]."""
+        min_val, max_val = int(values.min().item()), int(values.max().item())
+        if min_val >= -128 and max_val <= 127:
+            return torch.int8
+        elif min_val >= -32768 and max_val <= 32767:
+            return torch.int16
+        elif min_val >= -2147483648 and max_val <= 2147483647:
+            return torch.int32
+        else:
+            return torch.int64
+
+    @staticmethod
+    def rle_encode(tensor: torch.Tensor) -> dict[str, Any]:
+        flat = tensor.flatten()
+        # Find where values change
+        changes = torch.where(flat[1:] != flat[:-1])[0] + 1
+        starts = torch.cat([torch.tensor([0]), changes])
+        lengths = torch.diff(torch.cat([starts, torch.tensor([len(flat)])])).to(torch.int32)
+        values = flat[starts]
+
+        if values.dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+            # Use smallest dtype that can represent the values
+            optimal_dtype = GenerateGARfVDBMasks._smallest_int_dtype(values)
+            values = values.to(optimal_dtype)
+
+        return {
+            "values": values,
+            "lengths": lengths.to(GenerateGARfVDBMasks._smallest_int_dtype(lengths)),
+            "shape": tensor.shape,
+            "dtype": tensor.dtype,
+        }
+
+    @staticmethod
+    def rle_decode(encoded: dict[str, Any]) -> torch.Tensor:
+        lengths = encoded["lengths"]
+        if lengths.dtype in [torch.int8, torch.int16]:
+            lengths = lengths.to(torch.int32)
+        flat = torch.repeat_interleave(encoded["values"], lengths)
+        if flat.dtype in [torch.int8, torch.int16]:
+            flat = flat.to(torch.int32)
+        return flat.reshape(encoded["shape"])  # .to(encoded["dtype"])
+
+    def __call__(
+        self,
+        input_scene: SfmScene,
+    ) -> SfmScene:
+        """
+        Perform the compute image segmentation masks transform on the input scene and cache.
+
+        Args:
+            input_scene (SfmScene): The input scene containing images to be used to compute segmentation masks.
+
+        Returns:
+            output_scene (SfmScene): A new SfmScene with paths to computed segmentation masks.
+        """
+
+        # input validation
+        if len(input_scene.images) == 0:
+            self._logger.warning("No images found in the SfmScene. Returning the input scene unchanged.")
+            return input_scene
+        if len(input_scene.cameras) == 0:
+            self._logger.warning("No cameras found in the SfmScene. Returning the input scene unchanged.")
+            return input_scene
+        non_pinhole_cameras = [
+            camera_id
+            for camera_id, camera in input_scene.cameras.items()
+            if camera.camera_model != CameraModel.PINHOLE or camera.distortion_coeffs.size != 0
+        ]
+        if non_pinhole_cameras:
+            raise ValueError(
+                "GenerateGARfVDBMasks requires an undistorted pinhole SfmScene. "
+                "Apply UndistortImages before generating masks. "
+                f"Non-pinhole camera IDs: {non_pinhole_cameras}"
+            )
+
+        input_cache: SfmCache = input_scene.cache
+
+        # hash of the transform parameters
+        # TODO: In PyTorch 2.9 we can use torch.hash_tensor instead
+        if self._gs3d_hash is not None:
+            # Use precomputed hash (e.g., from state_dict restoration)
+            hash_str = self._gs3d_hash
+        elif self._gs3d is not None:
+            hash_str = hashlib.sha256(self._gs3d.means.detach().cpu().contiguous().numpy().tobytes()).hexdigest()
+            self._gs3d_hash = hash_str  # Cache for state_dict
+        else:
+            raise RuntimeError(
+                "Cannot compute cache hash: neither gs3d nor gs3d_hash was provided. "
+                "Provide either a GaussianSplat3d model or restore from a state_dict that includes gs3d_hash."
+            )
+
+        cache_prefix = (
+            f"garfvdb_masks_v{GARFVDB_MASK_DATA_SCHEMA_VERSION}_{hash_str}_p{self._points_per_side}_"
+            f"i{int(self._pred_iou_thresh * 100)}_s{int(self._stability_score_thresh * 100)}"
+        )
+        output_cache = input_cache.make_folder(
+            cache_prefix,
+            description=f"Segmentation masks with scales using points per side {self._points_per_side}, pred iou threshold {self._pred_iou_thresh}, and stability score threshold {self._stability_score_thresh}",
+        )
+
+        self._logger.info(
+            f"Calculating segmentation masks with scales using points per side {self._points_per_side}, "
+            f"pred iou threshold {self._pred_iou_thresh}, "
+            f"and stability score threshold {self._stability_score_thresh}"
+        )
+
+        self._logger.info(f"Attempting to load segmentation masks with scales from cache.")
+        # How many zeros to pad the image index in the mask file names
+        num_zeropad = len(str(len(input_scene.images))) + 2
+
+        regenerate_cache = False
+
+        if output_cache.num_files != input_scene.num_images:
+            if output_cache.num_files == 0:
+                self._logger.info(f"No segmentation masks found in the cache.")
+            else:
+                self._logger.info(
+                    f"Inconsistent number of segmentation masks in the cache. "
+                    f"Expected {input_scene.num_images}, found {output_cache.num_files}. "
+                    f"Clearing cache and regenerating segmentation masks."
+                )
+            output_cache.clear_current_folder()
+            regenerate_cache = True
+
+        mask_paths: list[str] = []
+        for image_id in range(input_scene.num_images):
+            if regenerate_cache:
+                break
+            cache_image_filename = f"masks_{image_id:0{num_zeropad}}"
+            image_meta = input_scene.images[image_id]
+            if not output_cache.has_file(cache_image_filename):
+                self._logger.info(
+                    f"Masks {cache_image_filename} not found in the cache. " f"Clearing cache and regenerating."
+                )
+                output_cache.clear_current_folder()
+                regenerate_cache = True
+                break
+
+            cache_file_meta = output_cache.get_file_metadata(cache_image_filename)
+            mask_paths.append(str(cache_file_meta["path"]))
+            value_meta = cache_file_meta["metadata"]
+            points_per_side = value_meta.get("points_per_side", -1)
+            pred_iou_thresh = value_meta.get("pred_iou_thresh", -1)
+            stability_score_thresh = value_meta.get("stability_score_thresh", -1)
+            gs3d_hash = value_meta.get("gs3d_hash", -1)
+
+            if (
+                cache_file_meta.get("data_type", "") != self._image_type
+                or points_per_side != self._points_per_side
+                or pred_iou_thresh != self._pred_iou_thresh
+                or stability_score_thresh != self._stability_score_thresh
+                or gs3d_hash != hash_str
+            ):
+                self._logger.info(
+                    f"Output cache mask metadata does not match expected format. "
+                    f"Clearing the cache and regenerating masks."
+                )
+                output_cache.clear_current_folder()
+                regenerate_cache = True
+                break
+
+        if regenerate_cache:
+            if self._gs3d is None or self._sam2 is None:
+                raise RuntimeError(
+                    "Cannot regenerate segmentation masks: gs3d was not provided. "
+                    "Either provide a GaussianSplat3d when creating the transform, "
+                    "or ensure the cache already contains valid precomputed results."
+                )
+            min = self._gs3d.means.min(dim=0)[0]
+            max = self._gs3d.means.max(dim=0)[0]
+            gs3d_extents = torch.abs(max - min)
+            max_scale = gs3d_extents.max().item()
+
+            self._logger.info(f"Generating segmentation masks with scales and saving to cache.")
+            pbar = tqdm.tqdm(input_scene.images, unit="masks", desc="Generating segmentation masks with scales")
+            mask_paths = []
+            for image_index, image_meta in enumerate(pbar):
+                image_path = image_meta.image_path
+                img = cv2.imread(image_path)
+                assert img is not None, f"Failed to load image {image_path}"
+
+                scales, pixel_to_mask_id, mask_cdf = self._generate_segmentation_mask(
+                    self._gs3d,
+                    img,
+                    image_meta.camera_metadata.projection_matrix,
+                    image_meta.world_to_camera_matrix,
+                    max_scale,
+                )
+
+                # Save the rescaled image to the cache
+                cache_image_filename = f"masks_{image_index:0{num_zeropad}}"
+                cache_file_meta = output_cache.write_file(
+                    name=cache_image_filename,
+                    data={
+                        "schema_version": GARFVDB_MASK_DATA_SCHEMA_VERSION,
+                        "scales": scales.detach().cpu(),
+                        "pixel_to_mask_id": pixel_to_mask_id.to(self._smallest_int_dtype(pixel_to_mask_id))
+                        .detach()
+                        .cpu(),
+                        "mask_cdf": mask_cdf.detach().cpu(),
+                    },
+                    data_type=self._image_type,
+                    metadata={
+                        "points_per_side": self._points_per_side,
+                        "pred_iou_thresh": self._pred_iou_thresh,
+                        "stability_score_thresh": self._stability_score_thresh,
+                        "gs3d_hash": hash_str,
+                    },
+                )
+                mask_paths.append(str(cache_file_meta["path"]))
+
+            pbar.close()
+
+            self._logger.info(f"Generated segmentation masks for {input_scene.num_images} images and saved to cache")
+
+        return input_scene.with_attributes(
+            **{
+                GARFVDB_MASK_ATTRIBUTE_NAME: GARfVDBMaskAttribute(
+                    paths=mask_paths,
+                    provenance={
+                        "generator": self.name(),
+                        "generator_version": self.version,
+                        "checkpoint": self._checkpoint,
+                        "points_per_side": self._points_per_side,
+                        "pred_iou_thresh": self._pred_iou_thresh,
+                        "stability_score_thresh": self._stability_score_thresh,
+                        "carrier_means_sha256": hash_str,
+                    },
+                )
+            }
+        )
+
+    @torch.inference_mode()
+    def _generate_segmentation_mask(
+        self,
+        gs3d: GaussianSplat3d,
+        img: np.ndarray,
+        projection_matrix: np.ndarray,
+        world_to_camera_matrix: np.ndarray,
+        max_scale: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Generate all the segmentation masks and correlated scale information for the given image using SAM2.
+
+        Args:
+            gs3d: GaussianSplat3d object containing the 3D model.
+            img: Image to generate segmentation masks for.
+            projection_matrix: Projection matrix for the image.
+            world_to_camera_matrix: World to camera matrix for the image.
+            max_scale: Maximum scale for the segmentation mask.
+
+        Returns:
+            scales: Scales for the segmentation masks.
+            pixel_to_mask_id: Pixel to mask id mapping.
+            mask_cdf: Mask CDF for the segmentation masks.
+        """
+        img = img.squeeze()  # [H, W, 3]
+        h, w = img.shape[:2]
+        intrinsics = torch.from_numpy(projection_matrix).to(self._device).squeeze()
+        world_to_cam = torch.from_numpy(world_to_camera_matrix).to(self._device).squeeze()
+
+        g_ids, _ = gs3d.render_contributing_gaussian_ids(
+            top_k_contributors=1,
+            world_to_camera_matrices=world_to_cam.unsqueeze(0).float(),
+            projection_matrices=intrinsics.unsqueeze(0).float(),
+            image_width=img.shape[1],
+            image_height=img.shape[0],
+            near=0.01,
+            far=1e10,
+        )
+        # The JaggedTensor has h*w entries, but some may be empty (pixels with no contributing gaussians).
+        # We need to create a full tensor with -1 for empty entries.
+        num_pixels = h * w
+        offsets = g_ids.joffsets  # [h*w + 1]
+
+        # Create output tensor initialized with -1 (no gaussian)
+        g_ids_full = torch.full((num_pixels,), -1, dtype=g_ids.jdata.dtype, device=g_ids.jdata.device)
+
+        # Find which pixels have data (where the entry has length > 0)
+        has_data = offsets[1:] > offsets[:-1]  # [h*w] bool tensor
+
+        # Fill in the values where we have data
+        if g_ids.jdata.numel() > 0:
+            g_ids_full[has_data] = g_ids.jdata.view(-1)
+
+        g_ids = g_ids_full.reshape(h, w, 1)  # [H, W, 1]
+
+        self._logger.debug("g_ids.shape " + str(g_ids.shape))
+        if g_ids.max() >= gs3d.means.shape[0]:
+            self._logger.debug("g_ids.max() " + str(g_ids.max()))
+            self._logger.debug("model.means.shape[0] " + str(gs3d.means.shape[0]))
+            raise ValueError("g_ids.max() is greater than gs3d.means.shape[0]")
+
+        invalid_mask = g_ids == -1
+        if invalid_mask.any():
+            self._logger.debug("Found %d invalid (-1) ids" % (invalid_mask.sum().item()))
+
+        world_pts = gs3d.means[g_ids].squeeze(2)  # [H, W, 3]
+
+        # Generate a set of masks for the current image using SAM2
+        assert self._sam2 is not None  # Guaranteed by check in __call__
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            sam_masks = self._sam2.predict_masks(img)
+            sam_masks = sorted(sam_masks, key=(lambda x: x["area"]), reverse=True)
+            sam_masks = torch.stack([torch.from_numpy(m["segmentation"]) for m in sam_masks]).to(
+                self._device
+            )  # [M, H, W]
+        # Erode masks to remove noise at the boundary.
+        # We're going to compute the scale of each mask by taking the standard deviation of the 3D points
+        # within that mask, and the points at the boundary of masks are usually noisy.
+        eroded_masks = torch.conv2d(
+            sam_masks.unsqueeze(1).float(),
+            torch.full((3, 3), 1.0, device=self._device).view(1, 1, 3, 3),
+            padding=1,
+        )
+        eroded_masks = (eroded_masks >= 5).squeeze(1)  # [M, H, W]
+
+        # mask out any pixels with invalid gaussian ids in the sam_masks
+        eroded_masks = eroded_masks * (~invalid_mask.squeeze().unsqueeze(0))
+
+        # Compute a 3D scale per mask which corresponds to the variance of the 3D points that fall within that mask
+        # Filter out masks whose scale is too large since very scattered 3D points are likely noise
+        self._logger.debug("world_pts " + str(world_pts.shape))
+        self._logger.debug("scale " + str(world_pts[eroded_masks[1]].std(dim=0) * 2.0))
+        scales = torch.stack([world_pts[mask].unique(dim=0).std(dim=0).norm() for mask in eroded_masks])  # [M]
+        keep = scales < max_scale  # [M]
+        eroded_masks = eroded_masks[keep]  # [M', H, W]
+        scales = scales[keep]  # [M']
+
+        # Compute a tensor that maps pixels to the set of masks which intersect that pixel (sorted by area)
+        # i.e. pixel_to_mask_id[i, j] = [m1, m2, m3, ...] where m1, m2, ... are the integer ids of the masks
+        # which contain pixel [i, j] and area(m1) <= area(m2) <= area(m3) <= ...
+        max_masks = int(eroded_masks.sum(dim=0).max().item())
+        pixel_to_mask_id = torch.full(
+            (max_masks, eroded_masks.shape[1], eroded_masks.shape[2]), -1, dtype=torch.long, device=self._device
+        )  # [MM, H, W]
+        for m, mask in enumerate(eroded_masks):
+            mask_clone = mask.clone()
+            for i in range(max_masks):
+                free = pixel_to_mask_id[i] == -1
+                masked_area = mask_clone == 1
+                right_index = free & masked_area
+                if len(pixel_to_mask_id[i][right_index]) > 0:
+                    pixel_to_mask_id[i][right_index] = m
+                mask_clone[right_index] = 0
+        pixel_to_mask_id = pixel_to_mask_id.permute(1, 2, 0)  # [H, W, MM]
+
+        # We're going to use the SAM masks to group pixels for contrastive learning.
+        # i.e. we're going to project features for each pixel into the image and push features corresponding to pixels
+        #      with the same mask together, and pixels with different masks apart.
+        # If we sample pixels, uniformly, we're going to overwhelmingly sample pixels in large masks, and small masks
+        # will not get supervised. To fix this, we assign a weight to each mask which intersects a pixel. The weight
+        # is proportional to the log probability of sampling that mask (under uniform sampling).
+        # These weights are encoded as a CDF per-pixel which we use to choose which mask to use for loss computation
+        # at training time
+
+        # Get the unique ids of each mask, and the number of pixels each mask occupies (area)
+        mask_ids, num_pix_per_mask = torch.unique(pixel_to_mask_id, return_counts=True)  # [N], [N]
+
+        # Sort masks by their area
+        mask_area_sort_ids = torch.argsort(num_pix_per_mask)
+        mask_ids, num_pix_per_mask = mask_ids[mask_area_sort_ids], num_pix_per_mask[mask_area_sort_ids]  # [N], [N]
+        num_pix_per_mask[0] = 0  # Remove the -1 mask which corresponds to no mask, [N]
+
+        # The probability of any pixel landing in a mask is just the area of the mask over the area of the image
+        probs = num_pix_per_mask / num_pix_per_mask.sum()  # [N]
+
+        # Gather the probability values into pixel_to_mask_id, which produces a tensor where
+        # each pixel has a list of probabilities that correspond to the masks that intersect that pixel
+        mask_probs = torch.gather(probs, 0, pixel_to_mask_id.reshape(-1) + 1).view(pixel_to_mask_id.shape)  # [H, W, MM]
+
+        # Compute a CDF for each pixel (which sums to 1) which weighs each mask by its log probability of being sampled
+        # i.e. mask_cdf[i, j, k] is a cumulative probability weight used to select mask k for pixel [i, j]
+        mask_cdf = torch.log(mask_probs)
+        never_masked = mask_cdf.isinf()
+        mask_cdf[never_masked] = 0.0
+        mask_cdf = mask_cdf / (mask_cdf.sum(dim=-1, keepdim=True) + 1e-6)
+        mask_cdf = torch.cumsum(mask_cdf, dim=-1)  # [H, W, MM]
+        mask_cdf[never_masked] = 1.0
+
+        return scales, pixel_to_mask_id, mask_cdf
+
+    @staticmethod
+    def name() -> str:
+        """
+        Return the name of the GenerateGARfVDBMasks transform.
+
+        Returns:
+            str: The name of the GenerateGARfVDBMasks transform.
+        """
+        return "GenerateGARfVDBMasks"
+
+    def state_dict(self) -> dict[str, Any]:
+        """
+        Return the state of the GenerateGARfVDBMasks transform for serialization.
+        Returns:
+            state_dict (dict[str, Any]): A dictionary containing information to serialize/deserialize the transform.
+        """
+        return {
+            "name": self.name(),
+            "version": self.version,
+            "checkpoint": self._checkpoint,
+            "points_per_side": self._points_per_side,
+            "pred_iou_thresh": self._pred_iou_thresh,
+            "stability_score_thresh": self._stability_score_thresh,
+            "device": self._device,
+            "gs3d_hash": self._gs3d_hash,
+        }
+
+    @staticmethod
+    def from_state_dict(state_dict: dict[str, Any]) -> "GenerateGARfVDBMasks":
+        """
+        Create a GenerateGARfVDBMasks transform from a state dictionary.
+
+        When restored from state_dict, the transform does not have gs3d or the SAM2 model loaded.
+        It can only be used with scenes that have precomputed cached results. The gs3d_hash
+        stored in the state_dict is used to locate the correct cache folder.
+
+        Args:
+            state_dict (dict[str, Any]): A dictionary containing information to serialize/deserialize the transform.
+
+        Returns:
+            GenerateGARfVDBMasks: A restored transform instance.
+        """
+        if state_dict["name"] != "GenerateGARfVDBMasks":
+            raise ValueError(f"Expected state_dict with name 'GenerateGARfVDBMasks', got {state_dict['name']} instead.")
+        if state_dict["version"] != GenerateGARfVDBMasks.version:
+            raise ValueError(
+                f"Expected state_dict with version '{GenerateGARfVDBMasks.version}', got {state_dict['version']} instead."
+            )
+
+        return GenerateGARfVDBMasks(
+            gs3d=None,  # Not needed for cached results
+            checkpoint=state_dict["checkpoint"],
+            points_per_side=state_dict["points_per_side"],
+            pred_iou_thresh=state_dict["pred_iou_thresh"],
+            stability_score_thresh=state_dict["stability_score_thresh"],
+            device=state_dict["device"],
+            gs3d_hash=state_dict.get("gs3d_hash"),  # Use stored hash for cache lookup
+        )

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -39,7 +39,7 @@ class GenerateGARfVDBMasks(BaseTransform):
         points_per_batch=128,
         pred_iou_thresh=0.80,
         stability_score_thresh=0.80,
-        device: torch.device | str = "cuda",
+        device: torch.device | str = "cuda:0",
         gs3d_hash: str | None = None,
     ):
         """Create a transform that uses SAM2 to compute segmentation masks with scale information for each image.

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -334,7 +334,7 @@ class GenerateGARfVDBMasks(BaseTransform):
                         "points_per_side": self._points_per_side,
                         "pred_iou_thresh": self._pred_iou_thresh,
                         "stability_score_thresh": self._stability_score_thresh,
-                        "carrier_means_sha256": hash_str,
+                        "gaussian_means_sha256": hash_str,
                     },
                 )
             }

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -99,6 +99,23 @@ class GenerateGARfVDBMasks(BaseTransform):
             return torch.int64
 
     @staticmethod
+    def _camera_parameters_sha256(scene: SfmScene) -> str:
+        """Hash ordered camera poses, intrinsics, image sizes, and stable image IDs."""
+        digest = hashlib.sha256()
+        arrays = (
+            scene.camera_to_world_matrices,
+            scene.projection_matrices,
+            scene.image_sizes,
+            np.asarray([image.image_id for image in scene.images], dtype=np.int64),
+        )
+        for values in arrays:
+            array = np.ascontiguousarray(values)
+            digest.update(str(array.dtype).encode("ascii"))
+            digest.update(np.asarray(array.shape, dtype=np.int64).tobytes())
+            digest.update(array.tobytes())
+        return digest.hexdigest()
+
+    @staticmethod
     def rle_encode(tensor: torch.Tensor) -> dict[str, Any]:
         flat = tensor.flatten()
         # Find where values change
@@ -177,10 +194,12 @@ class GenerateGARfVDBMasks(BaseTransform):
                 "Cannot compute cache hash: neither gs3d nor gs3d_hash was provided. "
                 "Provide either a GaussianSplat3d model or restore from a state_dict that includes gs3d_hash."
             )
+        camera_parameters_hash = self._camera_parameters_sha256(input_scene)
 
         cache_prefix = (
             f"garfvdb_masks_v{GARFVDB_MASK_DATA_SCHEMA_VERSION}_{hash_str}_p{self._points_per_side}_"
-            f"i{int(self._pred_iou_thresh * 100)}_s{int(self._stability_score_thresh * 100)}"
+            f"i{int(self._pred_iou_thresh * 100)}_s{int(self._stability_score_thresh * 100)}_"
+            f"c{camera_parameters_hash}"
         )
         output_cache = input_cache.make_folder(
             cache_prefix,
@@ -232,6 +251,7 @@ class GenerateGARfVDBMasks(BaseTransform):
             pred_iou_thresh = value_meta.get("pred_iou_thresh", -1)
             stability_score_thresh = value_meta.get("stability_score_thresh", -1)
             gs3d_hash = value_meta.get("gs3d_hash", -1)
+            cached_camera_parameters_hash = value_meta.get("camera_parameters_sha256", "")
 
             if (
                 cache_file_meta.get("data_type", "") != self._image_type
@@ -239,6 +259,7 @@ class GenerateGARfVDBMasks(BaseTransform):
                 or pred_iou_thresh != self._pred_iou_thresh
                 or stability_score_thresh != self._stability_score_thresh
                 or gs3d_hash != hash_str
+                or cached_camera_parameters_hash != camera_parameters_hash
             ):
                 self._logger.info(
                     f"Output cache mask metadata does not match expected format. "
@@ -278,6 +299,7 @@ class GenerateGARfVDBMasks(BaseTransform):
                     "pred_iou_thresh": self._pred_iou_thresh,
                     "stability_score_thresh": self._stability_score_thresh,
                     "gs3d_hash": hash_str,
+                    "camera_parameters_sha256": camera_parameters_hash,
                 }
                 write_futures.append(
                     writer.submit(
@@ -336,6 +358,7 @@ class GenerateGARfVDBMasks(BaseTransform):
                         "pred_iou_thresh": self._pred_iou_thresh,
                         "stability_score_thresh": self._stability_score_thresh,
                         "gaussian_means_sha256": hash_str,
+                        "camera_parameters_sha256": camera_parameters_hash,
                     },
                 )
             }

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -294,6 +294,7 @@ class GenerateGARfVDBMasks(BaseTransform):
                     image_path = image_meta.image_path
                     img = cv2.imread(image_path)
                     assert img is not None, f"Failed to load image {image_path}"
+                    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
                     scales, pixel_to_mask_id = self._generate_segmentation_mask(
                         self._gs3d,
@@ -339,6 +340,16 @@ class GenerateGARfVDBMasks(BaseTransform):
                 )
             }
         )
+
+    @staticmethod
+    def _erode_masks(masks: torch.Tensor) -> torch.Tensor:
+        """Erode binary masks by one pixel using a 3x3 square structuring element."""
+        neighborhood_counts = torch.conv2d(
+            masks.unsqueeze(1).float(),
+            torch.ones((1, 1, 3, 3), dtype=torch.float32, device=masks.device),
+            padding=1,
+        )
+        return (neighborhood_counts == 9).squeeze(1)
 
     @torch.inference_mode()
     def _generate_segmentation_mask(
@@ -416,12 +427,7 @@ class GenerateGARfVDBMasks(BaseTransform):
         # Erode masks to remove noise at the boundary.
         # We're going to compute the scale of each mask by taking the standard deviation of the 3D points
         # within that mask, and the points at the boundary of masks are usually noisy.
-        eroded_masks = torch.conv2d(
-            sam_masks.unsqueeze(1).float(),
-            torch.full((3, 3), 1.0, device=self._device).view(1, 1, 3, 3),
-            padding=1,
-        )
-        eroded_masks = (eroded_masks >= 5).squeeze(1)  # [M, H, W]
+        eroded_masks = self._erode_masks(sam_masks)  # [M, H, W]
 
         # mask out any pixels with invalid gaussian ids in the sam_masks
         eroded_masks = eroded_masks * (~invalid_mask.squeeze().unsqueeze(0))

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -3,6 +3,7 @@
 #
 import hashlib
 import logging
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Literal
 
 import cv2
@@ -10,6 +11,7 @@ import numpy as np
 import torch
 import tqdm
 from fvdb import CameraModel, GaussianSplat3d
+
 from fvdb_reality_capture.foundation_models import SAM2Model
 from fvdb_reality_capture.sfm_scene import SfmCache, SfmScene
 from fvdb_reality_capture.transforms import BaseTransform, transform
@@ -34,6 +36,7 @@ class GenerateGARfVDBMasks(BaseTransform):
         gs3d: GaussianSplat3d | None = None,
         checkpoint: Literal["large", "small", "tiny", "base_plus"] = "large",
         points_per_side=40,
+        points_per_batch=128,
         pred_iou_thresh=0.80,
         stability_score_thresh=0.80,
         device: torch.device | str = "cuda",
@@ -46,6 +49,10 @@ class GenerateGARfVDBMasks(BaseTransform):
                 If None, the transform can only be used with precomputed cached results (requires gs3d_hash).
             checkpoint (Literal["large", "small", "tiny", "base_plus"]): The checkpoint to use for the SAM2 model.
             points_per_side (int): The number of points to use per side for the segmentation mask.
+            points_per_batch (int): The number of point prompts run through the SAM2 mask decoder per
+                forward pass. Higher values reduce the number of decoder invocations (faster mask
+                generation) at the cost of more GPU memory. Does not affect the generated masks, so it
+                is not part of the cache key.
             pred_iou_thresh (float): The IoU threshold for the segmentation mask.
             stability_score_thresh (float): The stability score threshold for the segmentation mask.
             device (torch.device | str): The device to use for the SAM2 model.
@@ -57,6 +64,7 @@ class GenerateGARfVDBMasks(BaseTransform):
         self._gs3d = gs3d
         self._image_type = "pt"
         self._points_per_side = points_per_side
+        self._points_per_batch = points_per_batch
         self._pred_iou_thresh = pred_iou_thresh
         self._stability_score_thresh = stability_score_thresh
         self._device = device
@@ -68,6 +76,7 @@ class GenerateGARfVDBMasks(BaseTransform):
             self._sam2 = SAM2Model(
                 checkpoint=checkpoint,
                 points_per_side=points_per_side,
+                points_per_batch=points_per_batch,
                 pred_iou_thresh=pred_iou_thresh,
                 stability_score_thresh=stability_score_thresh,
                 device=device,
@@ -252,41 +261,62 @@ class GenerateGARfVDBMasks(BaseTransform):
 
             self._logger.info(f"Generating segmentation masks with scales and saving to cache.")
             pbar = tqdm.tqdm(input_scene.images, unit="masks", desc="Generating segmentation masks with scales")
-            mask_paths = []
-            for image_index, image_meta in enumerate(pbar):
-                image_path = image_meta.image_path
-                img = cv2.imread(image_path)
-                assert img is not None, f"Failed to load image {image_path}"
 
-                scales, pixel_to_mask_id, mask_cdf = self._generate_segmentation_mask(
-                    self._gs3d,
-                    img,
-                    image_meta.camera_metadata.projection_matrix,
-                    image_meta.world_to_camera_matrix,
-                    max_scale,
+            # Cache writes are disk-bound (~1 s/img) while mask generation is GPU-bound (~2.7 s/img), so we
+            # hand each write off to a single background thread. That overlaps an image's write with the next
+            # image's SAM2 forward pass instead of blocking on it. The GPU->CPU copies happen here on the main
+            # thread so the worker only touches CPU tensors and the disk. A single worker keeps writes ordered
+            # and avoids concurrent sqlite/disk contention; since writes are faster than SAM2 the queue stays
+            # shallow. Futures are resolved in order below to build mask_paths and surface any write errors.
+            write_futures: list[Future[str]] = []
+            writer = ThreadPoolExecutor(max_workers=1, thread_name_prefix="garfvdb-mask-writer")
+
+            def _submit_write(name: str, data: dict[str, Any]) -> None:
+                metadata = {
+                    "points_per_side": self._points_per_side,
+                    "pred_iou_thresh": self._pred_iou_thresh,
+                    "stability_score_thresh": self._stability_score_thresh,
+                    "gs3d_hash": hash_str,
+                }
+                write_futures.append(
+                    writer.submit(
+                        lambda: str(
+                            output_cache.write_file(
+                                name=name, data=data, data_type=self._image_type, metadata=metadata
+                            )["path"]
+                        )
+                    )
                 )
 
-                # Save the rescaled image to the cache
-                cache_image_filename = f"masks_{image_index:0{num_zeropad}}"
-                cache_file_meta = output_cache.write_file(
-                    name=cache_image_filename,
-                    data={
+            try:
+                for image_index, image_meta in enumerate(pbar):
+                    image_path = image_meta.image_path
+                    img = cv2.imread(image_path)
+                    assert img is not None, f"Failed to load image {image_path}"
+
+                    scales, pixel_to_mask_id = self._generate_segmentation_mask(
+                        self._gs3d,
+                        img,
+                        image_meta.camera_metadata.projection_matrix,
+                        image_meta.world_to_camera_matrix,
+                        max_scale,
+                    )
+
+                    # Copy to CPU on the main thread, then hand the disk write to the background thread.
+                    cache_image_filename = f"masks_{image_index:0{num_zeropad}}"
+                    data = {
                         "schema_version": GARFVDB_MASK_DATA_SCHEMA_VERSION,
                         "scales": scales.detach().cpu(),
                         "pixel_to_mask_id": pixel_to_mask_id.to(self._smallest_int_dtype(pixel_to_mask_id))
                         .detach()
                         .cpu(),
-                        "mask_cdf": mask_cdf.detach().cpu(),
-                    },
-                    data_type=self._image_type,
-                    metadata={
-                        "points_per_side": self._points_per_side,
-                        "pred_iou_thresh": self._pred_iou_thresh,
-                        "stability_score_thresh": self._stability_score_thresh,
-                        "gs3d_hash": hash_str,
-                    },
-                )
-                mask_paths.append(str(cache_file_meta["path"]))
+                    }
+                    _submit_write(cache_image_filename, data)
+
+                # Drain the background writer, preserving image order for mask_paths and surfacing errors.
+                mask_paths = [future.result() for future in write_futures]
+            finally:
+                writer.shutdown(wait=True)
 
             pbar.close()
 
@@ -317,7 +347,7 @@ class GenerateGARfVDBMasks(BaseTransform):
         projection_matrix: np.ndarray,
         world_to_camera_matrix: np.ndarray,
         max_scale: float,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Generate all the segmentation masks and correlated scale information for the given image using SAM2.
 
         Args:
@@ -329,8 +359,9 @@ class GenerateGARfVDBMasks(BaseTransform):
 
         Returns:
             scales: Scales for the segmentation masks.
-            pixel_to_mask_id: Pixel to mask id mapping.
-            mask_cdf: Mask CDF for the segmentation masks.
+            pixel_to_mask_id: Pixel to mask id mapping. The per-pixel mask-selection CDF is not
+                returned or cached; it is recomputed from this tensor at load time via
+                ``compute_mask_cdf`` since it is fully derived from the mask areas.
         """
         img = img.squeeze()  # [H, W, 3]
         h, w = img.shape[:2]
@@ -373,8 +404,6 @@ class GenerateGARfVDBMasks(BaseTransform):
         if invalid_mask.any():
             self._logger.debug("Found %d invalid (-1) ids" % (invalid_mask.sum().item()))
 
-        world_pts = gs3d.means[g_ids].squeeze(2)  # [H, W, 3]
-
         # Generate a set of masks for the current image using SAM2
         assert self._sam2 is not None  # Guaranteed by check in __call__
         with torch.autocast("cuda", dtype=torch.bfloat16):
@@ -397,10 +426,12 @@ class GenerateGARfVDBMasks(BaseTransform):
         eroded_masks = eroded_masks * (~invalid_mask.squeeze().unsqueeze(0))
 
         # Compute a 3D scale per mask which corresponds to the variance of the 3D points that fall within that mask
-        # Filter out masks whose scale is too large since very scattered 3D points are likely noise
-        self._logger.debug("world_pts " + str(world_pts.shape))
-        self._logger.debug("scale " + str(world_pts[eroded_masks[1]].std(dim=0) * 2.0))
-        scales = torch.stack([world_pts[mask].unique(dim=0).std(dim=0).norm() for mask in eroded_masks])  # [M]
+        # Filter out masks whose scale is too large since very scattered 3D points are likely noise.
+        # Multiple pixels in a mask can hit the same gaussian, so we deduplicate before taking the std. We
+        # deduplicate on the (integer) gaussian id rather than the (float3) world point, which is both cheaper
+        # and equivalent as long as distinct gaussians have distinct means.
+        g_ids_2d = g_ids.squeeze(-1)  # [H, W]
+        scales = torch.stack([gs3d.means[g_ids_2d[mask].unique()].std(dim=0).norm() for mask in eroded_masks])  # [M]
         keep = scales < max_scale  # [M]
         eroded_masks = eroded_masks[keep]  # [M', H, W]
         scales = scales[keep]  # [M']
@@ -408,55 +439,26 @@ class GenerateGARfVDBMasks(BaseTransform):
         # Compute a tensor that maps pixels to the set of masks which intersect that pixel (sorted by area)
         # i.e. pixel_to_mask_id[i, j] = [m1, m2, m3, ...] where m1, m2, ... are the integer ids of the masks
         # which contain pixel [i, j] and area(m1) <= area(m2) <= area(m3) <= ...
-        max_masks = int(eroded_masks.sum(dim=0).max().item())
+        num_masks, mask_h, mask_w = eroded_masks.shape
+        max_masks = int(eroded_masks.sum(dim=0).max().item()) if num_masks > 0 else 0
         pixel_to_mask_id = torch.full(
-            (max_masks, eroded_masks.shape[1], eroded_masks.shape[2]), -1, dtype=torch.long, device=self._device
+            (max_masks, mask_h, mask_w), -1, dtype=torch.long, device=self._device
         )  # [MM, H, W]
-        for m, mask in enumerate(eroded_masks):
-            mask_clone = mask.clone()
-            for i in range(max_masks):
-                free = pixel_to_mask_id[i] == -1
-                masked_area = mask_clone == 1
-                right_index = free & masked_area
-                if len(pixel_to_mask_id[i][right_index]) > 0:
-                    pixel_to_mask_id[i][right_index] = m
-                mask_clone[right_index] = 0
+        # For each pixel, the masks covering it are packed into slots 0, 1, 2, ... in order of increasing
+        # mask index (i.e. decreasing area, since sam_masks are area-sorted). The slot a mask occupies at a
+        # covered pixel is the number of lower-indexed masks that also cover that pixel, which is exactly the
+        # (exclusive) prefix sum over masks. This replaces the O(M * max_masks) Python loop (which also forced
+        # a device sync per iteration) with a single cumsum + scatter.
+        if num_masks > 0 and max_masks > 0:
+            slot = torch.cumsum(eroded_masks.to(torch.long), dim=0) - 1  # [M, H, W]
+            m_index, row, col = torch.where(eroded_masks)  # covered (mask, y, x) triples
+            pixel_to_mask_id[slot[m_index, row, col], row, col] = m_index
         pixel_to_mask_id = pixel_to_mask_id.permute(1, 2, 0)  # [H, W, MM]
 
-        # We're going to use the SAM masks to group pixels for contrastive learning.
-        # i.e. we're going to project features for each pixel into the image and push features corresponding to pixels
-        #      with the same mask together, and pixels with different masks apart.
-        # If we sample pixels, uniformly, we're going to overwhelmingly sample pixels in large masks, and small masks
-        # will not get supervised. To fix this, we assign a weight to each mask which intersects a pixel. The weight
-        # is proportional to the log probability of sampling that mask (under uniform sampling).
-        # These weights are encoded as a CDF per-pixel which we use to choose which mask to use for loss computation
-        # at training time
-
-        # Get the unique ids of each mask, and the number of pixels each mask occupies (area)
-        mask_ids, num_pix_per_mask = torch.unique(pixel_to_mask_id, return_counts=True)  # [N], [N]
-
-        # Sort masks by their area
-        mask_area_sort_ids = torch.argsort(num_pix_per_mask)
-        mask_ids, num_pix_per_mask = mask_ids[mask_area_sort_ids], num_pix_per_mask[mask_area_sort_ids]  # [N], [N]
-        num_pix_per_mask[0] = 0  # Remove the -1 mask which corresponds to no mask, [N]
-
-        # The probability of any pixel landing in a mask is just the area of the mask over the area of the image
-        probs = num_pix_per_mask / num_pix_per_mask.sum()  # [N]
-
-        # Gather the probability values into pixel_to_mask_id, which produces a tensor where
-        # each pixel has a list of probabilities that correspond to the masks that intersect that pixel
-        mask_probs = torch.gather(probs, 0, pixel_to_mask_id.reshape(-1) + 1).view(pixel_to_mask_id.shape)  # [H, W, MM]
-
-        # Compute a CDF for each pixel (which sums to 1) which weighs each mask by its log probability of being sampled
-        # i.e. mask_cdf[i, j, k] is a cumulative probability weight used to select mask k for pixel [i, j]
-        mask_cdf = torch.log(mask_probs)
-        never_masked = mask_cdf.isinf()
-        mask_cdf[never_masked] = 0.0
-        mask_cdf = mask_cdf / (mask_cdf.sum(dim=-1, keepdim=True) + 1e-6)
-        mask_cdf = torch.cumsum(mask_cdf, dim=-1)  # [H, W, MM]
-        mask_cdf[never_masked] = 1.0
-
-        return scales, pixel_to_mask_id, mask_cdf
+        # The per-pixel mask-selection CDF (used to weight masks for contrastive learning so small masks
+        # aren't drowned out by large ones) is fully derived from pixel_to_mask_id, so we do NOT compute or
+        # cache it here.
+        return scales, pixel_to_mask_id
 
     @staticmethod
     def name() -> str:
@@ -479,6 +481,7 @@ class GenerateGARfVDBMasks(BaseTransform):
             "version": self.version,
             "checkpoint": self._checkpoint,
             "points_per_side": self._points_per_side,
+            "points_per_batch": self._points_per_batch,
             "pred_iou_thresh": self._pred_iou_thresh,
             "stability_score_thresh": self._stability_score_thresh,
             "device": self._device,
@@ -511,6 +514,7 @@ class GenerateGARfVDBMasks(BaseTransform):
             gs3d=None,  # Not needed for cached results
             checkpoint=state_dict["checkpoint"],
             points_per_side=state_dict["points_per_side"],
+            points_per_batch=state_dict.get("points_per_batch", 128),
             pred_iou_thresh=state_dict["pred_iou_thresh"],
             stability_score_thresh=state_dict["stability_score_thresh"],
             device=state_dict["device"],

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/image_segmentation_masks.py
@@ -468,7 +468,7 @@ class GenerateGARfVDBMasks(BaseTransform):
 
         # Compute a tensor that maps pixels to the set of masks which intersect that pixel (sorted by area)
         # i.e. pixel_to_mask_id[i, j] = [m1, m2, m3, ...] where m1, m2, ... are the integer ids of the masks
-        # which contain pixel [i, j] and area(m1) <= area(m2) <= area(m3) <= ...
+        # which contain pixel [i, j] and area(m1) >= area(m2) >= area(m3) >= ...
         num_masks, mask_h, mask_w = eroded_masks.shape
         max_masks = int(eroded_masks.sum(dim=0).max().item()) if num_masks > 0 else 0
         pixel_to_mask_id = torch.full(

--- a/fvdb_reality_capture/instance_segmentation/scene_transforms/reconstruction_camera_poses.py
+++ b/fvdb_reality_capture/instance_segmentation/scene_transforms/reconstruction_camera_poses.py
@@ -1,0 +1,133 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Apply camera poses saved by a Gaussian reconstruction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+from fvdb_reality_capture.sfm_scene import SfmPosedImageMetadata, SfmScene
+from fvdb_reality_capture.transforms import BaseTransform, transform
+
+
+@transform
+class ApplyReconstructionCameraPoses(BaseTransform):
+    """Replace scene camera poses with the final poses used by a reconstruction."""
+
+    version = "1.0.0"
+
+    def __init__(
+        self,
+        camera_to_world_matrices: np.ndarray | torch.Tensor,
+        image_ids: np.ndarray | torch.Tensor | None = None,
+    ) -> None:
+        if isinstance(camera_to_world_matrices, torch.Tensor):
+            camera_to_world_matrices = camera_to_world_matrices.detach().cpu().numpy()
+        matrices = np.asarray(camera_to_world_matrices)
+        if matrices.ndim != 3 or matrices.shape[1:] != (4, 4):
+            raise ValueError(
+                "Reconstruction camera_to_world_matrices must have shape " f"(num_images, 4, 4), got {matrices.shape}."
+            )
+        if not np.isfinite(matrices).all():
+            raise ValueError("Reconstruction camera_to_world_matrices must contain only finite values.")
+        try:
+            np.linalg.inv(matrices)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError("Reconstruction camera_to_world_matrices must be invertible.") from exc
+        self._camera_to_world_matrices = matrices.copy()
+
+        if isinstance(image_ids, torch.Tensor):
+            image_ids = image_ids.detach().cpu().numpy()
+        if image_ids is None:
+            self._image_ids = None
+        else:
+            image_ids_array = np.asarray(image_ids)
+            if image_ids_array.ndim != 1 or len(image_ids_array) != len(matrices):
+                raise ValueError(
+                    "Reconstruction image_ids must have shape " f"({len(matrices)},), got {image_ids_array.shape}."
+                )
+            image_ids_array = image_ids_array.astype(np.int64, copy=False)
+            if len(np.unique(image_ids_array)) != len(image_ids_array):
+                raise ValueError("Reconstruction image_ids must be unique.")
+            self._image_ids = image_ids_array.copy()
+
+    def __call__(self, input_scene: SfmScene) -> SfmScene:
+        if self._image_ids is None:
+            if len(self._camera_to_world_matrices) != input_scene.num_images:
+                raise ValueError(
+                    "Reconstruction metadata does not contain image_ids, so camera poses can only be matched "
+                    "positionally when the reconstruction and transformed scene have the same number of images. "
+                    f"Reconstruction has {len(self._camera_to_world_matrices)} poses; "
+                    f"scene has {input_scene.num_images} images."
+                )
+            poses_by_scene_index = dict(enumerate(self._camera_to_world_matrices))
+            poses_by_image_id = None
+        else:
+            poses_by_scene_index = None
+            poses_by_image_id = dict(zip(self._image_ids.tolist(), self._camera_to_world_matrices))
+
+        updated_images = []
+        num_matched = 0
+        for scene_index, image in enumerate(input_scene.images):
+            if poses_by_scene_index is not None:
+                camera_to_world = poses_by_scene_index[scene_index]
+            else:
+                assert poses_by_image_id is not None
+                camera_to_world = poses_by_image_id.get(image.image_id)
+                if camera_to_world is None:
+                    updated_images.append(image)
+                    continue
+
+            num_matched += 1
+            updated_images.append(
+                SfmPosedImageMetadata(
+                    world_to_camera_matrix=np.linalg.inv(camera_to_world),
+                    camera_to_world_matrix=camera_to_world.copy(),
+                    camera_metadata=image.camera_metadata,
+                    camera_id=image.camera_id,
+                    image_path=image.image_path,
+                    mask_path=image.mask_path,
+                    point_indices=image.point_indices,
+                    image_id=image.image_id,
+                )
+            )
+
+        if num_matched == 0 and input_scene.num_images > 0:
+            raise ValueError("None of the reconstruction camera poses match the transformed scene image IDs.")
+        return input_scene.replace(images=updated_images)
+
+    @staticmethod
+    def name() -> str:
+        return "ApplyReconstructionCameraPoses"
+
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name(),
+            "version": self.version,
+            "camera_to_world_matrices": self._camera_to_world_matrices,
+            "image_ids": self._image_ids,
+        }
+
+    @staticmethod
+    def from_state_dict(state_dict: dict[str, Any]) -> "ApplyReconstructionCameraPoses":
+        if state_dict.get("name") != ApplyReconstructionCameraPoses.name():
+            raise ValueError(
+                f"Expected state_dict with name {ApplyReconstructionCameraPoses.name()!r}, "
+                f"got {state_dict.get('name')!r}."
+            )
+        if state_dict.get("version") != ApplyReconstructionCameraPoses.version:
+            raise ValueError(
+                f"Unsupported {ApplyReconstructionCameraPoses.name()} version {state_dict.get('version')!r}; "
+                f"expected {ApplyReconstructionCameraPoses.version!r}."
+            )
+        return ApplyReconstructionCameraPoses(
+            camera_to_world_matrices=state_dict["camera_to_world_matrices"],
+            image_ids=state_dict.get("image_ids"),
+        )
+
+
+__all__ = ["ApplyReconstructionCameraPoses"]

--- a/fvdb_reality_capture/instance_segmentation/training/__init__.py
+++ b/fvdb_reality_capture/instance_segmentation/training/__init__.py
@@ -1,0 +1,4 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+__all__: list[str] = []

--- a/fvdb_reality_capture/instance_segmentation/training/dataset.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset.py
@@ -8,11 +8,13 @@ import fvdb
 import numpy as np
 import torch
 import torch.cuda.nvtx as nvtx
-from fvdb_reality_capture.radiance_fields import SfmDataset
+
 from fvdb_reality_capture.instance_segmentation.scene_attribute import (
     GARFVDB_MASK_ATTRIBUTE_NAME,
     GARfVDBMaskAttribute,
 )
+from fvdb_reality_capture.instance_segmentation.util import compute_mask_cdf
+from fvdb_reality_capture.radiance_fields import SfmDataset
 from fvdb_reality_capture.sfm_scene import SfmScene
 
 
@@ -137,8 +139,9 @@ class SegmentationDataset(SfmDataset):
         # which are smaller (by about 2x) but are slower to decode on disk and would certainly
         # require caching to be performant.
         with nvtx.range("get_mask_data_decode"):
-            mask_cdf = data["mask_cdf"]
             mask_ids = data["pixel_to_mask_id"]
+            # mask_cdf is derived from pixel_to_mask_id and is not stored in the cache; compute it.
+            mask_cdf = compute_mask_cdf(mask_ids)
             # Using pixel_to_mask_id as indices, torch requires the indices to be at least int32.
             if mask_ids.dtype in [torch.int8, torch.int16]:
                 mask_ids = mask_ids.to(torch.int32)

--- a/fvdb_reality_capture/instance_segmentation/training/dataset.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, NotRequired, Sequence, Sized, TypedDict, cast, overload
+from typing import Any, Literal, NotRequired, Sequence, Sized, TypedDict, cast, overload
 
 import fvdb
 import numpy as np
@@ -289,7 +289,7 @@ class InfiniteSampler(torch.utils.data.Sampler):
         )
 
 
-class GARfVDBInput(dict[str, torch.Tensor | fvdb.JaggedTensor | list[int] | None]):
+class GARfVDBInput(dict[str, Any]):
     @overload
     def __getitem__(self, key: Literal["image_w"]) -> list[int]: ...
     @overload

--- a/fvdb_reality_capture/instance_segmentation/training/dataset.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset.py
@@ -1,0 +1,395 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from typing import Literal, NotRequired, Sequence, Sized, TypedDict, cast, overload
+
+import fvdb
+import numpy as np
+import torch
+import torch.cuda.nvtx as nvtx
+from fvdb_reality_capture.radiance_fields import SfmDataset
+from fvdb_reality_capture.instance_segmentation.scene_attribute import (
+    GARFVDB_MASK_ATTRIBUTE_NAME,
+    GARfVDBMaskAttribute,
+)
+from fvdb_reality_capture.sfm_scene import SfmScene
+
+
+class SegmentationDataItem(TypedDict):
+    """Type definition for a single item in the SegmentationDataset.
+
+    Attributes:
+        image: RGB image tensor of shape ``[H, W, 3]`` or ``[num_samples, 3]``.
+        projection: Camera projection matrix of shape ``[3, 3]``.
+        camera_to_world: Camera-to-world transformation of shape ``[4, 4]``.
+        world_to_camera: World-to-camera transformation of shape ``[4, 4]``.
+        scales: Per-mask scale values of shape ``[num_masks]``.
+        mask_cdf: Cumulative distribution for mask selection, shape ``[H, W, max_masks]``.
+        mask_ids: Per-pixel mask IDs of shape ``[H, W, max_masks]``, where -1 indicates
+            no mask.
+        image_h: Image height in pixels.
+        image_w: Image width in pixels.
+        image_full: Optional full-resolution image before pixel sampling.
+        pixel_coords: Optional sampled pixel coordinates of shape ``[num_samples, 2]``.
+    """
+
+    image: torch.Tensor
+    projection: torch.Tensor
+    camera_to_world: torch.Tensor
+    world_to_camera: torch.Tensor
+    scales: torch.Tensor
+    mask_cdf: torch.Tensor
+    mask_ids: torch.Tensor
+    image_h: int
+    image_w: int
+    image_full: NotRequired[torch.Tensor]
+    pixel_coords: NotRequired[torch.Tensor]
+
+
+class SegmentationDataset(SfmDataset):
+    """Dataset for loading segmentation training data from an SfmScene.
+
+    Extends SfmDataset to also load pre-computed segmentation masks and scale
+    information. The loaded data includes images, camera parameters, and mask
+    data that can be further processed by transforms.
+    """
+
+    def __init__(
+        self,
+        sfm_scene: SfmScene,
+        dataset_indices: Sequence[int] | np.ndarray | torch.Tensor | None = None,
+        cache_loaded_masks: bool = True,
+        cache_images: bool = True,
+        mask_attribute_name: str = GARFVDB_MASK_ATTRIBUTE_NAME,
+    ):
+        """
+        Args:
+            sfm_scene: The SfmScene containing images and camera data.
+            dataset_indices: Optional indices to subset the dataset.
+            cache_loaded_masks: If True, cache loaded mask data in memory to avoid
+                repeated decoding. This significantly speeds up data loading at the cost
+                of additional RAM usage. Default is True.
+            cache_images: If True, cache decoded/undistorted images in memory. This
+                eliminates repeated JPEG/PNG decoding and undistortion, which is
+                especially beneficial for small datasets with large images. Default is True.
+            mask_attribute_name: Name of the :class:`GARfVDBMaskAttribute` attached
+                to ``sfm_scene``.
+        """
+        super().__init__(sfm_scene, dataset_indices)
+        if not sfm_scene.has_attribute(mask_attribute_name):
+            raise ValueError(
+                f"SfmScene does not contain GARfVDB mask attribute {mask_attribute_name!r}. "
+                "Run GenerateGARfVDBMasks after the standard scene transforms."
+            )
+        mask_attribute = sfm_scene.get_attribute(mask_attribute_name)
+        if not isinstance(mask_attribute, GARfVDBMaskAttribute):
+            raise TypeError(
+                f"Scene attribute {mask_attribute_name!r} must be GARfVDBMaskAttribute, "
+                f"got {type(mask_attribute).__name__}."
+            )
+        self._mask_attribute = mask_attribute
+        self._cache_loaded_masks = cache_loaded_masks
+        self._cache_images = cache_images
+        self._loaded_masks_cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+        self._loaded_images_cache: dict[int, dict] = {}  # Cache for SfmDataset items (includes decoded image)
+
+    def warmup_cache(self) -> None:
+        """Pre-load all mask and image data into cache.
+
+        Call this BEFORE creating a DataLoader with num_workers > 0.
+        When workers are forked, they inherit the populated cache, eliminating
+        disk I/O and image decoding during training.
+        """
+        import tqdm
+
+        with nvtx.range("warmup_cache"):
+            # Cache masks
+            if self._cache_loaded_masks:
+                for idx in tqdm.tqdm(range(len(self)), desc="Warming up mask cache"):
+                    index = self._indices[idx]
+                    if index not in self._loaded_masks_cache:
+                        self._get_mask_data(index)
+
+            # Cache images (decoded and undistorted)
+            if self._cache_images:
+                for idx in tqdm.tqdm(range(len(self)), desc="Warming up image cache"):
+                    index = self._indices[idx]
+                    if index not in self._loaded_images_cache:
+                        # Call parent's __getitem__ to decode and undistort the image
+                        sfm_item = super().__getitem__(idx)
+                        self._loaded_images_cache[index] = sfm_item
+
+    def _get_mask_data(self, index: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Get mask data for the given index, using cache if enabled.
+
+        Returns:
+            Tuple of (mask_cdf, mask_ids, scales) tensors.
+        """
+        with nvtx.range("get_mask_data_cache_check"):
+            if self._cache_loaded_masks and index in self._loaded_masks_cache:
+                return self._loaded_masks_cache[index]
+
+        # Read and decode from disk
+        with nvtx.range("get_mask_data_disk_read"):
+            data = self._mask_attribute.load(index)
+        # NOTE: One other strategy we investigated was to RLE-encode the mask_cdf and mask_ids,
+        # which are smaller (by about 2x) but are slower to decode on disk and would certainly
+        # require caching to be performant.
+        with nvtx.range("get_mask_data_decode"):
+            mask_cdf = data["mask_cdf"]
+            mask_ids = data["pixel_to_mask_id"]
+            # Using pixel_to_mask_id as indices, torch requires the indices to be at least int32.
+            if mask_ids.dtype in [torch.int8, torch.int16]:
+                mask_ids = mask_ids.to(torch.int32)
+
+            scales = data["scales"]
+
+        # Cache if enabled
+        if self._cache_loaded_masks:
+            self._loaded_masks_cache[index] = (mask_cdf, mask_ids, scales)
+
+        return mask_cdf, mask_ids, scales
+
+    def _get_sfm_item(self, idx: int) -> dict:
+        """Get SfmDataset item, using cache if enabled.
+
+        Returns:
+            Dictionary with image, projection, camera matrices, etc.
+        """
+        index = self._indices[idx]
+
+        if self._cache_images and index in self._loaded_images_cache:
+            return self._loaded_images_cache[index]
+
+        # Decode from disk (slow path)
+        sfm_item = super().__getitem__(idx)
+
+        # Cache if enabled
+        if self._cache_images:
+            self._loaded_images_cache[index] = sfm_item
+
+        return sfm_item
+
+    def __getitem__(self, idx: int) -> SegmentationDataItem:  # pyright: ignore[reportIncompatibleMethodOverride]
+        with nvtx.range("SegmentationDataset.__getitem__"):
+            with nvtx.range("sfm_dataset_getitem"):
+                sfm_item = self._get_sfm_item(idx)
+            index = self._indices[idx]
+
+            mask_cdf, mask_ids, scales = self._get_mask_data(index)
+
+            with nvtx.range("build_segmentation_data_item"):
+                return SegmentationDataItem(
+                    image=torch.from_numpy(sfm_item["image"]),
+                    projection=sfm_item["projection"],
+                    camera_to_world=sfm_item["camera_to_world"],
+                    world_to_camera=sfm_item["world_to_camera"],
+                    scales=scales,
+                    mask_cdf=mask_cdf,
+                    mask_ids=mask_ids,
+                    image_h=sfm_item["image"].shape[0],
+                    image_w=sfm_item["image"].shape[1],
+                )
+
+    @property
+    def scales(self) -> torch.Tensor:
+        scales = []
+        for index in self._indices:
+            # Use cache if available, otherwise read from disk
+            if self._cache_loaded_masks and index in self._loaded_masks_cache:
+                scales.append(self._loaded_masks_cache[index][2])  # scales is third element
+            else:
+                data = self._mask_attribute.load(int(index))
+                scales.append(data["scales"])
+        return torch.cat(scales)
+
+    @property
+    def camera_to_world_matrices(self) -> np.ndarray:
+        """
+        Get the camera to world matrices for all images in the dataset.
+
+        This returns the camera to world matrices as a numpy array of shape (N, 4, 4) where N is the number of images.
+
+        Returns:
+            np.ndarray: An Nx4x4 array of camera to world matrices for the cameras in the dataset.
+        """
+        return self.sfm_scene.camera_to_world_matrices[self._indices]
+
+    @property
+    def projection_matrices(self) -> np.ndarray:
+        """
+        Get the projection matrices mapping camera to pixel coordinates for all images in the dataset.
+
+        This returns the undistorted projection matrices as a numpy array of shape (N, 3, 3) where N is the number of images.
+
+        Returns:
+            np.ndarray: An Nx3x3 array of projection matrices for the cameras in the dataset.
+        """
+        # in fvdb_3dgs/training/sfm_dataset.py
+        return np.stack(
+            [self._sfm_scene.images[i].camera_metadata.projection_matrix for i in self._indices],
+            axis=0,
+        )
+
+    @property
+    def indices(self) -> np.ndarray:
+        """
+        Return the indices of the images in the SfmScene used in the dataset.
+
+        Returns:
+            np.ndarray: The indices of the images in the SfmScene used in the dataset.
+        """
+        return self._indices
+
+
+class InfiniteSampler(torch.utils.data.Sampler):
+    """Sampler that yields dataset indices infinitely without stopping.
+
+    Unlike standard samplers, this never raises StopIteration, allowing the
+    DataLoader iterator to run indefinitely. This avoids the performance
+    overhead of recreating the iterator between epochs. Epoch boundaries
+    must be tracked manually by counting samples processed.
+    """
+
+    def __init__(self, dataset: Sized, shuffle: bool = True, seed: int = 0):
+        self.dataset = dataset
+        self.shuffle = shuffle
+        self.seed = seed
+        self._epoch = 0
+
+    def __iter__(self):
+        while True:
+            if self.shuffle:
+                # Use epoch as part of seed for reproducibility across restarts
+                g = torch.Generator()
+                g.manual_seed(self.seed + self._epoch)
+                indices = torch.randperm(len(self.dataset), generator=g).tolist()
+            else:
+                indices = list(range(len(self.dataset)))
+
+            yield from indices
+            self._epoch += 1
+
+    def __len__(self):
+        """Length is undefined for InfiniteSampler.
+
+        This sampler yields indices indefinitely and does not define epoch
+        boundaries. Code must not rely on len(sampler) to determine the number
+        of steps per epoch; track epochs/steps explicitly instead.
+        """
+        raise NotImplementedError(
+            "InfiniteSampler does not define __len__; it yields indices infinitely. "
+            "Do not rely on len(sampler) for epoch length."
+        )
+
+
+class GARfVDBInput(dict[str, torch.Tensor | fvdb.JaggedTensor | list[int] | None]):
+    @overload
+    def __getitem__(self, key: Literal["image_w"]) -> list[int]: ...
+    @overload
+    def __getitem__(self, key: Literal["image_h"]) -> list[int]: ...
+    @overload
+    def __getitem__(
+        self,
+        key: Literal["image", "projection", "camera_to_world", "world_to_camera", "scales", "mask_ids", "mask_cdf"],
+    ) -> torch.Tensor: ...
+    @overload
+    def __getitem__(self, key: Literal["pixel_coords"]) -> torch.Tensor: ...
+    @overload
+    def __getitem__(self, key: str) -> torch.Tensor | fvdb.JaggedTensor | list[int] | None: ...
+
+    def __getitem__(self, key: str) -> torch.Tensor | fvdb.JaggedTensor | list[int] | None:  # type: ignore[override]
+        return super().__getitem__(key)
+
+    @overload
+    def get(self, key: Literal["pixel_coords"], default: None = None) -> torch.Tensor | None: ...
+    @overload
+    def get(
+        self, key: str, default: torch.Tensor | fvdb.JaggedTensor | list[int] | None = None
+    ) -> torch.Tensor | fvdb.JaggedTensor | list[int] | None: ...
+
+    def get(self, key: str, default: torch.Tensor | fvdb.JaggedTensor | list[int] | None = None) -> torch.Tensor | fvdb.JaggedTensor | list[int] | None:  # type: ignore[override]
+        return super().get(key, default)
+
+    def __repr__(self):
+        return f"GARfVDBInput({dict(self)!r})"
+
+    def to(self, device: torch.device, non_blocking: bool = True) -> "GARfVDBInput":
+        result = {}
+        for k, v in self.items():
+            if isinstance(v, torch.Tensor):
+                result[k] = v.to(device, non_blocking=non_blocking)
+            elif isinstance(v, fvdb.JaggedTensor):
+                # JaggedTensor.to() doesn't support non_blocking
+                result[k] = v.to(device)
+            else:
+                result[k] = v
+        return GARfVDBInput(result)
+
+
+def GARfVDBInputCollateFn(
+    batch: list[SegmentationDataItem],
+    collate_full_image: bool = False,
+    include_mask_cdf: bool = False,
+) -> GARfVDBInput:
+    """Collate SegmentationDataItems into a batched GARfVDBInput.
+
+    Args:
+        batch: List of SegmentationDataItems to collate.
+        collate_full_image: If True, also stack the full-resolution images.
+        include_mask_cdf: If True, include mask_cdf for GPU-based mask selection.
+            Set to True when using GPURandomSelectMaskIDAndScale.
+
+    Returns:
+        Batched input dictionary for the GARfVDB model.
+    """
+    with nvtx.range("GARfVDBInputCollateFn"):
+        with nvtx.range("collate_stack_tensors"):
+            kwargs: dict[str, torch.Tensor | fvdb.JaggedTensor | list[int] | None] = {
+                "image": torch.stack([cast(torch.Tensor, b["image"]) for b in batch]),
+                "projection": torch.stack([cast(torch.Tensor, b["projection"]) for b in batch]),
+                "camera_to_world": torch.stack([cast(torch.Tensor, b["camera_to_world"]) for b in batch]),
+                "world_to_camera": torch.stack([cast(torch.Tensor, b["world_to_camera"]) for b in batch]),
+                "image_h": [cast(int, b["image_h"]) for b in batch],
+                "image_w": [cast(int, b["image_w"]) for b in batch],
+            }
+
+        # mask_ids has shape [num_samples, MM] where MM (max masks per pixel) varies per image
+        # Pad to max MM in batch for GPU transform path, or stack directly for CPU path
+        if include_mask_cdf:
+            # Pad mask_ids and mask_cdf to max MM dimension
+            mask_ids_list = [cast(torch.Tensor, b["mask_ids"]) for b in batch]
+            mask_cdf_list = [cast(torch.Tensor, b["mask_cdf"]) for b in batch]
+            max_mm = max(m.shape[-1] for m in mask_ids_list)
+
+            # Pad mask_ids with -1 (invalid mask), mask_cdf with 1.0 (never selected)
+            padded_mask_ids = []
+            padded_mask_cdf = []
+            for mask_ids, mask_cdf in zip(mask_ids_list, mask_cdf_list):
+                mm = mask_ids.shape[-1]
+                if mm < max_mm:
+                    pad_size = max_mm - mm
+                    # Pad last dimension: (left, right) for 2D tensor's last dim
+                    mask_ids = torch.nn.functional.pad(mask_ids, (0, pad_size), value=-1)
+                    mask_cdf = torch.nn.functional.pad(mask_cdf, (0, pad_size), value=1.0)
+                padded_mask_ids.append(mask_ids)
+                padded_mask_cdf.append(mask_cdf)
+
+            kwargs["mask_ids"] = torch.stack(padded_mask_ids)
+            kwargs["mask_cdf"] = torch.stack(padded_mask_cdf)
+
+            # scales has variable length per image (different number of masks), use JaggedTensor
+            kwargs["scales"] = fvdb.JaggedTensor([cast(torch.Tensor, b["scales"]) for b in batch])
+        else:
+            # CPU transform path - transforms already applied, dimensions should be uniform
+            kwargs["mask_ids"] = torch.stack([cast(torch.Tensor, b["mask_ids"]) for b in batch])
+            kwargs["scales"] = torch.stack([cast(torch.Tensor, b["scales"]) for b in batch])
+
+        if "pixel_coords" in batch[0]:
+            kwargs["pixel_coords"] = torch.stack([cast(torch.Tensor, b.get("pixel_coords")) for b in batch])
+
+        if collate_full_image and "image_full" in batch[0]:
+            kwargs["image_full"] = torch.stack([cast(torch.Tensor, b.get("image_full")) for b in batch])
+
+        return GARfVDBInput(**kwargs)

--- a/fvdb_reality_capture/instance_segmentation/training/dataset.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from __future__ import annotations
+
 from typing import Literal, NotRequired, Sequence, Sized, TypedDict, cast, overload
 
 import fvdb

--- a/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
@@ -355,6 +355,8 @@ class Resize:
         Returns:
             Resized item with updated dimensions and scaled projection matrix.
         """
+        original_h, original_w = item["image"].shape[:2]
+
         # Resize image from [H, W, 3] to [H * scale, W * scale, 3]
         item["image"] = (
             F.interpolate(
@@ -365,14 +367,20 @@ class Resize:
             .permute(0, 2, 3, 1)
             .squeeze(0)
         )  # back to [H * scale, W * scale, 3]
+        resized_h, resized_w = item["image"].shape[:2]
 
-        # Update dimensions
-        item["image_h"] = int(item["image_h"] * self.scale)
-        item["image_w"] = int(item["image_w"] * self.scale)
+        # Interpolation rounds output dimensions to integers. Record the actual dimensions and use
+        # their independent x/y ratios when updating intrinsics.
+        item["image_h"] = resized_h
+        item["image_w"] = resized_w
 
-        # Resize masks similarly
+        # Resize masks to the exact image dimensions.
         item["mask_cdf"] = (
-            F.interpolate(item["mask_cdf"].unsqueeze(0).permute(0, 3, 1, 2), scale_factor=self.scale, mode="nearest")
+            F.interpolate(
+                item["mask_cdf"].unsqueeze(0).permute(0, 3, 1, 2),
+                size=[resized_h, resized_w],
+                mode="nearest",
+            )
             .permute(0, 2, 3, 1)
             .squeeze(0)
         )
@@ -387,16 +395,11 @@ class Resize:
             .squeeze(0)
         )
 
-        # scale intrinsics for new image size
-        fx = item["projection"][0, 0]
-        fy = item["projection"][1, 1]
-        cx = item["projection"][0, 2]
-        cy = item["projection"][1, 2]
-        # Intrinsics scale with the image size: downsampling by ``scale`` (e.g. 0.5) also scales fx/fy/cx/cy.
-        new_fx = fx * self.scale
-        new_fy = fy * self.scale
-        new_cx = cx * self.scale
-        new_cy = cy * self.scale
-        item["projection"] = torch.tensor([[new_fx, 0, new_cx], [0, new_fy, new_cy], [0, 0, 1]], dtype=torch.float32)
+        scale_x = resized_w / original_w
+        scale_y = resized_h / original_h
+        projection = item["projection"].clone()
+        projection[0, :] *= scale_x
+        projection[1, :] *= scale_y
+        item["projection"] = projection
 
         return item

--- a/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
@@ -1,0 +1,400 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+from typing import cast
+
+import numpy as np
+import torch
+import torch.cuda.nvtx as nvtx
+import torch.nn.functional as F
+import torchvision
+import torchvision.transforms.functional as TF
+from fvdb_reality_capture.instance_segmentation.training.dataset import (
+    GARfVDBInput,
+    SegmentationDataItem,
+    SegmentationDataset,
+)
+from torch.utils.data import Dataset
+
+
+class TransformedSegmentationDataset(Dataset):
+    """Wrapper dataset that applies transforms to a SegmentationDataset.
+
+    Applies torchvision-style transforms to each item returned by the base
+    dataset, enabling data augmentation and preprocessing pipelines.
+    """
+
+    def __init__(self, base_dataset: SegmentationDataset, transform=None) -> None:
+        self._base_dataset = base_dataset
+        self._transform = transform
+
+    def __getitem__(self, idx):
+        with nvtx.range("TransformedSegmentationDataset.__getitem__"):
+            item = self._base_dataset[idx]
+            if self._transform:
+                with nvtx.range("apply_transforms"):
+                    return self._transform(item)
+            return item
+
+    def __len__(self):
+        return len(self._base_dataset)
+
+    @property
+    def base_dataset(self) -> SegmentationDataset:
+        return self._base_dataset
+
+    @property
+    def indices(self) -> np.ndarray:
+        return self._base_dataset.indices
+
+    def warmup_cache(self) -> None:
+        """Pre-load all data into cache before DataLoader workers are spawned."""
+        self._base_dataset.warmup_cache()
+
+
+class RandomSelectMaskIDAndScale:
+    """Transform that randomly selects a mask ID and interpolates scale values.
+
+    For each pixel, randomly selects one of the overlapping masks based on the
+    mask CDF (which biases towards smaller masks) and interpolates the scale
+    value to create smooth transitions between hierarchical groupings.
+
+    Note: Consider using GPURandomSelectMaskIDAndScale for better performance
+    on large batches when data is already on GPU.
+    """
+
+    def __call__(self, item: SegmentationDataItem) -> SegmentationDataItem:
+        """Apply random mask selection and scale interpolation.
+
+        Args:
+            item: Input data item with multi-mask information per pixel.
+
+        Returns:
+            Modified item with single mask ID and interpolated scale per pixel.
+        """
+        with nvtx.range("RandomSelectMaskIDAndScale"):
+            per_pixel_index = item["mask_ids"]  # [H, W, MM] or [num_samples, MM]
+            random_vec_sampling = torch.full(per_pixel_index.shape[:-1], torch.rand((1,)).item()).unsqueeze(
+                -1
+            )  # [H, W, 1]
+            random_vec_densify = torch.full(
+                per_pixel_index.shape[:-1], torch.rand((1,)).item()
+            )  # [H, W] or [num_samples]
+
+            random_index = torch.sum(random_vec_sampling > item["mask_cdf"], dim=-1)  # [H, W] dtype: torch.int64
+
+            # `per_pixel_index` encodes the list of groups that each pixel belongs to.
+            # If there's only one group, then `per_pixel_index` is a 1D tensor
+            # -- this will mess up the future `gather` operations.
+            if per_pixel_index.shape[-1] == 1:
+                per_pixel_mask = per_pixel_index.squeeze()
+            else:
+                per_pixel_mask = torch.gather(
+                    per_pixel_index, -1, random_index.unsqueeze(-1)
+                ).squeeze()  # [H, W] dtype: torch.int64
+                # per_pixel_mask_ is a selection of the *previous* group in the list before the per_pixel_mask selection
+                per_pixel_mask_ = torch.gather(
+                    per_pixel_index,
+                    -1,
+                    torch.max(random_index.unsqueeze(-1) - 1, torch.Tensor([0]).int()),
+                ).squeeze()
+
+            scales = item["scales"]  # [NM] dtype: torch.float32
+            curr_scale = scales[per_pixel_mask]  # [H, W] dtype: torch.float32
+
+            # For pixels in the first group (random_index == 0), randomly scale down their scale value
+            # between 0 and the full scale. This creates a smooth transition from zero to the first group's scale,
+            # similar to how we interpolate between groups for other indices.
+            curr_scale[random_index == 0] = (
+                scales[per_pixel_mask][random_index == 0] * random_vec_densify[random_index == 0]
+            )
+            # For each group, interpolate between the previous group's scale and the current group's scale,
+            # based on the random_vec_densify value. This creates a smooth transition between groups.
+            for j in range(1, item["mask_cdf"].shape[-1]):
+                if (random_index == j).sum() == 0:
+                    continue
+                curr_scale[random_index == j] = (
+                    scales[per_pixel_mask_][random_index == j]  # type: ignore
+                    + (scales[per_pixel_mask][random_index == j] - scales[per_pixel_mask_][random_index == j])  # type: ignore
+                    * random_vec_densify[random_index == j]
+                ).squeeze()
+
+            item["scales"] = curr_scale  # [rays_per_image] dtype: torch.float32
+
+            item["mask_ids"] = per_pixel_mask  # [rays_per_image] dtype: torch.int64
+
+            return item
+
+
+class GPURandomSelectMaskIDAndScale:
+    """GPU-accelerated transform that randomly selects mask IDs and interpolates scales.
+
+    This is a batched, GPU-optimized version of RandomSelectMaskIDAndScale.
+    It operates on batched data that has already been transferred to GPU,
+    providing significant speedup for large batches.
+
+    The transform:
+    1. Randomly selects one mask per pixel based on the mask CDF
+    2. Interpolates scale values between hierarchical groupings for smooth transitions
+    """
+
+    def __call__(self, batch: GARfVDBInput) -> GARfVDBInput:
+        """Apply random mask selection and scale interpolation to a GPU batch.
+
+        Args:
+            batch: Batched input dictionary with keys:
+                - mask_ids: [B, num_samples, MM] - mask IDs per pixel
+                - mask_cdf: [B, num_samples, MM] - cumulative distribution for mask selection
+                - scales: JaggedTensor with B elements, each of shape [NM_i] - scale values per mask
+                  (variable number of masks per image)
+
+        Returns:
+            Modified batch with:
+                - mask_ids: [B, num_samples] - single selected mask ID per pixel
+                - scales: [B, num_samples] - interpolated scale per pixel
+        """
+        with nvtx.range("GPURandomSelectMaskIDAndScale"):
+            import fvdb
+
+            mask_ids = batch["mask_ids"]  # [B, num_samples, MM]
+            mask_cdf = batch["mask_cdf"]  # [B, num_samples, MM]
+            scales_jagged = batch["scales"]  # JaggedTensor: B tensors of varying length [NM_i]
+
+            # Handle both JaggedTensor and regular Tensor for backward compatibility
+            if isinstance(scales_jagged, fvdb.JaggedTensor):
+                scales_data = scales_jagged.jdata  # Flat tensor of all scales
+                scales_offsets = scales_jagged.joffsets  # [B+1] offsets into scales_data
+            else:
+                # Fallback for regular tensor (shouldn't happen with include_mask_cdf=True)
+                scales_data = scales_jagged.flatten()
+                B_scales = scales_jagged.shape[0]
+                NM = scales_jagged.shape[1]
+                scales_offsets = torch.arange(0, (B_scales + 1) * NM, NM, device=scales_jagged.device)
+
+            B, num_samples, MM = mask_ids.shape
+            device = mask_ids.device
+
+            # Generate random values - one per batch element (matching CPU behavior)
+            # Each image in batch gets same random value for all its pixels
+            random_sampling = torch.rand(B, 1, 1, device=device).expand(-1, num_samples, 1)  # [B, num_samples, 1]
+            random_densify = torch.rand(B, 1, device=device).expand(-1, num_samples)  # [B, num_samples]
+
+            # Select mask index based on CDF: count how many CDF values are less than random
+            random_index = torch.sum(random_sampling > mask_cdf, dim=-1)  # [B, num_samples]
+            # Clamp to valid range
+            random_index = torch.clamp(random_index, 0, MM - 1)
+
+            if MM == 1:
+                # Single mask case - just squeeze
+                per_pixel_mask = mask_ids.squeeze(-1)  # [B, num_samples]
+                per_pixel_mask_prev = per_pixel_mask  # Not used but needed for shape consistency
+            else:
+                # Gather the selected mask ID for each pixel
+                per_pixel_mask = torch.gather(mask_ids, -1, random_index.unsqueeze(-1)).squeeze(-1)  # [B, num_samples]
+
+                # Gather the previous mask ID (for interpolation)
+                prev_index = torch.clamp(random_index - 1, min=0).unsqueeze(-1)
+                per_pixel_mask_prev = torch.gather(mask_ids, -1, prev_index).squeeze(-1)  # [B, num_samples]
+
+            # Get scale values for selected masks using JaggedTensor indexing
+            # For batch element b and mask index m, scale is at: scales_data[scales_offsets[b] + m]
+            # Create batch offsets expanded to [B, num_samples]
+            batch_offsets = scales_offsets[:-1].unsqueeze(1).expand(-1, num_samples)  # [B, num_samples]
+
+            # Compute flat indices into scales_data
+            curr_flat_idx = batch_offsets + per_pixel_mask  # [B, num_samples]
+            prev_flat_idx = batch_offsets + per_pixel_mask_prev  # [B, num_samples]
+
+            # Index into flat scales data
+            curr_scale = scales_data[curr_flat_idx]  # [B, num_samples]
+            prev_scale = scales_data[prev_flat_idx]  # [B, num_samples]
+
+            # Interpolate scales (vectorized version of the loop)
+            # For random_index == 0: interpolate from 0 to current scale
+            # For random_index > 0: interpolate from previous scale to current scale
+            is_first_group = random_index == 0
+
+            # Compute interpolated scale for all pixels
+            # When is_first_group: lerp from 0 to curr_scale
+            # Otherwise: lerp from prev_scale to curr_scale
+            interpolated_scale = torch.where(
+                is_first_group,
+                curr_scale * random_densify,  # First group: scale down from 0
+                prev_scale + (curr_scale - prev_scale) * random_densify,  # Other groups: interpolate
+            )
+
+            batch["scales"] = interpolated_scale  # [B, num_samples]
+            batch["mask_ids"] = per_pixel_mask  # [B, num_samples]
+
+            return batch
+
+
+class RandomSamplePixels:
+    """Transform that randomly samples pixels from an image.
+
+    Samples a subset of pixels for efficient training. Supports optional
+    importance sampling to bias towards smaller-scale regions, which can
+    improve learning of fine-grained segmentation boundaries. The original
+    full image is preserved in the ``image_full`` field.
+    """
+
+    def __init__(self, num_samples_per_image: int, scale_bias_strength: float = 0.0):
+        """
+        Args:
+            num_samples_per_image: Number of pixels to sample per image.
+            scale_bias_strength: Strength of bias towards smaller scales.
+                                0.0 = uniform random sampling (default behavior)
+                                > 0.0 = bias towards smaller scales (higher values = stronger bias)
+        """
+        self.num_samples_per_image = num_samples_per_image
+        self.scale_bias_strength = scale_bias_strength
+
+    def __call__(self, item: SegmentationDataItem) -> SegmentationDataItem:
+        """Sample pixels from the image.
+
+        Args:
+            item: Input data item with full-resolution data.
+
+        Returns:
+            Modified item where ``image``, ``mask_ids``, and ``mask_cdf``
+            contain only the sampled pixels. Original coordinates are stored
+            in ``pixel_coords`` and the full image in ``image_full``.
+        """
+        with nvtx.range("RandomSamplePixels"):
+            h, w = item["image_h"], item["image_w"]
+
+            if self.scale_bias_strength > 0.0 and "scales" in item:
+                with nvtx.range("importance_sampling"):
+                    # Use importance sampling based on scales (smaller scales = higher probability)
+                    scales = item["scales"]  # [NM] - scale per mask
+                    mask_ids = item["mask_ids"]  # [H, W, MM] - mask IDs per pixel
+
+                    # Get scale values for each pixel by indexing scales with mask_ids
+                    # Handle invalid mask IDs (typically -1) by masking them out
+                    valid_mask = mask_ids >= 0  # [H, W, MM]
+
+                    # Vectorized computation of per-pixel scales
+                    # Clamp mask_ids to valid range to avoid index errors when accessing scales
+                    clamped_mask_ids = torch.clamp(mask_ids, 0, len(scales) - 1)  # [H, W, MM]
+
+                    # Get scale values for all pixels at once using advanced indexing
+                    pixel_scale_values = scales[clamped_mask_ids]  # [H, W, MM]
+
+                    # Mask out invalid entries (set to inf so they don't affect min operation)
+                    pixel_scale_values = torch.where(valid_mask, pixel_scale_values, float("inf"))
+
+                    # Get minimum scale per pixel across the MM dimension
+                    pixel_scales, _ = torch.min(pixel_scale_values, dim=-1)  # [H, W]
+
+                    # Handle pixels with no valid masks (where all scales were inf)
+                    inf_mask = pixel_scales == float("inf")
+                    if inf_mask.any():
+                        median_scale = torch.median(scales)
+                        pixel_scales[inf_mask] = median_scale
+
+                    # Convert scales to sampling probabilities (smaller scales = higher prob)
+                    inv_scales = 1.0 / (pixel_scales + 1e-8)  # Add small epsilon to avoid division by zero
+
+                    # Apply bias strength (higher strength = more bias towards small scales)
+                    if self.scale_bias_strength != 1.0:
+                        inv_scales = torch.pow(inv_scales, self.scale_bias_strength)
+
+                    # Flatten and normalize to get probabilities
+                    flat_probs = inv_scales.flatten()
+                    flat_probs = flat_probs / flat_probs.sum()
+
+                    # Determine sampling parameters
+                    total_pixels = h * w
+                    num_samples = min(self.num_samples_per_image, total_pixels)
+
+                    # Sample according to probabilities - keep as tensor for vectorized ops
+                    flat_indices = torch.multinomial(flat_probs, num_samples, replacement=False)
+                    # Compute row/col directly
+                    pixels = torch.empty((num_samples, 2), dtype=torch.long)
+                    pixels[:, 0] = flat_indices // w  # row
+                    pixels[:, 1] = flat_indices % w  # col
+            else:
+                with nvtx.range("uniform_sampling"):
+                    # Uniform random sampling (with replacement, but duplicates are negligible)
+                    # For 4096 samples from 2M pixels: ~4 expected duplicates (0.1%)
+                    total_pixels = h * w
+                    num_samples = min(self.num_samples_per_image, total_pixels)
+                    flat_indices = torch.randint(0, total_pixels, (num_samples,))
+                    pixels = torch.empty((num_samples, 2), dtype=torch.long)
+                    pixels[:, 0] = flat_indices // w  # row
+                    pixels[:, 1] = flat_indices % w  # col
+
+            with nvtx.range("pixel_indexing"):
+                item["image_full"] = item["image"]
+                item["image"] = item["image"][pixels[:, 0], pixels[:, 1]]
+                item["mask_ids"] = item["mask_ids"][pixels[:, 0], pixels[:, 1]]
+                item["mask_cdf"] = item["mask_cdf"][pixels[:, 0], pixels[:, 1]]
+                item["pixel_coords"] = pixels
+
+            return item
+
+
+class Resize:
+    """Transform that resizes images and masks by a scale factor."""
+
+    def __init__(self, scale: float) -> None:
+        """Initialize the resize transform.
+
+        Args:
+            scale: Scale factor to apply (e.g., 0.5 for half resolution).
+        """
+        self.scale = scale
+
+    def __call__(self, item: SegmentationDataItem) -> SegmentationDataItem:
+        """Resize image, masks, and update projection matrix.
+
+        Args:
+            item: Input data item to resize.
+
+        Returns:
+            Resized item with updated dimensions and scaled projection matrix.
+        """
+        # Resize image from [H, W, 3] to [H * scale, W * scale, 3]
+        item["image"] = (
+            F.interpolate(
+                item["image"].unsqueeze(0).permute(0, 3, 1, 2),  # [1, 3, H, W]
+                scale_factor=self.scale,
+                mode="nearest",
+            )
+            .permute(0, 2, 3, 1)
+            .squeeze(0)
+        )  # back to [H * scale, W * scale, 3]
+
+        # Update dimensions
+        item["image_h"] = int(item["image_h"] * self.scale)
+        item["image_w"] = int(item["image_w"] * self.scale)
+
+        # Resize masks similarly
+        item["mask_cdf"] = (
+            F.interpolate(item["mask_cdf"].unsqueeze(0).permute(0, 3, 1, 2), scale_factor=self.scale, mode="nearest")
+            .permute(0, 2, 3, 1)
+            .squeeze(0)
+        )
+
+        item["mask_ids"] = (
+            TF.resize(
+                item["mask_ids"].unsqueeze(0).permute(0, 3, 1, 2),
+                size=[item["image"].shape[0], item["image"].shape[1]],
+                interpolation=torchvision.transforms.InterpolationMode.NEAREST,
+            )
+            .permute(0, 2, 3, 1)
+            .squeeze(0)
+        )
+
+        # scale intrinsics for new image size
+        fx = item["projection"][0, 0]
+        fy = item["projection"][1, 1]
+        cx = item["projection"][0, 2]
+        cy = item["projection"][1, 2]
+        new_fx = fx / self.scale
+        new_fy = fy / self.scale
+        new_cx = cx / self.scale
+        new_cy = cy / self.scale
+        item["projection"] = torch.tensor([[new_fx, 0, new_cx], [0, new_fy, new_cy], [0, 0, 1]], dtype=torch.float32)
+
+        return item

--- a/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
@@ -101,24 +101,35 @@ class RandomSelectMaskIDAndScale:
                 ).squeeze()
 
             scales = item["scales"]  # [NM] dtype: torch.float32
-            curr_scale = scales[per_pixel_mask]  # [H, W] dtype: torch.float32
+            # Pixels that intersect no mask carry a -1 padding id. Clamp the lookup so it never
+            # indexes ``scales`` with a negative id (which would silently select the last scale);
+            # the scale for these pixels is zeroed below while ``mask_ids`` stays -1 so downstream
+            # loss masking remains correct.
+            invalid_pixel = per_pixel_mask < 0
+            curr_lookup = per_pixel_mask.clamp(min=0)
+            curr_scale = scales[curr_lookup]  # [H, W] dtype: torch.float32
 
             # For pixels in the first group (random_index == 0), randomly scale down their scale value
             # between 0 and the full scale. This creates a smooth transition from zero to the first group's scale,
             # similar to how we interpolate between groups for other indices.
             curr_scale[random_index == 0] = (
-                scales[per_pixel_mask][random_index == 0] * random_vec_densify[random_index == 0]
+                scales[curr_lookup][random_index == 0] * random_vec_densify[random_index == 0]
             )
             # For each group, interpolate between the previous group's scale and the current group's scale,
             # based on the random_vec_densify value. This creates a smooth transition between groups.
-            for j in range(1, item["mask_cdf"].shape[-1]):
-                if (random_index == j).sum() == 0:
-                    continue
-                curr_scale[random_index == j] = (
-                    scales[per_pixel_mask_][random_index == j]  # type: ignore
-                    + (scales[per_pixel_mask][random_index == j] - scales[per_pixel_mask_][random_index == j])  # type: ignore
-                    * random_vec_densify[random_index == j]
-                ).squeeze()
+            if per_pixel_index.shape[-1] > 1:
+                prev_lookup = per_pixel_mask_.clamp(min=0)  # type: ignore
+                for j in range(1, item["mask_cdf"].shape[-1]):
+                    if (random_index == j).sum() == 0:
+                        continue
+                    curr_scale[random_index == j] = (
+                        scales[prev_lookup][random_index == j]
+                        + (scales[curr_lookup][random_index == j] - scales[prev_lookup][random_index == j])
+                        * random_vec_densify[random_index == j]
+                    ).squeeze()
+
+            # Background pixels get a zero scale; their -1 mask id is preserved below for loss masking.
+            curr_scale[invalid_pixel] = 0.0
 
             item["scales"] = curr_scale  # [rays_per_image] dtype: torch.float32
 
@@ -202,9 +213,16 @@ class GPURandomSelectMaskIDAndScale:
             # Create batch offsets expanded to [B, num_samples]
             batch_offsets = scales_offsets[:-1].unsqueeze(1).expand(-1, num_samples)  # [B, num_samples]
 
+            # Background pixels carry a -1 padding id. Clamp before adding the per-image offset so
+            # the index never goes negative and wraps into another image's scales (a cross-image,
+            # batch-order-dependent read). The interpolated scale for these pixels is zeroed below
+            # while their -1 mask id is preserved for downstream loss masking.
+            curr_lookup = per_pixel_mask.clamp(min=0)
+            prev_lookup = per_pixel_mask_prev.clamp(min=0)
+
             # Compute flat indices into scales_data
-            curr_flat_idx = batch_offsets + per_pixel_mask  # [B, num_samples]
-            prev_flat_idx = batch_offsets + per_pixel_mask_prev  # [B, num_samples]
+            curr_flat_idx = batch_offsets + curr_lookup  # [B, num_samples]
+            prev_flat_idx = batch_offsets + prev_lookup  # [B, num_samples]
 
             # Index into flat scales data
             curr_scale = scales_data[curr_flat_idx]  # [B, num_samples]
@@ -222,6 +240,11 @@ class GPURandomSelectMaskIDAndScale:
                 is_first_group,
                 curr_scale * random_densify,  # First group: scale down from 0
                 prev_scale + (curr_scale - prev_scale) * random_densify,  # Other groups: interpolate
+            )
+
+            # Zero the scale for background pixels (no intersecting mask); mask_ids stays -1.
+            interpolated_scale = torch.where(
+                per_pixel_mask < 0, torch.zeros_like(interpolated_scale), interpolated_scale
             )
 
             batch["scales"] = interpolated_scale  # [B, num_samples]

--- a/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
@@ -97,7 +97,7 @@ class RandomSelectMaskIDAndScale:
                 per_pixel_mask_ = torch.gather(
                     per_pixel_index,
                     -1,
-                    torch.max(random_index.unsqueeze(-1) - 1, torch.Tensor([0]).int()),
+                    torch.clamp(random_index.unsqueeze(-1) - 1, min=0),
                 ).squeeze()
 
             scales = item["scales"]  # [NM] dtype: torch.float32

--- a/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
@@ -9,12 +9,13 @@ import torch.cuda.nvtx as nvtx
 import torch.nn.functional as F
 import torchvision
 import torchvision.transforms.functional as TF
+from torch.utils.data import Dataset
+
 from fvdb_reality_capture.instance_segmentation.training.dataset import (
     GARfVDBInput,
     SegmentationDataItem,
     SegmentationDataset,
 )
-from torch.utils.data import Dataset
 
 
 class TransformedSegmentationDataset(Dataset):
@@ -391,10 +392,11 @@ class Resize:
         fy = item["projection"][1, 1]
         cx = item["projection"][0, 2]
         cy = item["projection"][1, 2]
-        new_fx = fx / self.scale
-        new_fy = fy / self.scale
-        new_cx = cx / self.scale
-        new_cy = cy / self.scale
+        # Intrinsics scale with the image size: downsampling by ``scale`` (e.g. 0.5) also scales fx/fy/cx/cy.
+        new_fx = fx * self.scale
+        new_fy = fy * self.scale
+        new_cx = cx * self.scale
+        new_cy = cy * self.scale
         item["projection"] = torch.tensor([[new_fx, 0, new_cx], [0, new_fy, new_cy], [0, 0, 1]], dtype=torch.float32)
 
         return item

--- a/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
+++ b/fvdb_reality_capture/instance_segmentation/training/dataset_transforms.py
@@ -253,6 +253,25 @@ class GPURandomSelectMaskIDAndScale:
             return batch
 
 
+def _sample_distinct_indices(total: int, num_samples: int) -> torch.Tensor:
+    """Draw ``num_samples`` distinct indices uniformly from ``range(total)``.
+
+    Draws with replacement, deduplicates, and tops up any shortfall. Duplicates
+    are rare when ``num_samples`` is small relative to ``total``, so the top-up
+    loop almost never runs and no ``total``-sized tensor is ever allocated. When
+    the sample count approaches ``total`` that stops holding, so fall back to a
+    full permutation. The result is sorted, which nothing downstream depends on.
+    """
+    if num_samples * 2 > total:
+        return torch.randperm(total)[:num_samples]
+
+    indices = torch.randint(0, total, (num_samples,)).unique()
+    while indices.numel() < num_samples:
+        extra = torch.randint(0, total, (num_samples - indices.numel(),))
+        indices = torch.cat([indices, extra]).unique()
+    return indices
+
+
 class RandomSamplePixels:
     """Transform that randomly samples pixels from an image.
 
@@ -339,11 +358,9 @@ class RandomSamplePixels:
                     pixels[:, 1] = flat_indices % w  # col
             else:
                 with nvtx.range("uniform_sampling"):
-                    # Uniform random sampling (with replacement, but duplicates are negligible)
-                    # For 4096 samples from 2M pixels: ~4 expected duplicates (0.1%)
                     total_pixels = h * w
                     num_samples = min(self.num_samples_per_image, total_pixels)
-                    flat_indices = torch.randint(0, total_pixels, (num_samples,))
+                    flat_indices = _sample_distinct_indices(total_pixels, num_samples)
                     pixels = torch.empty((num_samples, 2), dtype=torch.long)
                     pixels[:, 0] = flat_indices // w  # row
                     pixels[:, 1] = flat_indices % w  # col

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -42,7 +42,6 @@ from fvdb_reality_capture.instance_segmentation.training.dataset_transforms impo
 )
 from fvdb_reality_capture.instance_segmentation.training.segmentation_writer import GARfVDBWriter
 from fvdb_reality_capture.instance_segmentation.util import pca_projection_fast
-from torch.utils.tensorboard import SummaryWriter
 
 if TYPE_CHECKING:
     from fvdb_reality_capture.instance_segmentation.garfvdb import GARfVDB
@@ -67,6 +66,11 @@ class TensorboardLogger:
         self._log_every_step = log_every_step
         self._log_dir = log_dir
         self._log_images_to_tensorboard = log_images_to_tensorboard
+        # Imported lazily so importing this module (and the fvdb_reality_capture package) does not require
+        # the optional `tensorboard` package unless TensorBoard logging is actually used. Mirrors the lazy
+        # import in segmentation_writer.py.
+        from torch.utils.tensorboard import SummaryWriter
+
         self._tb_writer = SummaryWriter(log_dir=log_dir)
 
     def log_training_iteration(

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -7,6 +7,7 @@ import math
 import os
 import pathlib
 import random
+import time
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
@@ -168,6 +169,15 @@ class GARfVDBTrainer:
         viz_callback: Callable[["GARfVDBTrainer", int], None] | None = None,
         cache_dataset: bool = True,
         reconstruction_metadata: dict[str, Any] | None = None,
+        enable_viewer: bool = False,
+        viewer_scene_name: str = "GARfVDB Training",
+        viewer_scale_fraction: float = 0.1,
+        viewer_mask_blend: float = 0.5,
+        viewer_lock_pca_colors: bool = False,
+        viewer_overlay_width: int = 1440,
+        viewer_overlay_height: int = 720,
+        viewer_overlay_downsample: int = 2,
+        viewer_update_interval_seconds: float = 0.5,
         _private: object | None = None,
     ) -> None:
         """
@@ -268,6 +278,20 @@ class GARfVDBTrainer:
         self._viewer_update_interval_epochs = viewer_update_interval_epochs
         self._viz_callback = viz_callback
 
+        # Live training viewer (fvdb Viewer with interactive scale/opacity/show-overlay controls).
+        # fviz.init(...) must already have been called by the caller before the model was moved to CUDA.
+        self._enable_viewer = enable_viewer
+        self._viewer_scene_name = viewer_scene_name
+        self._viewer_scale_fraction = viewer_scale_fraction
+        self._viewer_mask_blend = viewer_mask_blend
+        self._viewer_lock_pca_colors = viewer_lock_pca_colors
+        self._viewer_overlay_width = viewer_overlay_width
+        self._viewer_overlay_height = viewer_overlay_height
+        self._viewer_overlay_downsample = viewer_overlay_downsample
+        self._viewer_update_interval_seconds = viewer_update_interval_seconds
+        self._overlay_viewer = None
+        self._last_viewer_render_time = 0.0
+
     @property
     def total_steps(self) -> int:
         """Get the total number of steps for training."""
@@ -349,7 +373,7 @@ class GARfVDBTrainer:
         gs_model_path: pathlib.Path,
         writer: GARfVDBWriter,
         config: GARfVDBTrainingConfig = GARfVDBTrainingConfig(),
-        device: str | torch.device = "cuda",
+        device: str | torch.device = "cuda:0",
         use_every_n_as_val: int = 100,
         exclude_indices: Sequence[int] | None = None,
         viewer_update_interval_epochs: int = 10,
@@ -357,6 +381,13 @@ class GARfVDBTrainer:
         viz_callback: Callable[["GARfVDBTrainer", int], None] | None = None,
         cache_dataset: bool = True,
         reconstruction_metadata: dict[str, Any] | None = None,
+        enable_viewer: bool = False,
+        viewer_scale_fraction: float = 0.1,
+        viewer_mask_blend: float = 0.5,
+        viewer_lock_pca_colors: bool = False,
+        viewer_overlay_width: int = 1440,
+        viewer_overlay_height: int = 720,
+        viewer_overlay_downsample: int = 2,
     ) -> "GARfVDBTrainer":
         """
         Create a `GARfVDBTrainer` instance for a new training run.
@@ -479,6 +510,13 @@ class GARfVDBTrainer:
             viz_callback=viz_callback,
             cache_dataset=cache_dataset,
             reconstruction_metadata=reconstruction_metadata,
+            enable_viewer=enable_viewer,
+            viewer_scale_fraction=viewer_scale_fraction,
+            viewer_mask_blend=viewer_mask_blend,
+            viewer_lock_pca_colors=viewer_lock_pca_colors,
+            viewer_overlay_width=viewer_overlay_width,
+            viewer_overlay_height=viewer_overlay_height,
+            viewer_overlay_downsample=viewer_overlay_downsample,
             _private=GARfVDBTrainer.__PRIVATE__,
         )
 
@@ -489,7 +527,7 @@ class GARfVDBTrainer:
         gs_model: GaussianSplat3d,
         gs_model_path: pathlib.Path,
         writer: GARfVDBWriter | None = None,
-        device: str | torch.device = "cuda",
+        device: str | torch.device = "cuda:0",
         eval_only: bool = False,
     ) -> "GARfVDBTrainer":
         """
@@ -672,7 +710,7 @@ class GARfVDBTrainer:
         checkpoint_path: pathlib.Path,
         *,
         writer: GARfVDBWriter | None = None,
-        device: str | torch.device = "cuda",
+        device: str | torch.device = "cuda:0",
         reconstruction_path: pathlib.Path | None = None,
     ) -> "GARfVDBTrainer":
         """Restore a trainer and its carrier from a checkpoint path."""
@@ -690,7 +728,7 @@ class GARfVDBTrainer:
         checkpoint: dict[str, Any],
         *,
         writer: GARfVDBWriter | None = None,
-        device: str | torch.device = "cuda",
+        device: str | torch.device = "cuda:0",
         reconstruction_path: pathlib.Path | None = None,
     ) -> "GARfVDBTrainer":
         """Restore a trainer and carrier from already loaded method state."""
@@ -730,6 +768,53 @@ class GARfVDBTrainer:
         from fvdb_reality_capture.instance_segmentation.garfvdb import GARfVDB
 
         return GARfVDB(model=self._model, reconstruction_metadata=self._reconstruction_metadata)
+
+    def _setup_viewer(self) -> None:
+        """Start the live training viewer if enabled. fviz.init(...) must already have been called."""
+        if not self._enable_viewer:
+            return
+        try:
+            import fvdb.viz as fviz
+
+            from fvdb_reality_capture.instance_segmentation.viewer import GARfVDBOverlayViewer
+
+            scene = fviz.get_scene(self._viewer_scene_name)
+            # to_product() wraps the live model by reference, so overlay frames reflect current weights.
+            self._overlay_viewer = GARfVDBOverlayViewer(
+                scene,
+                self.to_product(),
+                device=self._model.device,
+                overlay_width=self._viewer_overlay_width,
+                overlay_height=self._viewer_overlay_height,
+                overlay_downsample=self._viewer_overlay_downsample,
+                initial_scale_fraction=self._viewer_scale_fraction,
+                initial_mask_blend=self._viewer_mask_blend,
+                lock_pca_colors=self._viewer_lock_pca_colors,
+            )
+            fviz.show()
+            self._logger.info("GARfVDB training viewer running.")
+        except Exception as e:  # never let viewer setup take down training
+            self._logger.warning(f"Failed to start GARfVDB training viewer: {e}")
+            self._overlay_viewer = None
+
+    def _pump_viewer(self) -> None:
+        """Render one overlay frame from the current model, throttled by wall-clock. Never raises."""
+        if self._overlay_viewer is None:
+            return
+        now = time.monotonic()
+        if now - self._last_viewer_render_time < self._viewer_update_interval_seconds:
+            return
+        self._last_viewer_render_time = now
+        was_training = self._model.training
+        try:
+            self._model.eval()
+            with torch.no_grad():
+                self._overlay_viewer.render_once()
+        except Exception as e:  # a viewer hiccup must never interrupt training
+            self._logger.warning(f"GARfVDB training viewer update failed: {e}")
+        finally:
+            if was_training:
+                self._model.train()
 
     def train(self, show_progress: bool = True, log_tag: str = "train"):
         if self._optimizer is None:
@@ -784,6 +869,9 @@ class GARfVDBTrainer:
         self._model.train()
         self._optimizer.zero_grad()
 
+        # Start the live training viewer (no-op unless enabled).
+        self._setup_viewer()
+
         pbar = tqdm.tqdm(range(self.total_steps), desc="Training")
 
         # Gradient accumulation settings
@@ -802,6 +890,9 @@ class GARfVDBTrainer:
         trainloader_iter = iter(trainloader)
         step = 0
         while True:
+            # Refresh the live viewer between steps (throttled internally; no-op unless enabled).
+            self._pump_viewer()
+
             with nvtx.range("dataloader_fetch_batch"):
                 try:
                     minibatch = next(trainloader_iter)

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -1,0 +1,1093 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import hashlib
+import logging
+import math
+import os
+import pathlib
+import random
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any, Callable, Sequence
+
+import numpy as np
+import torch
+import torch.cuda.nvtx as nvtx
+import torchvision
+import torchvision.transforms.functional as tvF
+import tqdm
+from fvdb import GaussianSplat3d
+from fvdb_reality_capture.checkpoints import load_training_checkpoint
+from fvdb_reality_capture.sfm_scene import SfmScene
+from fvdb_reality_capture.tools import filter_splats_above_scale
+from fvdb_reality_capture.instance_segmentation.checkpoint import (
+    GARFVDB_TRAINING_METHOD,
+    GARFVDB_TRAINING_METHOD_VERSION,
+)
+from fvdb_reality_capture.instance_segmentation.config import GARfVDBConfig, GARfVDBTrainingConfig
+from fvdb_reality_capture.instance_segmentation.loss import calculate_loss
+from fvdb_reality_capture.instance_segmentation.model import GARfVDBModel
+from fvdb_reality_capture.instance_segmentation.optim import ExponentialLRWithRampUpScheduler
+from fvdb_reality_capture.instance_segmentation.training.dataset import (
+    GARfVDBInputCollateFn,
+    InfiniteSampler,
+    SegmentationDataset,
+)
+from fvdb_reality_capture.instance_segmentation.training.dataset_transforms import (
+    GPURandomSelectMaskIDAndScale,
+    RandomSamplePixels,
+    RandomSelectMaskIDAndScale,
+    TransformedSegmentationDataset,
+)
+from fvdb_reality_capture.instance_segmentation.training.segmentation_writer import GARfVDBWriter
+from fvdb_reality_capture.instance_segmentation.util import pca_projection_fast
+from torch.utils.tensorboard import SummaryWriter
+
+if TYPE_CHECKING:
+    from fvdb_reality_capture.instance_segmentation.garfvdb import GARfVDB
+
+
+class TensorboardLogger:
+    """Utility class for logging training metrics to TensorBoard."""
+
+    def __init__(
+        self,
+        log_dir: pathlib.Path,
+        log_every_step: int = 100,
+        log_images_to_tensorboard: bool = False,
+    ) -> None:
+        """Initialize TensorBoard logger.
+
+        Args:
+            log_dir: Directory to save TensorBoard event files.
+            log_every_step: Logging frequency in training steps.
+            log_images_to_tensorboard: Whether to log rendered images.
+        """
+        self._log_every_step = log_every_step
+        self._log_dir = log_dir
+        self._log_images_to_tensorboard = log_images_to_tensorboard
+        self._tb_writer = SummaryWriter(log_dir=log_dir)
+
+    def log_training_iteration(
+        self,
+        step: int,
+        metrics: dict[str, torch.Tensor],
+        mem: float,
+        gt_img: torch.Tensor | None,
+        pred_img: torch.Tensor | None,
+    ):
+        """
+        Log training metrics to TensorBoard.
+
+        Args:
+            step: Current training step.
+            metrics: Dictionary of metrics to log.
+            mem: Maximum GPU memory allocated in GB.
+            gt_img: Ground truth image for visualization.
+            pred_img: Predicted image for visualization.
+        """
+        if self._log_every_step > 0 and step % self._log_every_step == 0 and self._tb_writer is not None:
+            mem = torch.cuda.max_memory_allocated() / 1024**3
+            # Log loss components to tensorboard
+            for key, value in metrics.items():
+                self._tb_writer.add_scalar(f"train/{key}", value.item(), step)
+            self._tb_writer.add_scalar("train/mem", mem, step)
+            if self._log_images_to_tensorboard and gt_img is not None and pred_img is not None:
+                canvas = torch.cat([gt_img, pred_img], dim=2).detach().cpu().numpy()
+                canvas = canvas.reshape(-1, *canvas.shape[2:])
+                self._tb_writer.add_image("train/render", canvas, step)
+            self._tb_writer.flush()
+
+    def log_evaluation_iteration(
+        self,
+        step: int,
+        loss: float,
+        beauty_output: torch.Tensor,
+        beauty_gt: torch.Tensor,
+        sample_mask: torch.Tensor,
+        sample_image: torch.Tensor,
+    ):
+        """
+        Log evaluation metrics to TensorBoard.
+
+        Args:
+            step: The training step after which the evaluation was performed.
+            loss: Loss value for the evaluation (averaged over all images in the validation set).
+            beauty_output: Gaussian splat rendered beauty output for the evaluation
+            beauty_gt: Ground truth beauty image from validation set for the evaluation
+            sample_mask: Mask for the evaluation
+            sample_image: Sample blended image with beauty output and mask for the evaluation
+        """
+
+        self._tb_writer.add_scalar("eval/loss", loss, step)
+        self._tb_writer.add_image("eval/beauty_output", beauty_output, step)
+        self._tb_writer.add_image("eval/beauty_gt", beauty_gt, step)
+        self._tb_writer.add_image("eval/sample_mask", sample_mask, step)
+        self._tb_writer.add_image("eval/sample_image", sample_image, step)
+
+
+class GARfVDBTrainer:
+    """Training and evaluation engine for scale-conditioned Gaussian splat segmentation.
+
+    This class manages the complete training pipeline for GARfVDB segmentation models,
+    including dataset loading, optimization, checkpointing, and evaluation. It supports
+    both training from scratch and resuming from checkpoints.
+
+    Attributes:
+        version: Checkpoint format version string.
+        model: The GARfVDB segmentation model.
+        gs_model: The underlying GaussianSplat3d radiance field.
+        sfm_scene: The transformed SfmScene with segmentation masks.
+        config: Training configuration parameters.
+    """
+
+    version = GARFVDB_TRAINING_METHOD_VERSION
+
+    _magic = "GARfVDBInstanceSegmentationCheckpoint"
+
+    __PRIVATE__ = object()
+
+    def __init__(
+        self,
+        model: GARfVDBModel,
+        optimizer: torch.optim.Optimizer,
+        scheduler: torch.optim.lr_scheduler.LRScheduler,
+        config: GARfVDBTrainingConfig,
+        gs_model: GaussianSplat3d,
+        gs_model_path: pathlib.Path,
+        sfm_scene: SfmScene,
+        train_indices: np.ndarray,
+        val_indices: np.ndarray,
+        train_transform: torchvision.transforms.Compose,
+        val_transform: torchvision.transforms.Compose,
+        writer: GARfVDBWriter,
+        start_step: int,
+        log_interval_steps: int,
+        viewer_update_interval_epochs: int,
+        grouping_scale_stats: torch.Tensor | None = None,
+        viz_callback: Callable[["GARfVDBTrainer", int], None] | None = None,
+        cache_dataset: bool = True,
+        reconstruction_metadata: dict[str, Any] | None = None,
+        _private: object | None = None,
+    ) -> None:
+        """
+        Initialize the Runner with the provided configuration, model, optimizer, datasets, and paths.
+
+        Note: This constructor should only be called by the `new` or `resume_from_checkpoint` methods.
+
+        Args:
+            model (GARfVDBModel): The GARfVDB model to train.
+            optimizer (torch.optim.Optimizer): The optimizer for the model.
+            scheduler (torch.optim.lr_scheduler.LRScheduler): The learning rate scheduler.
+            config (GARfVDBTrainingConfig): Configuration object containing model parameters.
+            gs_model (GaussianSplat3d): The optimized GaussianSplat3d model.
+            gs_model_path (pathlib.Path): Path to the GaussianSplat3d model file.
+            sfm_scene (SfmScene): The Structure-from-Motion scene.
+            train_indices (np.ndarray): The indices for the training set.
+            val_indices (np.ndarray): The indices for the validation set.
+            train_transform (torchvision.transforms.Compose): The transform for training data.
+            val_transform (torchvision.transforms.Compose): The transform for validation data.
+            writer (GARfVDBWriter): The writer to use for logging and saving results.
+            start_step (int): The step to start training from (useful for resuming from a checkpoint).
+            log_interval_steps (int): How often to log metrics to TensorBoard.
+            viewer_update_interval_epochs (int): How often to update the viewer.
+            grouping_scale_stats (torch.Tensor | None): The scale statistics of the GaussianSplat3d model.
+            viz_callback (Callable | None): Optional callback function called at epoch boundaries for visualization.
+                The callback receives the runner instance and the current epoch number.
+            cache_dataset (bool): If True, cache images and masks in memory to speed up data loading.
+                Set to False to reduce memory usage for large datasets. Default is True.
+            _private (object | None): Private object to ensure this class is only initialized
+                through `new` or `resume_from_checkpoint`.
+        """
+        if _private is not GARfVDBTrainer.__PRIVATE__:
+            raise ValueError("Runner should only be initialized through `new_run` or `resume_from_checkpoint`.")
+
+        self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
+
+        self._cfg = config
+
+        self._start_step = start_step
+
+        self._sfm_scene = sfm_scene
+
+        self._gs_model = gs_model
+        self._gs_model_path = gs_model_path
+        self._reconstruction_metadata = dict(reconstruction_metadata or {})
+        self._carrier_means_sha256 = hashlib.sha256(
+            gs_model.means.detach().cpu().contiguous().numpy().tobytes()
+        ).hexdigest()
+
+        # Store scale statistics for checkpoint restoration
+        # If provided (from checkpoint), use them directly; otherwise compute from the dataset
+        if grouping_scale_stats is not None:
+            self._grouping_scale_stats = grouping_scale_stats
+        else:
+            _full_dataset_for_scales = SegmentationDataset(
+                sfm_scene=sfm_scene,
+                cache_loaded_masks=cache_dataset,
+                cache_images=cache_dataset,
+            )
+            self._grouping_scale_stats = _full_dataset_for_scales.scales
+
+        self._training_dataset = SegmentationDataset(
+            sfm_scene=sfm_scene,
+            dataset_indices=train_indices,
+            cache_loaded_masks=cache_dataset,
+            cache_images=cache_dataset,
+        )
+        self._validation_dataset = SegmentationDataset(
+            sfm_scene=sfm_scene,
+            dataset_indices=val_indices,
+            cache_loaded_masks=cache_dataset,
+            cache_images=cache_dataset,
+        )
+        self._train_transforms = train_transform
+        self._val_transforms = val_transform
+        self._training_dataset = TransformedSegmentationDataset(
+            self._training_dataset,
+            train_transform,
+        )
+        self._validation_dataset = TransformedSegmentationDataset(
+            self._validation_dataset,
+            val_transform,
+        )
+        self._logger.info(
+            f"Created dataset training and test datasets with {len(self._training_dataset)} training images and {len(self._validation_dataset)} test images."
+        )
+
+        self._model = model
+        self._optimizer = optimizer
+        self._scheduler = scheduler
+        if isinstance(self._scheduler, ExponentialLRWithRampUpScheduler):
+            self._scheduler.max_steps = self.total_steps
+
+        self._global_step: int = 0
+
+        self._writer = writer
+        self._log_interval_steps = log_interval_steps
+        self._viewer_update_interval_epochs = viewer_update_interval_epochs
+        self._viz_callback = viz_callback
+
+    @property
+    def total_steps(self) -> int:
+        """Get the total number of steps for training."""
+        computed_total_steps: int = int(self._cfg.max_epochs * len(self._training_dataset))
+        total_steps: int = self._cfg.max_steps if self._cfg.max_steps is not None else computed_total_steps
+        return total_steps
+
+    @property
+    def model(self) -> GARfVDBModel:
+        """Get the GARfVDB segmentation model."""
+        return self._model
+
+    @property
+    def gs_model(self) -> GaussianSplat3d:
+        """Get the underlying GaussianSplat3d model."""
+        return self._gs_model
+
+    @property
+    def sfm_scene(self) -> SfmScene:
+        """Get the transformed SfmScene used for training."""
+        return self._sfm_scene
+
+    @property
+    def config(self) -> GARfVDBTrainingConfig:
+        """Get the configuration used for training."""
+        return self._cfg
+
+    @property
+    def grouping_scale_stats(self) -> torch.Tensor:
+        """Get the grouping scale statistics used for the model."""
+        return self._grouping_scale_stats
+
+    @property
+    def device(self) -> torch.device:
+        """Get the device the model is running on."""
+        dev = self._model.device
+        if isinstance(dev, str):
+            return torch.device(dev)
+        return dev
+
+    @property
+    def viz_callback(self) -> Callable[["GARfVDBTrainer", int], None] | None:
+        """Get or set the visualization callback invoked at epoch boundaries."""
+        return self._viz_callback
+
+    @viz_callback.setter
+    def viz_callback(self, callback: Callable[["GARfVDBTrainer", int], None] | None) -> None:
+        self._viz_callback = callback
+
+    @staticmethod
+    def _init_model(
+        model_config: GARfVDBConfig,
+        gs_model: GaussianSplat3d,
+        grouping_scale_stats: torch.Tensor,
+        device: torch.device | str,
+    ) -> GARfVDBModel:
+        """
+        Initialize the GARfVDB model.
+
+        Args:
+            model_config: Configuration object containing model parameters.
+            gs_model: The optimized GaussianSplat3d model.
+            grouping_scale_stats: The scale statistics of the GaussianSplat3d model.
+            device: The device to run the model on (e.g., "cuda" or "cpu").
+        """
+
+        return GARfVDBModel(
+            gs_model,
+            grouping_scale_stats,
+            model_config=model_config,
+            device=device,
+        )
+
+    @classmethod
+    def new(
+        cls,
+        sfm_scene: SfmScene,
+        gs_model: GaussianSplat3d,
+        gs_model_path: pathlib.Path,
+        writer: GARfVDBWriter,
+        config: GARfVDBTrainingConfig = GARfVDBTrainingConfig(),
+        device: str | torch.device = "cuda",
+        use_every_n_as_val: int = 100,
+        exclude_indices: Sequence[int] | None = None,
+        viewer_update_interval_epochs: int = 10,
+        log_interval_steps: int = 10,
+        viz_callback: Callable[["GARfVDBTrainer", int], None] | None = None,
+        cache_dataset: bool = True,
+        reconstruction_metadata: dict[str, Any] | None = None,
+    ) -> "GARfVDBTrainer":
+        """
+        Create a `GARfVDBTrainer` instance for a new training run.
+
+        Args:
+            sfm_scene (SfmScene): The SfmScene to train on.
+            gs_model (GaussianSplat3d): The optimized GaussianSplat3d model.
+            gs_model_path (pathlib.Path): Path to the GaussianSplat3d model file.
+            writer (GARfVDBWriter): The writer to use for logging and saving results.
+            config (GARfVDBTrainingConfig): Configuration object containing model parameters.
+            device (str | torch.device): The device to run the model on (e.g., "cuda" or "cpu").
+            use_every_n_as_val (int): Use every nth image as validation data.
+            exclude_indices (Sequence[int] | None): Indices to exclude from both training and validation.
+                These images will still be used for computing scale statistics but won't be trained on.
+                This is useful for excluding test/evaluation images from training (e.g., NVOS benchmark).
+            viewer_update_interval_epochs (int): How often to update the viewer.
+            log_interval_steps (int): How often to log metrics to TensorBoard.
+            viz_callback (Callable | None): Optional callback function called at epoch boundaries for visualization.
+                The callback receives the runner instance and the current epoch number.
+            cache_dataset (bool): If True, cache images and masks in memory to speed up data loading.
+                Set to False to reduce memory usage for large datasets. Default is True.
+
+        Returns:
+            GARfVDBTrainer: A `GARfVDBTrainer` instance initialized with the specified configuration and datasets.
+        """
+
+        np.random.seed(config.seed)
+        random.seed(config.seed)
+        torch.manual_seed(config.seed)
+        if not config.model.use_grid:
+            raise ValueError("First-class GARfVDB training requires GARfVDBConfig.use_grid=True")
+
+        logger = logging.getLogger(f"{cls.__module__}.{cls.__name__}")
+
+        ## SfmScene
+        ## Split into train and validation sets
+        indices = np.arange(sfm_scene.num_images)
+
+        # Exclude specified indices (e.g., test images for evaluation benchmarks)
+        if exclude_indices is not None and len(exclude_indices) > 0:
+            exclude_set = set(exclude_indices)
+            indices = np.array([i for i in indices if i not in exclude_set], dtype=int)
+            logger.info(f"Excluding {len(exclude_indices)} images from training: {list(exclude_indices)}")
+
+        if use_every_n_as_val > 0:
+            mask = np.ones(len(indices), dtype=bool)
+            mask[::use_every_n_as_val] = False
+            train_indices = indices[mask]
+            val_indices = indices[~mask]
+        else:
+            train_indices = indices
+            val_indices = np.array([], dtype=int)
+
+        ## SegmentationDataset transforms
+        # For training, randomly sample pixels from each image
+        # Note: RandomSelectMaskIDAndScale is applied on GPU after data transfer for better performance
+        train_transforms = torchvision.transforms.Compose(
+            [
+                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=0.0),
+            ]
+        )
+        val_transforms = torchvision.transforms.Compose(
+            [
+                RandomSamplePixels(config.sample_pixels_per_image),
+            ]
+        )
+        # For testing, use the full image, scaled down for memory reasons
+        # test_dataset = TransformedSegmentationDataset(test_dataset, Compose([Resize(1 / 6), RandomSelectMaskIDAndScale()]))
+
+        ## Initialize Model
+        # Scale grouping stats
+        full_dataset = SegmentationDataset(
+            sfm_scene,
+            cache_loaded_masks=cache_dataset,
+            cache_images=cache_dataset,
+        )
+        grouping_scale_stats = full_dataset.scales
+
+        gs_model = filter_splats_above_scale(gs_model, 0.1)
+        # gs_model = filter_splat_means(gs_model, [0.95, 0.95, 0.95, 0.95, 0.95, 0.999])
+
+        model = GARfVDBTrainer._init_model(config.model, gs_model, grouping_scale_stats, device)
+        logger.info(f"Model initialized with {gs_model.num_gaussians:,} Gaussians")
+
+        ## Initialize Optimizer
+        base_lr = 1e-5
+        lr = base_lr
+        if config.scale_lr_with_batch_size and config.batch_size > 1:
+            lr = base_lr * math.sqrt(config.batch_size)
+            logger.info(f"Scaled LR from {base_lr:.2e} to {lr:.2e} (sqrt({config.batch_size}) scaling)")
+        optimizer = torch.optim.Adam(
+            params=model.parameters(),
+            lr=lr,
+            eps=1e-15,
+            weight_decay=1e-6,
+        )
+
+        scheduler = ExponentialLRWithRampUpScheduler(
+            optimizer=optimizer,
+            lr_init=lr,
+            lr_final=1e-6,
+        )
+
+        return GARfVDBTrainer(
+            model=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            config=config,
+            gs_model=gs_model,
+            gs_model_path=gs_model_path,
+            sfm_scene=sfm_scene,
+            train_indices=train_indices,
+            val_indices=val_indices,
+            train_transform=train_transforms,
+            val_transform=val_transforms,
+            writer=writer,
+            log_interval_steps=log_interval_steps,
+            viewer_update_interval_epochs=viewer_update_interval_epochs,
+            start_step=0,
+            viz_callback=viz_callback,
+            cache_dataset=cache_dataset,
+            reconstruction_metadata=reconstruction_metadata,
+            _private=GARfVDBTrainer.__PRIVATE__,
+        )
+
+    @classmethod
+    def from_state_dict(
+        cls,
+        state_dict: dict[str, Any],
+        gs_model: GaussianSplat3d,
+        gs_model_path: pathlib.Path,
+        writer: GARfVDBWriter | None = None,
+        device: str | torch.device = "cuda",
+        eval_only: bool = False,
+    ) -> "GARfVDBTrainer":
+        """
+        Load a :class:`GARfVDBTrainer` instance from a state dictionary.
+
+        This method restores the model, optimizer, SfmScene (with correct transforms/scales), and configuration
+        from a checkpoint. The restored SfmScene contains the correct scale statistics that were used during training.
+
+        Args:
+            state_dict (dict): State dictionary containing the model, optimizer, and configuration state.
+                Generated by the :meth:`state_dict` method.
+            gs_model (GaussianSplat3d): GaussianSplat3d model.
+            gs_model_path (pathlib.Path): Path to the GaussianSplat3d model.
+            writer (GARfVDBWriter | None): Optional writer for logging. If None, a default
+                writer with no output will be used.
+            device (str | torch.device): Device to load the model onto.
+            eval_only (bool): If True, disables gradients on all model parameters for evaluation only.
+                This is useful when loading for visualization where training is not needed.
+
+        Returns:
+            GARfVDBTrainer: A restored instance ready for evaluation or continued training.
+        """
+        logger = logging.getLogger(f"{cls.__module__}.{cls.__name__}")
+
+        # Validate checkpoint
+        magic = state_dict.get("magic")
+        if magic != cls._magic:
+            raise ValueError(f"State dict has invalid GARfVDB magic value: {magic!r}")
+        if state_dict.get("version") != cls.version:
+            raise ValueError(
+                f"Checkpoint version {state_dict.get('version')!r} does not match supported version {cls.version!r}."
+            )
+        if not isinstance(state_dict.get("step", None), int):
+            raise ValueError("Checkpoint step is missing or invalid.")
+        if not isinstance(state_dict.get("config", None), dict):
+            raise ValueError("Checkpoint config is missing or invalid.")
+        if not isinstance(state_dict.get("sfm_scene", None), dict):
+            raise ValueError("Checkpoint SfM scene is missing or invalid.")
+        if not isinstance(state_dict.get("model", None), dict):
+            raise ValueError("Checkpoint model state is missing or invalid.")
+        if not isinstance(state_dict.get("optimizer", None), dict):
+            raise ValueError("Checkpoint optimizer state is missing or invalid.")
+        if not isinstance(state_dict.get("train_indices", None), (list, np.ndarray, torch.Tensor)):
+            raise ValueError("Checkpoint train indices are missing or invalid.")
+        if not isinstance(state_dict.get("val_indices", None), (list, np.ndarray, torch.Tensor)):
+            raise ValueError("Checkpoint val indices are missing or invalid.")
+
+        global_step = state_dict["step"]
+        config_state = dict(state_dict["config"])
+        model_config_state = config_state.get("model", {})
+        if isinstance(model_config_state, dict):
+            config_state["model"] = GARfVDBConfig(**model_config_state)
+        config = GARfVDBTrainingConfig(**config_state)
+
+        np.random.seed(config.seed)
+        random.seed(config.seed)
+        torch.manual_seed(config.seed)
+
+        # Restore SfmScene (this is the transformed scene with correct scales)
+        sfm_scene: SfmScene = SfmScene.from_state_dict(state_dict["sfm_scene"])
+        logger.info(f"Restored SfmScene with {sfm_scene.num_images} images")
+
+        # Disable gradients on GS model tensors if eval_only
+        if eval_only:
+            gs_model.means.detach_()
+            gs_model.quats.detach_()
+            gs_model.log_scales.detach_()
+            gs_model.logit_opacities.detach_()
+            gs_model.sh0.detach_()
+            gs_model.shN.detach_()
+
+        # Get train/val indices
+        train_indices = np.array(state_dict["train_indices"], dtype=int)
+        val_indices = np.array(state_dict["val_indices"], dtype=int)
+
+        # Get scale statistics from the checkpoint (saved during training)
+        if "grouping_scale_stats" not in state_dict:
+            raise ValueError(
+                "Checkpoint is missing 'grouping_scale_stats'. Please retrain to generate a new checkpoint."
+            )
+        grouping_scale_stats = state_dict["grouping_scale_stats"]
+        if isinstance(grouping_scale_stats, np.ndarray):
+            grouping_scale_stats = torch.from_numpy(grouping_scale_stats)
+        grouping_scale_stats = grouping_scale_stats.to(device)
+        logger.info(f"Restored grouping_scale_stats with {len(grouping_scale_stats)} entries")
+
+        # Initialize model from state dict
+        model = GARfVDBModel.create_from_state_dict(state_dict["model"], config.model, gs_model, grouping_scale_stats)
+        model.to(device)
+        model.eval()
+
+        # Disable gradients on all model parameters if eval_only
+        if eval_only:
+            for param in model.parameters():
+                param.requires_grad_(False)
+            logger.info("Restored GARfVDB segmentation model (eval mode, gradients disabled)")
+        else:
+            logger.info("Restored GARfVDB segmentation model")
+
+        # Create transforms (same as in new())
+        train_transforms = torchvision.transforms.Compose(
+            [
+                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=0.0),
+                RandomSelectMaskIDAndScale(),
+            ]
+        )
+        val_transforms = torchvision.transforms.Compose(
+            [
+                RandomSamplePixels(config.sample_pixels_per_image),
+                RandomSelectMaskIDAndScale(),
+            ]
+        )
+
+        # Initialize optimizer
+        base_lr = 1e-5
+        lr = base_lr
+        if config.scale_lr_with_batch_size and config.batch_size > 1:
+            lr = base_lr * math.sqrt(config.batch_size)
+            logger.info(f"Scaled LR from {base_lr:.2e} to {lr:.2e} (sqrt({config.batch_size}) scaling)")
+        optimizer = torch.optim.Adam(
+            params=model.parameters(),
+            lr=lr,
+            eps=1e-15,
+            weight_decay=1e-6,
+        )
+        optimizer.load_state_dict(state_dict["optimizer"])
+
+        # Create scheduler using the LR restored from the checkpoint
+        restored_lr = optimizer.param_groups[0]["lr"]
+        scheduler = ExponentialLRWithRampUpScheduler(
+            optimizer=optimizer,
+            lr_init=restored_lr,
+            lr_final=1e-6,
+        )
+        scheduler_state = state_dict.get("scheduler")
+        if scheduler_state is not None:
+            scheduler.load_state_dict(scheduler_state)
+
+        # Create default writer if not provided
+        if writer is None:
+            writer = GARfVDBWriter(run_name=None, save_path=None)
+
+        logger.info(f"Restored from checkpoint at step {global_step}")
+
+        return GARfVDBTrainer(
+            model=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            config=config,
+            gs_model=gs_model,
+            gs_model_path=gs_model_path,
+            sfm_scene=sfm_scene,
+            train_indices=train_indices,
+            val_indices=val_indices,
+            train_transform=train_transforms,
+            val_transform=val_transforms,
+            writer=writer,
+            log_interval_steps=10,
+            viewer_update_interval_epochs=-1,
+            start_step=global_step,
+            grouping_scale_stats=grouping_scale_stats,
+            reconstruction_metadata=state_dict.get("reconstruction_metadata", {}),
+            _private=GARfVDBTrainer.__PRIVATE__,
+        )
+
+    @classmethod
+    def load_checkpoint_state(
+        cls, checkpoint_path: pathlib.Path, map_location: str | torch.device = "cpu"
+    ) -> dict[str, Any]:
+        """Load a first-class GARfVDB training checkpoint dictionary."""
+        return load_training_checkpoint(
+            checkpoint_path,
+            map_location=map_location,
+            expected_method=GARFVDB_TRAINING_METHOD,
+        ).state
+
+    @classmethod
+    def from_checkpoint_file(
+        cls,
+        checkpoint_path: pathlib.Path,
+        *,
+        writer: GARfVDBWriter | None = None,
+        device: str | torch.device = "cuda",
+        reconstruction_path: pathlib.Path | None = None,
+    ) -> "GARfVDBTrainer":
+        """Restore a trainer and its carrier from a checkpoint path."""
+        checkpoint = cls.load_checkpoint_state(checkpoint_path, map_location=device)
+        return cls.from_checkpoint_state(
+            checkpoint,
+            writer=writer,
+            device=device,
+            reconstruction_path=reconstruction_path,
+        )
+
+    @classmethod
+    def from_checkpoint_state(
+        cls,
+        checkpoint: dict[str, Any],
+        *,
+        writer: GARfVDBWriter | None = None,
+        device: str | torch.device = "cuda",
+        reconstruction_path: pathlib.Path | None = None,
+    ) -> "GARfVDBTrainer":
+        """Restore a trainer and carrier from already loaded method state."""
+        from fvdb_reality_capture.radiance_fields import load_splats_from_file
+
+        stored_path = checkpoint.get("gs_model_path")
+        carrier_path = reconstruction_path or (pathlib.Path(stored_path) if stored_path is not None else None)
+        if carrier_path is None:
+            raise ValueError("Checkpoint has no reconstruction path; pass reconstruction_path explicitly.")
+        if not carrier_path.exists():
+            raise FileNotFoundError(
+                f"Reconstruction referenced by GARfVDB checkpoint does not exist: {carrier_path}. "
+                "Pass --reconstruction-path if it moved."
+            )
+        gs_model, metadata = load_splats_from_file(carrier_path, device)
+        gs_model = filter_splats_above_scale(gs_model, checkpoint.get("carrier_filter_threshold", 0.1))
+        expected_count = checkpoint.get("carrier_num_gaussians")
+        if expected_count is not None and gs_model.num_gaussians != expected_count:
+            raise ValueError(
+                f"Reconstructed carrier has {gs_model.num_gaussians} Gaussians; checkpoint expects {expected_count}."
+            )
+        expected_hash = checkpoint.get("carrier_means_sha256")
+        actual_hash = hashlib.sha256(gs_model.means.detach().cpu().contiguous().numpy().tobytes()).hexdigest()
+        if expected_hash is not None and actual_hash != expected_hash:
+            raise ValueError("Reconstructed carrier ordering/content does not match the GARfVDB checkpoint")
+        checkpoint["reconstruction_metadata"] = checkpoint.get("reconstruction_metadata", metadata)
+        return cls.from_state_dict(
+            checkpoint,
+            gs_model=gs_model,
+            gs_model_path=carrier_path,
+            writer=writer,
+            device=device,
+        )
+
+    def to_product(self) -> "GARfVDB":
+        """Create the portable inference product represented by the trained state."""
+        from fvdb_reality_capture.instance_segmentation.garfvdb import GARfVDB
+
+        return GARfVDB(model=self._model, reconstruction_metadata=self._reconstruction_metadata)
+
+    def train(self, show_progress: bool = True, log_tag: str = "train"):
+        if self._optimizer is None:
+            raise ValueError("This runner was not created with an optimizer. Cannot run training.")
+        logging.debug(f"Training with batch size {self._cfg.batch_size}")
+
+        # Pre-warm the cache BEFORE creating DataLoader workers
+        # Workers inherit the populated cache via fork, eliminating disk I/O during training
+        with nvtx.range("dataset_warmup_cache"):
+            self._training_dataset.warmup_cache()
+
+        # Scale num_workers based on dataset size to avoid IPC overhead dominating
+        # Even for small datasets, use a few workers to overlap CPU transforms with GPU training
+        dataset_size = len(self._training_dataset)
+        if dataset_size <= self._cfg.batch_size * 2:
+            num_workers = 2
+            self._logger.info(f"Small dataset ({dataset_size} images): using num_workers=2")
+        elif dataset_size <= 64:
+            # Small dataset: limit workers to avoid contention
+            num_workers = min(4, os.cpu_count() or 4)
+        else:
+            num_workers = min(8, os.cpu_count() or 4)
+
+        # Use InfiniteSampler to avoid pauses at epoch boundaries
+        # The sampler never stops, so we track epochs by counting batches
+        infinite_sampler = InfiniteSampler(self._training_dataset, shuffle=True, seed=self._cfg.seed)
+
+        # Use collate function with mask_cdf included for GPU-based mask selection
+        from functools import partial
+
+        collate_fn = partial(GARfVDBInputCollateFn, include_mask_cdf=True)
+
+        # For small datasets, use smaller prefetch to avoid wraparound thrashing
+        prefetch = 2 if num_workers > 0 else None
+        if num_workers > 0 and dataset_size < self._cfg.batch_size * 4:
+            prefetch = 1  # Reduce prefetch for tiny datasets
+
+        trainloader = torch.utils.data.DataLoader(
+            self._training_dataset,
+            batch_size=self._cfg.batch_size,
+            sampler=infinite_sampler,  # Use infinite sampler instead of shuffle
+            num_workers=num_workers,
+            persistent_workers=True if num_workers > 0 else False,
+            pin_memory=True,
+            prefetch_factor=prefetch,
+            collate_fn=collate_fn,
+        )
+
+        # GPU transform for mask selection (moved from CPU for better performance)
+        gpu_mask_transform = GPURandomSelectMaskIDAndScale()
+
+        self._model.train()
+        self._optimizer.zero_grad()
+
+        pbar = tqdm.tqdm(range(self.total_steps), desc="Training")
+
+        # Gradient accumulation settings
+        gradient_accumulation_steps = self._cfg.accumulate_grad_steps
+        # Track accumulated loss as a tensor to avoid .item() sync on every step
+        accumulated_loss: torch.Tensor | float = 0.0
+
+        # Zero out gradients before training in case we resume training
+        self._optimizer.zero_grad()
+
+        # Track epochs by samples processed (global_step), not batches
+        # This correctly aligns with how InfiniteSampler yields exactly dataset_size indices per epoch
+        samples_per_epoch = len(self._training_dataset)
+        prev_epoch = -1
+
+        trainloader_iter = iter(trainloader)
+        step = 0
+        while True:
+            with nvtx.range("dataloader_fetch_batch"):
+                try:
+                    minibatch = next(trainloader_iter)
+                except StopIteration:
+                    break
+
+            batch_size = minibatch["image"].shape[0]
+
+            # Skip steps before the start step
+            if self._global_step < self._start_step:
+                if pbar is not None:
+                    pbar.set_description(
+                        f"Skipping step {self._global_step:,} (before start step {self._start_step:,})"
+                    )
+                    pbar.update(batch_size)
+                    self._global_step = pbar.n
+                else:
+                    self._global_step += batch_size
+                continue
+
+            # Move to device
+            with nvtx.range("data_to_device"):
+                minibatch = minibatch.to(self.device)
+
+            # Apply GPU-accelerated mask transform
+            with nvtx.range("gpu_mask_transform"):
+                minibatch = gpu_mask_transform(minibatch)
+
+            # Debug prints for first iteration
+            if step == 0:
+                logging.debug(f"Training with sample_pixels_per_image={self._cfg.sample_pixels_per_image}")
+                logging.debug(f"Batch size: {minibatch['image'].shape[0]}")
+                logging.debug(f"scales shape: {minibatch['scales'].shape}")
+                logging.debug(f"mask_ids shape: {minibatch['mask_ids'].shape}")
+                if "pixel_coords" in minibatch and minibatch["pixel_coords"] is not None:
+                    logging.debug(f"pixel_coords shape: {minibatch['pixel_coords'].shape}")
+                logging.debug(f"mean2d shape: {self._model.gs_model.means.shape}")
+                logging.debug(f"Using gradient accumulation over {gradient_accumulation_steps} steps")
+
+            ### Forward pass ###
+            with nvtx.range("forward_pass"):
+                cam_enc_feats = self._model.get_encoded_features(minibatch)
+                logging.debug(f"Cam enc feats shape: {cam_enc_feats.shape}")
+
+            with nvtx.range("loss_calculation"):
+                loss_dict = calculate_loss(self._model, cam_enc_feats, minibatch)
+                loss = loss_dict["total_loss"]
+                logging.debug(f"Loss: {loss.item()}")
+
+            # Scale loss by accumulation steps to maintain same effective learning rate
+            loss = loss / gradient_accumulation_steps
+            # Accumulate as tensor to avoid .item() sync on every step
+            accumulated_loss = accumulated_loss + loss.detach()
+
+            # Zero gradients only at the beginning of accumulation cycle
+            if step % gradient_accumulation_steps == 0:
+                self._optimizer.zero_grad()
+            logging.debug(f"Backward pass")
+            with nvtx.range("backward_pass"):
+                loss.backward()
+
+            # Perform optimizer step and gradient clipping only after accumulating gradients
+            if (step + 1) % gradient_accumulation_steps == 0:
+                logging.debug(f"Optimizer step")
+                with nvtx.range("optimizer_step"):
+                    if self._cfg.grad_clip_max_norm is not None:
+                        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self._cfg.grad_clip_max_norm)
+                    self._optimizer.step()
+                    self._scheduler.step()
+
+                # Reset accumulated loss
+                accumulated_loss = 0.0
+
+            ## Logging and checkpointing
+            # Log train metrics
+            if self._global_step % self._log_interval_steps == 0:
+                display_loss = loss.item() * gradient_accumulation_steps
+                # For display purposes, show the scaled loss
+                pbar.set_postfix(loss=f"{display_loss:.4g}")
+
+                mem_allocated = torch.cuda.memory_allocated(self.device) / (1024**3)
+                mem_reserved = torch.cuda.memory_reserved(self.device) / (1024**3)
+                self._writer.log_metric(self._global_step, f"{log_tag}/loss", display_loss)
+                self._writer.log_metric(self._global_step, f"{log_tag}/mem_allocated", mem_allocated)
+                self._writer.log_metric(self._global_step, f"{log_tag}/mem_reserved", mem_reserved)
+
+            # Update the progress bar and global step
+            if pbar is not None:
+                pbar.update(batch_size)
+                self._global_step = pbar.n
+            else:
+                self._global_step += batch_size
+
+            # Calculate current epoch from samples processed
+            epoch = self._global_step // samples_per_epoch
+
+            # Check for epoch boundary - run save/eval only once per epoch transition
+            if epoch > prev_epoch:
+                prev_epoch = epoch
+
+                # Update visualization if enabled
+                if (
+                    self._viz_callback is not None
+                    and self._viewer_update_interval_epochs > 0
+                    and epoch % self._viewer_update_interval_epochs == 0
+                ):
+                    try:
+                        self._viz_callback(self, epoch)
+                    except Exception as e:
+                        self._logger.warning(f"Visualization callback failed: {e}")
+
+                # Save the model if we've reached a percentage of the total epochs specified in save_at_percent
+                if epoch in [pct * self._cfg.max_epochs // 100 for pct in self._cfg.save_at_percent]:
+                    logging.info(f"Saving checkpoint at epoch {epoch}")
+                    logging.info(f"Global step: {self._global_step}")
+                    if self._global_step > self._start_step:
+                        self._logger.info(f"Saving checkpoint at global step {self._global_step}.")
+                        self._writer.save_checkpoint(self._global_step, f"{log_tag}_ckpt.pt", self.state_dict())
+
+                # Run evaluation if we've reached a percentage of the total epochs specified in eval_at_percent
+                if epoch in [pct * self._cfg.max_epochs // 100 for pct in self._cfg.eval_at_percent]:
+                    logging.info(f"Running evaluation at epoch {epoch}")
+                    if len(self._validation_dataset) > 0 and self._global_step > self._start_step:
+                        self.eval(log_tag=log_tag + "_eval")
+
+            # Check if we've reached max_steps or max_epochs
+            if self._cfg.max_steps is not None and self._global_step >= self._cfg.max_steps:
+                logging.debug(f"Reached max steps: {self._cfg.max_steps}")
+                break
+            if epoch >= self._cfg.max_epochs:
+                logging.debug(f"Reached max epochs: {self._cfg.max_epochs}")
+                break
+
+            step += 1
+
+        self._logger.info("Training completed.")
+
+    @torch.inference_mode()
+    def eval(self, log_tag: str = "eval") -> None:
+        """
+        Run evaluation of the Gaussian Splatting model on the validation dataset.
+
+        Args:
+            log_tag (str): The tag to use for logging the evaluation results.
+        """
+        self._logger.info("Running evaluation...")
+
+        valloader = torch.utils.data.DataLoader(
+            self._validation_dataset,
+            batch_size=1,
+            shuffle=False,
+            num_workers=1,
+            collate_fn=lambda batch: GARfVDBInputCollateFn(batch, collate_full_image=True, include_mask_cdf=True),
+        )
+
+        # GPU transform for mask selection
+        gpu_mask_transform = GPURandomSelectMaskIDAndScale()
+
+        ## Log metrics
+        metrics = {"psnr": [], "loss": []}
+        for val_batch in valloader:
+            val_batch = val_batch.to(self.device)
+            val_batch = gpu_mask_transform(val_batch)
+            with nvtx.range("eval_forward_pass"):
+                val_enc_feats = self._model.get_encoded_features(val_batch)
+            with nvtx.range("eval_loss_calculation"):
+                val_loss_dict = calculate_loss(self._model, val_enc_feats, val_batch)
+            metrics["loss"].append(val_loss_dict["total_loss"])
+
+        loss_mean = torch.stack(metrics["loss"]).mean().cpu()
+
+        self._logger.info(f"Evaluation for stage {log_tag} completed. Average loss: {loss_mean.item():.3f}")
+
+        self._writer.log_metric(self._global_step, f"{log_tag}/loss", loss_mean.item())
+
+        # Clean up memory because no-grid rendering is memory intensive
+        del loss_mean, metrics
+        torch.cuda.empty_cache()
+
+        ## Validation image
+        val_batch = next(iter(valloader)).to(self.device)
+        val_batch = gpu_mask_transform(val_batch)
+
+        world_to_cam_matrix = val_batch["world_to_camera"]
+        projection_matrix = val_batch["projection"]
+        beauty_gt = val_batch["image_full"]
+        img_w, img_h = val_batch["image_w"][0], val_batch["image_h"][0]
+        with nvtx.range("eval_render_beauty"):
+            beauty_output, _ = self.gs_model.render_images(
+                world_to_cam_matrix,
+                projection_matrix,
+                img_w,
+                img_h,
+                0.01,
+                1e10,
+            )
+        # Ground truth and rendered image for reference
+        beauty_output = torch.clamp(beauty_output, 0.0, 1.0)
+
+        # scale image to 1/2 size
+        def downscale(image: torch.Tensor) -> torch.Tensor:
+            return tvF.resize(image.permute(0, 3, 1, 2), size=[img_h // 2, img_w // 2], antialias=True).permute(
+                0, 2, 3, 1
+            )
+
+        # Save reference images to step 0 (they don't change during training)
+        self._writer.save_image(0, f"{log_tag}/beauty_image.jpg", downscale(beauty_output).cpu())
+        self._writer.save_image(0, f"{log_tag}/ground_truth_image.jpg", downscale(beauty_gt).cpu())
+
+        # Mask outputs at 10% of the maximum scale
+        desired_scale = torch.max(val_batch["scales"]) * 0.1
+
+        with nvtx.range("eval_get_mask_output"):
+            val_mask_output, mask_alpha = self._model.get_mask_output(val_batch, desired_scale.item())
+        logging.debug(f"mask_alpha zeros: {mask_alpha.sum()}")
+
+        with nvtx.range("eval_pca_projection"):
+            pca_output = pca_projection_fast(val_mask_output, 3, mask=mask_alpha.squeeze(-1) > 0)
+        pca_output = pca_output.clamp(0.0, 1.0)  # [B, H, W, 3]
+        self._writer.save_image(self._global_step, f"{log_tag}/mask.jpg", downscale(pca_output).cpu())
+        alpha = 0.7
+        blended = beauty_output * (1 - alpha) + pca_output * alpha
+
+        self._writer.save_image(self._global_step, f"{log_tag}/mask_beauty_blended.jpg", downscale(blended).cpu())
+
+        # # Log test loss images
+        # if self.config.log_test_images:
+        #     with torch.no_grad():
+        #         for test_batch_idx, test_batch in enumerate(testloader):
+        #             if test_batch_idx != 0:
+        #                 break
+
+        #             # Log the image
+        #             # Permute from [H, W, C] to [C, H, W] for TensorBoard
+        #             test_image = test_batch["image"][0].cpu().permute(2, 0, 1)
+        #             self.writer.add_image("test/sample_image", test_image, step)
+        #             # Move input to device
+        #             for k, v in test_batch.items():
+        #                 test_batch[k] = v.to(self.device)
+        #             # Set scales to 0.1
+        #             test_batch["scales"] = torch.full_like(test_batch["scales"], 0.05)
+        #             test_enc_feats = self.model.get_encoded_features(test_batch)
+
+        #             # NOTE: If this starts using too much memory, we can move the image loss calculation to the CPU
+        #             test_loss_dict = calculate_loss(self.model, test_enc_feats, test_batch, return_loss_images=True)
+        #             for key in ("instance_loss_1", "instance_loss_2", "instance_loss_4"):
+        #                 self.writer.add_image(f"test/{key}_img", test_loss_dict[f"{key}_img"].detach().cpu(), step)
+        #             self.model.to(self.device)
+
+    @torch.no_grad()
+    def state_dict(self) -> dict[str, Any]:
+        """
+        Get the state dictionary of the current training state, including model, optimizer, and training parameters.
+
+        Returns:
+            dict: A dictionary containing the state of the training process. Its keys include:
+                - magic: A magic string to identify the checkpoint type.
+                - version: The version of the checkpoint format.
+                - step: The current global training step.
+                - config: The configuration parameters used for training.
+                - sfm_scene: The state dictionary of the SfM scene.
+                - gs_model_path: Path to the GaussianSplat3d model file.
+                - grouping_scale_stats: The scale statistics of the GaussianSplat3d model.
+                - model: The state dictionary of the Gaussian Splatting model.
+                - optimizer: The state dictionary of the optimizer.
+                - train_indices: The indices of the training dataset.
+                - val_indices: The indices of the validation dataset.
+        """
+        return {
+            "magic": self._magic,
+            "version": self.version,
+            "step": self._global_step,
+            "config": asdict(self._cfg),
+            "sfm_scene": self._sfm_scene.state_dict(),
+            "gs_model_path": self._gs_model_path,
+            "reconstruction_metadata": self._reconstruction_metadata,
+            "carrier_filter_threshold": 0.1,
+            "carrier_num_gaussians": self._gs_model.num_gaussians,
+            "carrier_means_sha256": self._carrier_means_sha256,
+            "grouping_scale_stats": self._grouping_scale_stats.cpu(),
+            "model": self._model.state_dict(),
+            "optimizer": self._optimizer.state_dict(),
+            "scheduler": self._scheduler.state_dict(),
+            "train_indices": self._training_dataset.indices,
+            "val_indices": self._validation_dataset.indices,
+        }
+
+
+__all__ = ["GARfVDBTrainer"]

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -223,7 +223,7 @@ class GARfVDBTrainer:
         self._gs_model = gs_model
         self._gs_model_path = gs_model_path
         self._reconstruction_metadata = dict(reconstruction_metadata or {})
-        self._carrier_means_sha256 = hashlib.sha256(
+        self._gaussian_means_sha256 = hashlib.sha256(
             gs_model.means.detach().cpu().contiguous().numpy().tobytes()
         ).hexdigest()
 
@@ -713,7 +713,7 @@ class GARfVDBTrainer:
         device: str | torch.device = "cuda:0",
         reconstruction_path: pathlib.Path | None = None,
     ) -> "GARfVDBTrainer":
-        """Restore a trainer and its carrier from a checkpoint path."""
+        """Restore a trainer and its gaussians from a checkpoint path."""
         checkpoint = cls.load_checkpoint_state(checkpoint_path, map_location=device)
         return cls.from_checkpoint_state(
             checkpoint,
@@ -731,34 +731,34 @@ class GARfVDBTrainer:
         device: str | torch.device = "cuda:0",
         reconstruction_path: pathlib.Path | None = None,
     ) -> "GARfVDBTrainer":
-        """Restore a trainer and carrier from already loaded method state."""
+        """Restore a trainer and gaussians from already loaded method state."""
         from fvdb_reality_capture.radiance_fields import load_splats_from_file
 
         stored_path = checkpoint.get("gs_model_path")
-        carrier_path = reconstruction_path or (pathlib.Path(stored_path) if stored_path is not None else None)
-        if carrier_path is None:
+        gaussians_path = reconstruction_path or (pathlib.Path(stored_path) if stored_path is not None else None)
+        if gaussians_path is None:
             raise ValueError("Checkpoint has no reconstruction path; pass reconstruction_path explicitly.")
-        if not carrier_path.exists():
+        if not gaussians_path.exists():
             raise FileNotFoundError(
-                f"Reconstruction referenced by GARfVDB checkpoint does not exist: {carrier_path}. "
+                f"Reconstruction referenced by GARfVDB checkpoint does not exist: {gaussians_path}. "
                 "Pass --reconstruction-path if it moved."
             )
-        gs_model, metadata = load_splats_from_file(carrier_path, device)
-        gs_model = filter_splats_above_scale(gs_model, checkpoint.get("carrier_filter_threshold", 0.1))
-        expected_count = checkpoint.get("carrier_num_gaussians")
+        gs_model, metadata = load_splats_from_file(gaussians_path, device)
+        gs_model = filter_splats_above_scale(gs_model, checkpoint.get("gaussian_filter_threshold", 0.1))
+        expected_count = checkpoint.get("num_gaussians")
         if expected_count is not None and gs_model.num_gaussians != expected_count:
             raise ValueError(
-                f"Reconstructed carrier has {gs_model.num_gaussians} Gaussians; checkpoint expects {expected_count}."
+                f"Reconstructed model has {gs_model.num_gaussians} Gaussians; checkpoint expects {expected_count}."
             )
-        expected_hash = checkpoint.get("carrier_means_sha256")
+        expected_hash = checkpoint.get("gaussian_means_sha256")
         actual_hash = hashlib.sha256(gs_model.means.detach().cpu().contiguous().numpy().tobytes()).hexdigest()
         if expected_hash is not None and actual_hash != expected_hash:
-            raise ValueError("Reconstructed carrier ordering/content does not match the GARfVDB checkpoint")
+            raise ValueError("Reconstructed Gaussian ordering/content does not match the GARfVDB checkpoint")
         checkpoint["reconstruction_metadata"] = checkpoint.get("reconstruction_metadata", metadata)
         return cls.from_state_dict(
             checkpoint,
             gs_model=gs_model,
-            gs_model_path=carrier_path,
+            gs_model_path=gaussians_path,
             writer=writer,
             device=device,
         )
@@ -1169,9 +1169,9 @@ class GARfVDBTrainer:
             "sfm_scene": self._sfm_scene.state_dict(),
             "gs_model_path": self._gs_model_path,
             "reconstruction_metadata": self._reconstruction_metadata,
-            "carrier_filter_threshold": 0.1,
-            "carrier_num_gaussians": self._gs_model.num_gaussians,
-            "carrier_means_sha256": self._carrier_means_sha256,
+            "gaussian_filter_threshold": 0.1,
+            "num_gaussians": self._gs_model.num_gaussians,
+            "gaussian_means_sha256": self._gaussian_means_sha256,
             "grouping_scale_stats": self._grouping_scale_stats.cpu(),
             "model": self._model.state_dict(),
             "optimizer": self._optimizer.state_dict(),

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -17,7 +17,7 @@ import torch.cuda.nvtx as nvtx
 import torchvision
 import torchvision.transforms.functional as tvF
 import tqdm
-from fvdb import GaussianSplat3d
+from fvdb_reality_capture.radiance_fields.gaussian_splatting import GaussianSplat3d
 from fvdb_reality_capture.checkpoints import load_training_checkpoint
 from fvdb_reality_capture.sfm_scene import SfmScene
 from fvdb_reality_capture.tools import filter_splats_above_scale

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -371,7 +371,7 @@ class GARfVDBTrainer:
         # Note: RandomSelectMaskIDAndScale is applied on GPU after data transfer for better performance
         train_transforms = torchvision.transforms.Compose(
             [
-                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=0.0),
+                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=config.scale_bias_strength),
             ]
         )
         val_transforms = torchvision.transforms.Compose(
@@ -555,7 +555,7 @@ class GARfVDBTrainer:
         # Create transforms (same as in new())
         train_transforms = torchvision.transforms.Compose(
             [
-                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=0.0),
+                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=config.scale_bias_strength),
                 RandomSelectMaskIDAndScale(),
             ]
         )

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -37,7 +37,6 @@ from fvdb_reality_capture.instance_segmentation.training.dataset import (
 from fvdb_reality_capture.instance_segmentation.training.dataset_transforms import (
     GPURandomSelectMaskIDAndScale,
     RandomSamplePixels,
-    RandomSelectMaskIDAndScale,
     TransformedSegmentationDataset,
 )
 from fvdb_reality_capture.instance_segmentation.training.segmentation_writer import GARfVDBWriter
@@ -45,6 +44,29 @@ from fvdb_reality_capture.instance_segmentation.util import pca_projection_fast
 
 if TYPE_CHECKING:
     from fvdb_reality_capture.instance_segmentation.garfvdb import GARfVDB
+
+
+def make_pixel_transforms(
+    config: GARfVDBTrainingConfig,
+) -> tuple[torchvision.transforms.Compose, torchvision.transforms.Compose]:
+    """Build the per-item dataset transforms for training and validation.
+
+    Both only sample pixels. Mask selection and scale interpolation run afterwards on the GPU
+    via ``GPURandomSelectMaskIDAndScale``, which needs the full ``[num_samples, MM]`` mask ids
+    and CDF, so the CPU ``RandomSelectMaskIDAndScale`` must not be applied here. Training may
+    bias sampling toward small-scale masks; validation always samples uniformly.
+    """
+    train_transforms = torchvision.transforms.Compose(
+        [
+            RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=config.scale_bias_strength),
+        ]
+    )
+    val_transforms = torchvision.transforms.Compose(
+        [
+            RandomSamplePixels(config.sample_pixels_per_image),
+        ]
+    )
+    return train_transforms, val_transforms
 
 
 class GARfVDBTrainer:
@@ -366,21 +388,7 @@ class GARfVDBTrainer:
             train_indices = indices
             val_indices = np.array([], dtype=int)
 
-        ## SegmentationDataset transforms
-        # For training, randomly sample pixels from each image
-        # Note: RandomSelectMaskIDAndScale is applied on GPU after data transfer for better performance
-        train_transforms = torchvision.transforms.Compose(
-            [
-                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=config.scale_bias_strength),
-            ]
-        )
-        val_transforms = torchvision.transforms.Compose(
-            [
-                RandomSamplePixels(config.sample_pixels_per_image),
-            ]
-        )
-        # For testing, use the full image, scaled down for memory reasons
-        # test_dataset = TransformedSegmentationDataset(test_dataset, Compose([Resize(1 / 6), RandomSelectMaskIDAndScale()]))
+        train_transforms, val_transforms = make_pixel_transforms(config)
 
         ## Initialize Model
         # Scale grouping stats
@@ -552,19 +560,7 @@ class GARfVDBTrainer:
         else:
             logger.info("Restored GARfVDB segmentation model")
 
-        # Create transforms (same as in new())
-        train_transforms = torchvision.transforms.Compose(
-            [
-                RandomSamplePixels(config.sample_pixels_per_image, scale_bias_strength=config.scale_bias_strength),
-                RandomSelectMaskIDAndScale(),
-            ]
-        )
-        val_transforms = torchvision.transforms.Compose(
-            [
-                RandomSamplePixels(config.sample_pixels_per_image),
-                RandomSelectMaskIDAndScale(),
-            ]
-        )
+        train_transforms, val_transforms = make_pixel_transforms(config)
 
         # Initialize optimizer
         base_lr = 1e-5

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -944,7 +944,8 @@ class GARfVDBTrainer:
             with nvtx.range("loss_calculation"):
                 loss_dict = calculate_loss(self._model, cam_enc_feats, minibatch)
                 loss = loss_dict["total_loss"]
-                logging.debug(f"Loss: {loss.item()}")
+                # Lazy formatting so the device sync only happens when debug logging is on.
+                logging.debug("Loss: %s", loss.detach())
 
             # Scale loss by accumulation steps to maintain same effective learning rate
             loss = loss / gradient_accumulation_steps
@@ -1111,7 +1112,7 @@ class GARfVDBTrainer:
 
         with nvtx.range("eval_get_mask_output"):
             val_mask_output, mask_alpha = self._model.get_mask_output(val_batch, desired_scale.item())
-        logging.debug(f"mask_alpha zeros: {mask_alpha.sum()}")
+        logging.debug("mask_alpha sum: %s", mask_alpha.sum())
 
         with nvtx.range("eval_pca_projection"):
             pca_output = pca_projection_fast(val_mask_output, 3, mask=mask_alpha.squeeze(-1) > 0)

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -47,63 +47,6 @@ if TYPE_CHECKING:
     from fvdb_reality_capture.instance_segmentation.garfvdb import GARfVDB
 
 
-class TensorboardLogger:
-    """Utility class for logging training metrics to TensorBoard."""
-
-    def __init__(
-        self,
-        log_dir: pathlib.Path,
-        log_every_step: int = 100,
-        log_images_to_tensorboard: bool = False,
-    ) -> None:
-        """Initialize TensorBoard logger.
-
-        Args:
-            log_dir: Directory to save TensorBoard event files.
-            log_every_step: Logging frequency in training steps.
-            log_images_to_tensorboard: Whether to log rendered images.
-        """
-        self._log_every_step = log_every_step
-        self._log_dir = log_dir
-        self._log_images_to_tensorboard = log_images_to_tensorboard
-        # Imported lazily so importing this module (and the fvdb_reality_capture package) does not require
-        # the optional `tensorboard` package unless TensorBoard logging is actually used. Mirrors the lazy
-        # import in segmentation_writer.py.
-        from torch.utils.tensorboard import SummaryWriter
-
-        self._tb_writer = SummaryWriter(log_dir=log_dir)
-
-    def log_training_iteration(
-        self,
-        step: int,
-        metrics: dict[str, torch.Tensor],
-        mem: float,
-        gt_img: torch.Tensor | None,
-        pred_img: torch.Tensor | None,
-    ):
-        """
-        Log training metrics to TensorBoard.
-
-        Args:
-            step: Current training step.
-            metrics: Dictionary of metrics to log.
-            mem: Maximum GPU memory allocated in GB.
-            gt_img: Ground truth image for visualization.
-            pred_img: Predicted image for visualization.
-        """
-        if self._log_every_step > 0 and step % self._log_every_step == 0 and self._tb_writer is not None:
-            mem = torch.cuda.max_memory_allocated() / 1024**3
-            # Log loss components to tensorboard
-            for key, value in metrics.items():
-                self._tb_writer.add_scalar(f"train/{key}", value.item(), step)
-            self._tb_writer.add_scalar("train/mem", mem, step)
-            if self._log_images_to_tensorboard and gt_img is not None and pred_img is not None:
-                canvas = torch.cat([gt_img, pred_img], dim=2).detach().cpu().numpy()
-                canvas = canvas.reshape(-1, *canvas.shape[2:])
-                self._tb_writer.add_image("train/render", canvas, step)
-            self._tb_writer.flush()
-
-
 class GARfVDBTrainer:
     """Training and evaluation engine for scale-conditioned Gaussian splat segmentation.
 

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation.py
@@ -103,33 +103,6 @@ class TensorboardLogger:
                 self._tb_writer.add_image("train/render", canvas, step)
             self._tb_writer.flush()
 
-    def log_evaluation_iteration(
-        self,
-        step: int,
-        loss: float,
-        beauty_output: torch.Tensor,
-        beauty_gt: torch.Tensor,
-        sample_mask: torch.Tensor,
-        sample_image: torch.Tensor,
-    ):
-        """
-        Log evaluation metrics to TensorBoard.
-
-        Args:
-            step: The training step after which the evaluation was performed.
-            loss: Loss value for the evaluation (averaged over all images in the validation set).
-            beauty_output: Gaussian splat rendered beauty output for the evaluation
-            beauty_gt: Ground truth beauty image from validation set for the evaluation
-            sample_mask: Mask for the evaluation
-            sample_image: Sample blended image with beauty output and mask for the evaluation
-        """
-
-        self._tb_writer.add_scalar("eval/loss", loss, step)
-        self._tb_writer.add_image("eval/beauty_output", beauty_output, step)
-        self._tb_writer.add_image("eval/beauty_gt", beauty_gt, step)
-        self._tb_writer.add_image("eval/sample_mask", sample_mask, step)
-        self._tb_writer.add_image("eval/sample_image", sample_image, step)
-
 
 class GARfVDBTrainer:
     """Training and evaluation engine for scale-conditioned Gaussian splat segmentation.
@@ -268,6 +241,11 @@ class GARfVDBTrainer:
         self._logger.info(
             f"Created dataset training and test datasets with {len(self._training_dataset)} training images and {len(self._validation_dataset)} test images."
         )
+        if len(self._validation_dataset) == 0 and len(self._cfg.eval_at_percent) > 0:
+            self._logger.warning(
+                "eval_at_percent is set but the validation set is empty, so no evaluation will run. "
+                "Hold out validation images (e.g. use_every_n_as_val > 0) to enable it."
+            )
 
         self._model = model
         self._optimizer = optimizer
@@ -1019,8 +997,8 @@ class GARfVDBTrainer:
 
                 # Run evaluation if we've reached a percentage of the total epochs specified in eval_at_percent
                 if epoch in [pct * self._cfg.max_epochs // 100 for pct in self._cfg.eval_at_percent]:
-                    logging.info(f"Running evaluation at epoch {epoch}")
                     if len(self._validation_dataset) > 0 and self._global_step > self._start_step:
+                        self._logger.info(f"Running evaluation at epoch {epoch}")
                         self.eval(log_tag=log_tag + "_eval")
 
             # Check if we've reached max_steps or max_epochs

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation_writer.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation_writer.py
@@ -316,7 +316,7 @@ class GARfVDBWriter(GARfVDBBaseWriter):
         attempts = 0
         max_attempts = 50
         run_name = f"{prefix}_{time.strftime('%Y-%m-%d-%H-%M-%S')}"
-        while attempts < 50:
+        while attempts < max_attempts:
             log_path = base_path / run_name
             try:
                 log_path.mkdir(exist_ok=False, parents=True)
@@ -436,8 +436,8 @@ class GARfVDBWriter(GARfVDBBaseWriter):
                         image_np = image_np[:, :, 0]  # Remove channel dimension for grayscale
                     cv2.imwrite(str(image_batch_path), image_np)
                 elif image_batch_path.suffix.lower() == ".jpg" or image_batch_path.suffix.lower() == ".jpeg":
-                    # Save as JPEG
-                    image_np = (image[b].cpu().numpy() * 255.0).clip(0, 255).astype(np.uint8)
+                    # Save as JPEG. `image` is already uint8 (see _to_batched_uint8_image); do not rescale.
+                    image_np = image[b].cpu().numpy()
                     if num_channels == 1:
                         image_np = image_np[:, :, 0]  # Remove channel dimension for grayscale
                     cv2.imwrite(str(image_batch_path), image_np, [int(cv2.IMWRITE_JPEG_QUALITY), jpeg_quality])

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation_writer.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation_writer.py
@@ -12,42 +12,39 @@ from typing import Any, TextIO
 import cv2
 import numpy as np
 import torch
-from fvdb import GaussianSplat3d
-from fvdb.types import NumericScalar, to_FloatingScalar
 from fvdb_reality_capture.checkpoints import create_training_checkpoint
-
-from .checkpoint import (
-    GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
-    GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION,
+from fvdb_reality_capture.instance_segmentation.checkpoint import (
+    GARFVDB_TRAINING_METHOD,
+    GARFVDB_TRAINING_METHOD_VERSION,
 )
+from fvdb.types import NumericScalar, to_FloatingScalar
 
 
-class GaussianSplatReconstructionBaseWriter(ABC):
+class GARfVDBBaseWriter(ABC):
     """
-    Base class for logging and saving data during Gaussian splat reconstruction.
-
-    This class defines the interface for logging metrics, saving images, checkpoints, and PLY files during
-    Gaussian splat reconstruction. Concrete implementations must implement all abstract methods.
-
-    To implement custom logging/saving behavior, subclass this class and implement the abstract methods.
+    Base class for logging and saving data during GARfVDB training.
     """
+
+    def __init__(self) -> None:
+        pass
 
     @abstractmethod
     def log_metric(self, global_step: int, metric_name: str, metric_value: NumericScalar) -> None:
         """
-        Abstract method to log a scalar metric value. This function is called during reconstruction to log metrics such as loss, PSNR, etc.
+        Log a scalar metric value. This function is called during training to log metrics such as loss, PSNR, etc.
 
         Args:
             global_step (int): The global step at which the metric is being logged.
             metric_name (str): The name of the metric being logged.
-            metric_value (NumericScalar): The value of the metric being logged. Must be a scalar type (int, float, np.number, torch.number, etc.).
+            metric_value (NumericScalar): The value of the metric being logged. Must be a scalar type
+                (int, float, np.number, torch.number, etc.).
         """
         pass
 
     @abstractmethod
     def save_image(self, global_step: int, image_name: str, image: torch.Tensor) -> None:
         """
-        Abstract method to save an image. This function is called during reconstruction to save images such as rendered outputs or intermediate results.
+        Save an image. This function is called during training to save images such as rendered outputs or intermediate results.
 
         Args:
             global_step (int): The global step at which the image is being saved.
@@ -59,7 +56,7 @@ class GaussianSplatReconstructionBaseWriter(ABC):
     @abstractmethod
     def save_checkpoint(self, global_step: int, checkpoint_name: str, checkpoint: dict[str, Any]) -> None:
         """
-        Abstract method to save a checkpoint. This function is called during reconstruction to save model checkpoints.
+        Save a checkpoint. This function is called during training to save model checkpoints.
 
         Args:
             global_step (int): The global step at which the checkpoint is being saved.
@@ -68,119 +65,49 @@ class GaussianSplatReconstructionBaseWriter(ABC):
         """
         pass
 
-    @abstractmethod
-    def save_ply(
-        self, global_step: int, ply_name: str, model: GaussianSplat3d, metadata: dict[str, Any] | None = None
-    ) -> None:
-        """
-        Abstract method to save a Gaussian splat model to a PLY file. This function is called during reconstruction to save the current state of the model.
-
-        Args:
-            global_step (int): The global step at which the PLY file is being saved.
-            ply_name (str): The name of the PLY file being saved.
-            model (GaussianSplat3d): The Gaussian splat model to be saved.
-            metadata (dict[str, Any] | None): Optional metadata to be saved with the PLY file.
-        """
-        pass
-
 
 @dataclass
-class GaussianSplatReconstructionWriterConfig:
+class GARfVDBWriterConfig:
     """
-    Parameters for configuring the behavior of a  :class:`GaussianSplatReconstructionWriter`.
+    Parameters for configuring the behavior of the GARfVDBWriter.
     Controls what data gets saved to disk, how much buffering to use, and whether to use TensorBoard.
     """
 
-    # Whether to save images to disk
+    # Configure what kind of data gets saved to disk
     save_images: bool = False
-    """
-    Whether to save images to disk. If ``False``, images will not be saved to disk.
-
-    Default is ``False``.
-    """
-
-    # Whether to save checkpoints to disk
     save_checkpoints: bool = True
-    """
-    Whether to save checkpoints to disk. If ``False``, checkpoints will not be saved to disk.
-
-    Default is ``True``.
-    """
-
-    # Whether to save PLY files to disk
-    save_plys: bool = True
-    """
-    Whether to save PLY files to disk. If ``False``, PLY files will not be saved to disk.
-
-    Default is ``True``.
-    """
-
-    # Whether to save metrics to a CSV file
     save_metrics: bool = True
-    """
-    Whether to save metrics to a CSV file. If ``False``, metrics will not be saved to a CSV file.
-
-    Default is ``True``.
-    """
 
     # How much buffering to use for metrics file logging
     metrics_file_buffer_size: int = 8 * 1024 * 1024  # 8 MB
-    """
-    How much buffering (in bytes) to use for metrics file logging. Larger values can improve performance when logging many metrics.
 
-    Default is 8 MiB.
-    """
-
-    # Whether to use TensorBoard for logging metrics and images
     use_tensorboard: bool = False
-    """
-    Whether to use TensorBoard for logging metrics and images. If ``True``, metrics and images will be logged to TensorBoard.
-
-    Default is ``False``.
-    """
-
-    # Whether to also save images to TensorBoard if use_tensorboard is True
     save_images_to_tensorboard: bool = False
-    """
-    Whether to also save images to TensorBoard if :obj:`use_tensorboard` is ``True``. If ``True``, images will be saved to TensorBoard.
-
-    Default is ``False``.
-    """
 
 
-class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
+class GARfVDBWriter(GARfVDBBaseWriter):
     """
-    Class to handle logging and saving data during Gaussian splat reconstruction.
-    This class is responsible for saving, checkpoints, PLY files, images, and metrics.
+    Class to handle logging and saving data during GARfVDB training.
+    This class is responsible for saving, checkpoints, images, and metrics.
     It can also log metrics and images to TensorBoard if requested.
-
-    .. code-block:: text
-
-        save_path/run_name/
-            checkpoints/
-                <step>/
-                    <first_checkpoint>.pth
-                    <second_checkpoint>.pth
-                    ...
-                <step>/
-                    ...
-            ply/
-                <step>/
-                    <first_ply>.ply
-                    <second_ply>.ply
-                    ...
-                <step>/
-                    ...
-            images/
-                <step>/
-                    <first_image>.png
-                    <second_image>.png
-                    ...
-                <step>/
-                    ...
-            tensorboard/
-                events.out.tfevents...
-            metrics_log.csv
+    save_path/run_name/
+        checkpoints/
+            <step>/
+                <first_checkpoint>.pth
+                <second_checkpoint>.pth
+                ...
+            <step>/
+                ...
+        images/
+            <step>/
+                <first_image>.png
+                <second_image>.png
+                ...
+            <step>/
+                ...
+        tensorboard/
+            events.out.tfevents...
+        metrics_log.csv
 
     """
 
@@ -189,19 +116,18 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
         run_name: str | None,
         save_path: pathlib.Path | None,
         exist_ok: bool = False,
-        config: GaussianSplatReconstructionWriterConfig = GaussianSplatReconstructionWriterConfig(),
+        config: GARfVDBWriterConfig = GARfVDBWriterConfig(),
     ) -> None:
         """
-        Create a new :class:`GaussianSplatReconstructionWriter` instance, which can log and save data during reconstruction.
+        Create a new GARfVDBWriter instance, which can log and save data during training.
 
         Args:
-            run_name (str | None): Name of this reconstruction run. If None, a unique name will be generated.
+            run_name (str | None): Name of this training run. If None, a unique name will be generated.
             save_path (pathlib.Path | None): Path to the directory where results should be saved.
                 If None, no data will be saved to disk.
-            exist_ok (bool): Whether to keep existing data in the save_path/run_name directory if it exists. If ``False``,
-                an error will be raised if the directory already exists. Default is ``False``.
-            config (GaussianSplatReconstructionWriterConfig): Configuration parameters for what data to save and how.
-
+            exist_ok (bool): Whether to keep existing data in the save_path/run_name directory if it exists. If False,
+                an error will be raised if the directory already exists. Default is False.
+            config (GARfVDBWriterConfig): Configuration parameters for what data to save and how.
         """
         super().__init__()
         self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
@@ -234,12 +160,6 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
 
         self._run_name = run_name
         self._save_path = save_path
-
-        # Create directory to save PLY files if requested
-        self._ply_path: pathlib.Path | None = None
-        if self._config.save_plys and self._save_path is not None:
-            self._ply_path = self._save_path / "ply"
-            self._ply_path.mkdir(parents=True, exist_ok=True)
 
         # Create directory to save checkpoints if requested
         self._checkpoints_path: pathlib.Path | None = None
@@ -345,8 +265,8 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
         Args:
             base_path (pathlib.Path): Base directory where the file should be saved.
             global_step (int): Global step at which the file is being saved. A subdirectory with this name will be created under base_path.
-            file_name (str): Name of the file to be saved. Can include subdirectories (*e.g.* ``"reconstruction/image_0001.png"``).
-            file_type (str): Type of the file used for error messages (*e.g.* ``"Image"``, ``"Checkpoint"``).
+            file_name (str): Name of the file to be saved. Can include subdirectories (e.g. "train/image_0001.png").
+            file_type (str): Type of the file used for error messages (E.g. "Image", "Checkpoint").
             allowed_sufixes (tuple[str, ...]): Allowed file suffixes/extensions.
             default_suffix (str): Default file suffix/extension to use if none is provided.
 
@@ -362,7 +282,7 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
             raise ValueError(f"{file_type} name {file_name} results in a path outside of {base_path.name} directory.")
 
         # Create parent directory if it does not exist. If the user passes in a nested path, we need to create it.
-        # e.g. file_name = "reconstruction/image_0001.png" will create "images/reconstruction/" directory
+        # e.g. file_name = "train/image_0001.png" will create "images/train/" directory
         if not step_file_path.parent.exists():
             step_file_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -385,12 +305,12 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
         """
         Generate a unique results directory based on the current time, and return its name and path.
 
-        The results directory will be created under ``base_path`` with a name in the format
-        ``prefix_YYYY-MM-DD-HH-MM-SS``. If a directory with the same name already exists,
+        The results directory will be created under `base_path` with a name in the format
+        `prefix_YYYY-MM-DD-HH-MM-SS`. If a directory with the same name already exists,
         it will attempt to create a new one by appending an incremented number to the name
 
         Returns:
-            run_name: The name of a unique log directory for a specific run in the format ``run_YYYY-MM-DD-HH-MM-SS``.
+            run_name: The name of a unique log directory for a specific run in the format "run_YYYY-MM-DD-HH-MM-SS".
             log_path: A pathlib.Path object pointing to the created log directory.
         """
         attempts = 0
@@ -412,26 +332,26 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
 
         self._logger.info(f"Created unique log directory with name {run_name} after {attempts} attempts.")
 
-        return run_name, log_path
+        return run_name, log_path  # type: ignore
 
     @property
     def run_name(self) -> str | None:
         """
-        Return the name of this reconstruction run, or ``None`` if the writer is not saving any data. The name of the run matches
+        Return the name of this training run, or None if no name was specified. The name of the run matches
         the name of the directory where logged results are being saved.
 
         Returns:
-            str | None: The name of this reconstruction run, or ``None`` if the writer is not saving any data.
+            str | None: The name of this training run, or None if no name was specified.
         """
         return self._run_name
 
     @property
     def log_path(self) -> pathlib.Path | None:
         """
-        Return the path where logged results are being saved, or ``None`` if no results are being saved.
+        Return the path where logged results are being saved, or None if no results are being saved.
 
         Returns:
-            log_path (pathlib.Path | None): The path where logged results are being saved, or ``None`` if
+            log_path (pathlib.Path | None): The path where logged results are being saved, or None if
                 no logged results are being saved.
         """
         return self._save_path
@@ -439,7 +359,7 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
     @torch.no_grad()
     def log_metric(self, global_step: int, metric_name: str, metric_value: NumericScalar) -> None:
         """
-        Log a scalar metric value. This function is called during reconstruction to log metrics such as loss, PSNR, etc.
+        Log a scalar metric value. This function is called during training to log metrics such as loss, PSNR, etc.
 
         Args:
             global_step (int): The global step at which the metric is being logged.
@@ -509,17 +429,17 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
                     else image_path
                 )
 
-                image_np = image[b].cpu().numpy()
-                if num_channels == 1:
-                    image_np = image_np[:, :, 0]  # Remove channel dimension for grayscale
-                if num_channels == 3:
-                    image_np = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)  # Convert RGB to BGR for OpenCV
-
                 if image_batch_path.suffix.lower() == ".png":
                     # Save as PNG
+                    image_np = image[b].cpu().numpy()
+                    if num_channels == 1:
+                        image_np = image_np[:, :, 0]  # Remove channel dimension for grayscale
                     cv2.imwrite(str(image_batch_path), image_np)
                 elif image_batch_path.suffix.lower() == ".jpg" or image_batch_path.suffix.lower() == ".jpeg":
                     # Save as JPEG
+                    image_np = (image[b].cpu().numpy() * 255.0).clip(0, 255).astype(np.uint8)
+                    if num_channels == 1:
+                        image_np = image_np[:, :, 0]  # Remove channel dimension for grayscale
                     cv2.imwrite(str(image_batch_path), image_np, [int(cv2.IMWRITE_JPEG_QUALITY), jpeg_quality])
                 else:
                     raise ValueError(f"Unsupported image format {image_batch_path.suffix} for saving. Use .png or .jpg")
@@ -531,12 +451,14 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
     @torch.no_grad()
     def save_checkpoint(self, global_step: int, checkpoint_name: str, checkpoint: dict[str, Any]) -> None:
         """
-        Save a reconstruction checkpoint to disk. This function is called during reconstruction to save model and optimizer state.
+        Save a training checkpoint to disk. This function is called during training to save model and optimizer state.
 
         Args:
             global_step (int): The global step at which the checkpoint is being saved.
-            checkpoint_name (str): The name of the checkpoint file. This will be used as the file name. Must have a ``.pth`` or ``.pt`` suffix.
-            checkpoint (dict[str, Any]): The checkpoint dictionary to be saved. Typically contains model state, optimizer state, etc.
+            checkpoint_name (str): The name of the checkpoint file. This will be used as the file name.
+                Must have a .pth or .pt suffix.
+            checkpoint (dict[str, Any]): The checkpoint dictionary to be saved. Typically contains model state,
+                optimizer state, etc.
         """
         if self._config.save_checkpoints and self._checkpoints_path is not None:
             ckpt_path = self._resolve_saved_file(
@@ -549,35 +471,11 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
             )
 
             envelope = create_training_checkpoint(
-                GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+                GARFVDB_TRAINING_METHOD,
                 checkpoint,
-                method_version=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION,
+                method_version=GARFVDB_TRAINING_METHOD_VERSION,
             )
             torch.save(envelope.to_dict(), ckpt_path)
 
-    @torch.no_grad()
-    def save_ply(
-        self, global_step: int, ply_name: str, model: GaussianSplat3d, metadata: dict[str, Any] | None = None
-    ) -> None:
-        """
-        Save the current Gaussian splat model to a PLY file. This function is called during reconstruction to save
-        the reconstructed model at various stages.
 
-        Args:
-            global_step (int): The global step at which the PLY file is being saved.
-            ply_name (str): The name of the PLY file. This will be used as the file name. Must have a ``.ply`` suffix.
-            model (GaussianSplat3d): The Gaussian splat model to be saved.
-            metadata (dict[str, Any] | None): Optional metadata to include in the PLY file (e.g. camera parameters, reconstruction config, etc.).
-        """
-        if self._config.save_plys and self._ply_path is not None:
-            ply_path = self._resolve_saved_file(
-                base_path=self._ply_path,
-                global_step=global_step,
-                file_name=ply_name,
-                file_type="PLY",
-                allowed_sufixes=(".ply",),
-                default_suffix=".ply",
-            )
-
-            # Save PLY using model's built-in save function
-            model.save_ply(str(ply_path), metadata=metadata)
+__all__ = ["GARfVDBBaseWriter", "GARfVDBWriter", "GARfVDBWriterConfig"]

--- a/fvdb_reality_capture/instance_segmentation/training/segmentation_writer.py
+++ b/fvdb_reality_capture/instance_segmentation/training/segmentation_writer.py
@@ -470,12 +470,12 @@ class GARfVDBWriter(GARfVDBBaseWriter):
                 default_suffix=".pt",
             )
 
-            envelope = create_training_checkpoint(
+            container = create_training_checkpoint(
                 GARFVDB_TRAINING_METHOD,
                 checkpoint,
                 method_version=GARFVDB_TRAINING_METHOD_VERSION,
             )
-            torch.save(envelope.to_dict(), ckpt_path)
+            torch.save(container.to_dict(), ckpt_path)
 
 
 __all__ = ["GARfVDBBaseWriter", "GARfVDBWriter", "GARfVDBWriterConfig"]

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -13,8 +13,11 @@ def compute_mask_cdf(pixel_to_mask_id: torch.Tensor) -> torch.Tensor:
     masks intersecting each pixel), so it is recomputed at load time rather than stored on disk.
     A full ``[H, W, MM]`` float32 CDF is by far the largest field in the mask cache (~155 MB for a
     ~2K image), and dropping it from the cache roughly quarters the on-disk artifact and the (disk
-    bound) write time. This must stay byte-for-byte consistent with the value that used to be
-    written, so the implementation matches the original inline computation exactly.
+    bound) write time.
+
+    Each mask is weighted by the log of its sampling probability (its area over the total masked
+    area) so that small masks are more likely to be selected for supervision; the ``-1`` padding is
+    excluded.
 
     Args:
         pixel_to_mask_id: ``[H, W, MM]`` integer tensor mapping each pixel to the ids of the masks
@@ -23,25 +26,21 @@ def compute_mask_cdf(pixel_to_mask_id: torch.Tensor) -> torch.Tensor:
     Returns:
         ``[H, W, MM]`` float32 CDF used to sample a mask per pixel during training.
     """
-    # Get the unique ids of each mask, and the number of pixels each mask occupies (area)
-    mask_ids, num_pix_per_mask = torch.unique(pixel_to_mask_id, return_counts=True)  # [N], [N]
+    # Shift ids by +1 so the -1 "no mask" padding maps to index 0 of the per-id tables.
+    shifted = pixel_to_mask_id.reshape(-1).long() + 1  # [H*W*MM]
+    num_ids = int(shifted.max().item()) + 1 if shifted.numel() > 0 else 1
 
-    # Sort masks by their area
-    mask_area_sort_ids = torch.argsort(num_pix_per_mask)
-    mask_ids, num_pix_per_mask = mask_ids[mask_area_sort_ids], num_pix_per_mask[mask_area_sort_ids]  # [N], [N]
-    num_pix_per_mask[0] = 0  # Remove the -1 mask which corresponds to no mask, [N]
+    # Per-mask area = number of pixel slots each mask id occupies, indexed by (id + 1).
+    area_per_id = torch.bincount(shifted, minlength=num_ids).to(torch.float32)
+    area_per_id[0] = 0.0  # drop the -1 padding so it contributes no probability
 
-    # The probability of any pixel landing in a mask is just the area of the mask over the area of the image
-    probs = num_pix_per_mask / num_pix_per_mask.sum()  # [N]
+    # Probability of sampling each mask = its area over the total masked area.
+    probs = area_per_id / area_per_id.sum().clamp(min=1e-12)  # indexed by (id + 1)
+    mask_probs = probs[shifted].view(pixel_to_mask_id.shape)  # [H, W, MM]
 
-    # Gather the probability values into pixel_to_mask_id, which produces a tensor where
-    # each pixel has a list of probabilities that correspond to the masks that intersect that pixel
-    mask_probs = torch.gather(probs, 0, pixel_to_mask_id.reshape(-1).long() + 1).view(
-        pixel_to_mask_id.shape
-    )  # [H, W, MM]
-
-    # Compute a CDF for each pixel (which sums to 1) which weighs each mask by its log probability of being sampled
-    # i.e. mask_cdf[i, j, k] is a cumulative probability weight used to select mask k for pixel [i, j]
+    # Compute a CDF for each pixel which weighs each mask by its log probability of being sampled.
+    # Padding / never-masked slots have probability 0 (log -> -inf); exclude them and set them so
+    # they are effectively never selected.
     mask_cdf = torch.log(mask_probs)
     never_masked = mask_cdf.isinf()
     mask_cdf[never_masked] = 0.0

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -280,3 +280,15 @@ def rgb_to_sh(rgb: torch.Tensor) -> torch.Tensor:
         [N, 3] Tensor of spherical harmonics coefficients
     """
     return rgb * _SH_SCALE + _SH_OFFSET
+
+
+def sh_to_rgb(sh: torch.Tensor) -> torch.Tensor:
+    """Convert degree-zero spherical harmonics coefficients to RGB values.
+
+    Args:
+        sh: Tensor of spherical harmonics coefficients.
+
+    Returns:
+        Tensor of RGB values with the same shape.
+    """
+    return (sh - _SH_OFFSET) / _SH_SCALE

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -4,6 +4,51 @@
 import torch
 
 
+def compute_mask_cdf(pixel_to_mask_id: torch.Tensor) -> torch.Tensor:
+    """Compute the per-pixel mask-selection CDF from a pixel-to-mask-id tensor.
+
+    ``mask_cdf`` is fully derived from ``pixel_to_mask_id`` (it depends only on the areas of the
+    masks intersecting each pixel), so it is recomputed at load time rather than stored on disk.
+    A full ``[H, W, MM]`` float32 CDF is by far the largest field in the mask cache (~155 MB for a
+    ~2K image), and dropping it from the cache roughly quarters the on-disk artifact and the (disk
+    bound) write time. This must stay byte-for-byte consistent with the value that used to be
+    written, so the implementation matches the original inline computation exactly.
+
+    Args:
+        pixel_to_mask_id: ``[H, W, MM]`` integer tensor mapping each pixel to the ids of the masks
+            that intersect it (``-1`` padding), packed in order of decreasing mask area.
+
+    Returns:
+        ``[H, W, MM]`` float32 CDF used to sample a mask per pixel during training.
+    """
+    # Get the unique ids of each mask, and the number of pixels each mask occupies (area)
+    mask_ids, num_pix_per_mask = torch.unique(pixel_to_mask_id, return_counts=True)  # [N], [N]
+
+    # Sort masks by their area
+    mask_area_sort_ids = torch.argsort(num_pix_per_mask)
+    mask_ids, num_pix_per_mask = mask_ids[mask_area_sort_ids], num_pix_per_mask[mask_area_sort_ids]  # [N], [N]
+    num_pix_per_mask[0] = 0  # Remove the -1 mask which corresponds to no mask, [N]
+
+    # The probability of any pixel landing in a mask is just the area of the mask over the area of the image
+    probs = num_pix_per_mask / num_pix_per_mask.sum()  # [N]
+
+    # Gather the probability values into pixel_to_mask_id, which produces a tensor where
+    # each pixel has a list of probabilities that correspond to the masks that intersect that pixel
+    mask_probs = torch.gather(probs, 0, pixel_to_mask_id.reshape(-1).long() + 1).view(
+        pixel_to_mask_id.shape
+    )  # [H, W, MM]
+
+    # Compute a CDF for each pixel (which sums to 1) which weighs each mask by its log probability of being sampled
+    # i.e. mask_cdf[i, j, k] is a cumulative probability weight used to select mask k for pixel [i, j]
+    mask_cdf = torch.log(mask_probs)
+    never_masked = mask_cdf.isinf()
+    mask_cdf[never_masked] = 0.0
+    mask_cdf = mask_cdf / (mask_cdf.sum(dim=-1, keepdim=True) + 1e-6)
+    mask_cdf = torch.cumsum(mask_cdf, dim=-1)  # [H, W, MM]
+    mask_cdf[never_masked] = 1.0
+    return mask_cdf
+
+
 def center_features(features: torch.Tensor) -> torch.Tensor:
     """Center features by subtracting the mean across samples.
 

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 #
+from typing import NamedTuple
+
 import torch
 
 
@@ -138,6 +140,83 @@ def pca_projection_fast(
     else:
         result = projected_normalized
 
+    return result
+
+
+class PCAProjectionState(NamedTuple):
+    """A frozen PCA-to-RGB transform.
+
+    Captures every per-frame quantity that :func:`pca_projection_fast` recomputes — the centering
+    ``mean``, the principal-component ``basis``, and the ``mins``/``maxs`` used for [0, 1] normalization
+    — so the same feature vector maps to the same color across frames. Used to "lock" the feature
+    visualization so colors do not flicker when the camera moves.
+    """
+
+    mean: torch.Tensor  # [1, C]
+    basis: torch.Tensor  # [C, n_components]
+    mins: torch.Tensor  # [1, n_components]
+    maxs: torch.Tensor  # [1, n_components]
+
+
+def fit_pca_projection(
+    features: torch.Tensor,
+    n_components: int = 3,
+    mask: torch.Tensor | None = None,
+) -> PCAProjectionState:
+    """Fit a reusable PCA-to-RGB transform from a single frame of features.
+
+    Args:
+        features: Feature tensor of shape ``[B, H, W, C]``.
+        n_components: Number of principal components to project onto.
+        mask: Optional boolean mask of shape ``[B, H, W]`` selecting valid features.
+
+    Returns:
+        A :class:`PCAProjectionState` that can be reused via :func:`apply_pca_projection`.
+    """
+    if mask is not None:
+        features = features[mask]
+    features_flat = features.reshape(-1, features.shape[-1])
+    mean = torch.mean(features_flat, dim=0, keepdim=True)
+    features_centered = features_flat - mean
+    basis = calculate_pca_projection(features_centered, n_components, center=False)
+    projected = torch.mm(features_centered, basis)
+    mins = projected.min(dim=0, keepdim=True)[0]
+    maxs = projected.max(dim=0, keepdim=True)[0]
+    return PCAProjectionState(mean=mean, basis=basis, mins=mins, maxs=maxs)
+
+
+def apply_pca_projection(
+    features: torch.Tensor,
+    state: PCAProjectionState,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Project features to RGB using a previously fitted :class:`PCAProjectionState`.
+
+    Mirrors :func:`pca_projection_fast` but with the transform frozen, so unseen features are placed
+    consistently (and may fall outside [0, 1] — callers should clamp).
+
+    Args:
+        features: Feature tensor of shape ``[B, H, W, C]``.
+        state: A transform produced by :func:`fit_pca_projection`.
+        mask: Optional boolean mask of shape ``[B, H, W]`` selecting valid features.
+
+    Returns:
+        Projected features of shape ``[B, H, W, n_components]`` (invalid pixels set to zero).
+    """
+    B, H, W, C = features.shape
+    n_components = state.basis.shape[-1]
+    device = features.device
+    selected = features[mask] if mask is not None else features
+    features_flat = selected.reshape(-1, C)
+    projected = torch.mm(features_flat - state.mean.to(device), state.basis.to(device))
+    mins = state.mins.to(device)
+    maxs = state.maxs.to(device)
+    projected_normalized = (projected - mins) / (maxs - mins + 1e-8)
+    if mask is not None:
+        result = torch.zeros(B, H, W, n_components, device=device)
+        result[mask] = projected_normalized
+    else:
+        result = projected_normalized
     return result
 
 

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -125,8 +125,9 @@ def pca_projection_fast(
             features. Invalid features are set to zero in the output.
 
     Returns:
-        Projected features of shape ``[B, H, W, n_components]`` normalized
-        to [0, 1] range.
+        Projected features normalized to the [0, 1] range. The shape depends on ``mask``: if a mask
+        is provided the result is the full ``[B, H, W, n_components]`` tensor with invalid pixels set
+        to zero; if ``mask`` is None the result is the flattened ``[B*H*W, n_components]`` projection.
     """
     B, H, W, C = features.shape
 
@@ -215,7 +216,9 @@ def apply_pca_projection(
         mask: Optional boolean mask of shape ``[B, H, W]`` selecting valid features.
 
     Returns:
-        Projected features of shape ``[B, H, W, n_components]`` (invalid pixels set to zero).
+        Projected features. The shape depends on ``mask``: if a mask is provided the result is the
+        full ``[B, H, W, n_components]`` tensor with invalid pixels set to zero; if ``mask`` is None
+        the result is the flattened ``[B*H*W, n_components]`` projection.
     """
     B, H, W, C = features.shape
     n_components = state.basis.shape[-1]

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -15,9 +15,11 @@ def compute_mask_cdf(pixel_to_mask_id: torch.Tensor) -> torch.Tensor:
     ~2K image), and dropping it from the cache roughly quarters the on-disk artifact and the (disk
     bound) write time.
 
-    Each mask is weighted by the log of its sampling probability (its area over the total masked
+    Each mask is weighted by ``-log`` of its sampling probability (its area over the total masked
     area) so that small masks are more likely to be selected for supervision; the ``-1`` padding is
-    excluded.
+    excluded. Pixels whose only mask has probability 1 (a lone mask) or which intersect no mask at
+    all fall back to a uniform distribution so the CDF always terminates at 1 on a real mask rather
+    than on padding.
 
     Args:
         pixel_to_mask_id: ``[H, W, MM]`` integer tensor mapping each pixel to the ids of the masks
@@ -38,15 +40,28 @@ def compute_mask_cdf(pixel_to_mask_id: torch.Tensor) -> torch.Tensor:
     probs = area_per_id / area_per_id.sum().clamp(min=1e-12)  # indexed by (id + 1)
     mask_probs = probs[shifted].view(pixel_to_mask_id.shape)  # [H, W, MM]
 
-    # Compute a CDF for each pixel which weighs each mask by its log probability of being sampled.
-    # Padding / never-masked slots have probability 0 (log -> -inf); exclude them and set them so
-    # they are effectively never selected.
-    mask_cdf = torch.log(mask_probs)
-    never_masked = mask_cdf.isinf()
-    mask_cdf[never_masked] = 0.0
-    mask_cdf = mask_cdf / (mask_cdf.sum(dim=-1, keepdim=True) + 1e-6)
-    mask_cdf = torch.cumsum(mask_cdf, dim=-1)  # [H, W, MM]
-    mask_cdf[never_masked] = 1.0
+    # Weight each valid mask by -log(prob) (>= 0 for prob in (0, 1]): smaller masks (smaller prob)
+    # get more weight, biasing sampling toward them. Padding / never-masked slots have prob 0
+    # (-log -> +inf) and are excluded.
+    weights = -torch.log(mask_probs)
+    valid = torch.isfinite(weights)
+    weights = torch.where(valid, weights, torch.zeros_like(weights))
+
+    # The per-pixel weight sum is 0 when a pixel's only mask has prob 1 (a lone mask, -log(1) = 0)
+    # or when a pixel intersects no mask at all. In the lone-mask case fall back to a uniform
+    # distribution over the pixel's valid masks so the CDF still reaches 1 on a real mask instead of
+    # collapsing to all zeros (which would make sampling select padding).
+    weight_sum = weights.sum(dim=-1, keepdim=True)
+    degenerate = weight_sum <= 0.0
+    valid_weights = valid.to(weights.dtype)
+    weights = torch.where(degenerate, valid_weights, weights)
+    weight_sum = torch.where(degenerate, valid_weights.sum(dim=-1, keepdim=True), weight_sum)
+
+    mask_pdf = weights / weight_sum.clamp(min=1e-12)
+    mask_cdf = torch.cumsum(mask_pdf, dim=-1)  # [H, W, MM]
+    # Push padding slots (and fully-unmasked pixels, whose pdf is all zero) to 1 so a uniform sample
+    # never selects padding when at least one real mask exists.
+    mask_cdf[~valid] = 1.0
     return mask_cdf
 
 
@@ -235,30 +250,28 @@ def unique_values_to_colors(tensor: torch.Tensor) -> torch.Tensor:
     unique_values, inverse_indices = torch.unique(tensor, return_inverse=True)
     num_unique = len(unique_values)
 
-    # Generate distinct colors using HSV color space
-    # We'll use evenly spaced hues and full saturation/value
-    hues = torch.linspace(0, 1, num_unique, device=tensor.device)
+    # Generate distinct colors using HSV color space with evenly spaced hues and full
+    # saturation/value. Exclude the endpoint (linspace of num_unique + 1, drop the last) so hue 0
+    # and hue 1 -- which are both red -- don't collide when the wheel is sampled.
+    hues = torch.linspace(0, 1, num_unique + 1, device=tensor.device)[:-1]  # [num_unique]
     saturation = torch.ones_like(hues)
     value = torch.ones_like(hues)
 
-    # Convert HSV to RGB
-    h = hues.unsqueeze(1).unsqueeze(2)  # [num_unique, 1, 1]
-    s = saturation.unsqueeze(1).unsqueeze(2)  # [num_unique, 1, 1]
-    v = value.unsqueeze(1).unsqueeze(2)  # [num_unique, 1, 1]
+    # HSV -> RGB (standard six-sector conversion): c is the chroma, x the second-largest component,
+    # and m the achromatic offset added to every channel. Which of (c, x, 0) each of R, G, B takes
+    # depends on the 60-degree hue sector, so the assignment must be permuted per sector rather than
+    # fixed to (R, G, B) = (c, x, m).
+    c = value * saturation  # [num_unique]
+    h6 = hues * 6.0
+    x = c * (1 - torch.abs(h6 % 2 - 1))
+    m = value - c
+    sector = torch.floor(h6).to(torch.long) % 6
 
-    # HSV to RGB conversion
-    c = v * s
-    x = c * (1 - torch.abs((h * 6) % 2 - 1))
-    m = v - c
-
-    # Create RGB components
-    rgb = torch.zeros((num_unique, 1, 1, 3), device=tensor.device)
-    rgb[:, 0, 0, 0] = c.squeeze()  # R
-    rgb[:, 0, 0, 1] = x.squeeze()  # G
-    rgb[:, 0, 0, 2] = m.squeeze()  # B
-
-    # Map each unique value to its color
-    color_map = rgb.squeeze(1).squeeze(1)  # [num_unique, 3]
+    zero = torch.zeros_like(c)
+    r = torch.where((sector == 0) | (sector == 5), c, torch.where((sector == 1) | (sector == 4), x, zero))
+    g = torch.where((sector == 1) | (sector == 2), c, torch.where((sector == 0) | (sector == 3), x, zero))
+    b = torch.where((sector == 3) | (sector == 4), c, torch.where((sector == 2) | (sector == 5), x, zero))
+    color_map = torch.stack((r + m, g + m, b + m), dim=-1)  # [num_unique, 3]
 
     # Create output tensor by mapping indices to colors
     output = color_map[inverse_indices.reshape(tensor.shape)]  # [H, W, 3]

--- a/fvdb_reality_capture/instance_segmentation/util.py
+++ b/fvdb_reality_capture/instance_segmentation/util.py
@@ -1,0 +1,159 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+import torch
+
+
+def center_features(features: torch.Tensor) -> torch.Tensor:
+    """Center features by subtracting the mean across samples.
+
+    Args:
+        features: Tensor of shape [N, C] where N is the number of samples and C is the feature dimension.
+
+    Returns:
+        Zero-mean features with the same shape as input.
+    """
+    mean = torch.mean(features, dim=0, keepdim=True)
+    return features - mean
+
+
+def calculate_pca_projection(features: torch.Tensor, n_components: int = 3, center: bool = True) -> torch.Tensor:
+    """Calculate the PCA projection matrix from feature data.
+
+    Computes the principal components of the input features using low-rank SVD.
+
+    Args:
+        features: Feature tensor of shape ``[B, H, W, C]`` or ``[N, C]``.
+        n_components: Number of principal components to compute.
+        center: If True, center features before computing PCA.
+
+    Returns:
+        Projection matrix of shape ``[C, n_components]`` containing the
+        principal component vectors.
+    """
+    features_flat = features.reshape(-1, features.shape[-1])
+
+    # Center the data
+    if center:
+        features_centered = center_features(features_flat)
+    else:
+        features_centered = features_flat
+
+    _, _, V = torch.pca_lowrank(features_centered, q=n_components, center=False)
+
+    return V
+
+
+def pca_projection_fast(
+    features: torch.Tensor,
+    n_components: int = 3,
+    V: torch.Tensor | None = None,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Project features to a lower dimension using PCA.
+
+    Projects high-dimensional features onto the first few principal components
+    and normalizes the result to [0, 1] range for visualization.
+
+    Args:
+        features: Feature tensor of shape ``[B, H, W, C]``.
+        n_components: Number of principal components to project onto.
+        V: Optional pre-computed projection matrix of shape ``[C, n_components]``.
+            If None, PCA is computed from the input features.
+        mask: Optional boolean mask of shape ``[B, H, W]`` indicating valid
+            features. Invalid features are set to zero in the output.
+
+    Returns:
+        Projected features of shape ``[B, H, W, n_components]`` normalized
+        to [0, 1] range.
+    """
+    B, H, W, C = features.shape
+
+    if mask is not None:
+        features = features[mask]
+    features_flat = features.reshape(-1, C)
+
+    # Center the data
+    features_centered = center_features(features_flat)
+
+    if V is None:
+        V = calculate_pca_projection(features_centered, n_components, center=False)
+
+    # Project data onto principal components
+    projected = torch.mm(features_centered, V.to(features.device))
+
+    # Normalize to [0, 1] range
+    mins = projected.min(dim=0, keepdim=True)[0]
+    maxs = projected.max(dim=0, keepdim=True)[0]
+    projected_normalized = (projected - mins) / (maxs - mins + 1e-8)
+
+    if mask is not None:
+        result = torch.zeros(B, H, W, n_components, device=features.device)
+        result[mask] = projected_normalized
+    else:
+        result = projected_normalized
+
+    return result
+
+
+def unique_values_to_colors(tensor: torch.Tensor) -> torch.Tensor:
+    """Map unique integer values to distinct RGB colors.
+
+    Generates evenly-spaced hues in HSV space for each unique value and
+    converts to RGB for visualization of segmentation masks or labels.
+
+    Args:
+        tensor: Integer tensor of shape ``[H, W]`` containing label values.
+
+    Returns:
+        RGB color tensor of shape ``[H, W, 3]`` with values in [0, 1].
+    """
+    # Get unique values and their indices
+    unique_values, inverse_indices = torch.unique(tensor, return_inverse=True)
+    num_unique = len(unique_values)
+
+    # Generate distinct colors using HSV color space
+    # We'll use evenly spaced hues and full saturation/value
+    hues = torch.linspace(0, 1, num_unique, device=tensor.device)
+    saturation = torch.ones_like(hues)
+    value = torch.ones_like(hues)
+
+    # Convert HSV to RGB
+    h = hues.unsqueeze(1).unsqueeze(2)  # [num_unique, 1, 1]
+    s = saturation.unsqueeze(1).unsqueeze(2)  # [num_unique, 1, 1]
+    v = value.unsqueeze(1).unsqueeze(2)  # [num_unique, 1, 1]
+
+    # HSV to RGB conversion
+    c = v * s
+    x = c * (1 - torch.abs((h * 6) % 2 - 1))
+    m = v - c
+
+    # Create RGB components
+    rgb = torch.zeros((num_unique, 1, 1, 3), device=tensor.device)
+    rgb[:, 0, 0, 0] = c.squeeze()  # R
+    rgb[:, 0, 0, 1] = x.squeeze()  # G
+    rgb[:, 0, 0, 2] = m.squeeze()  # B
+
+    # Map each unique value to its color
+    color_map = rgb.squeeze(1).squeeze(1)  # [num_unique, 3]
+
+    # Create output tensor by mapping indices to colors
+    output = color_map[inverse_indices.reshape(tensor.shape)]  # [H, W, 3]
+
+    return output
+
+
+_SH_SCALE = 1.0 / 0.28209479177387814  # ≈ 3.5449077018110318
+_SH_OFFSET = -0.5 * _SH_SCALE  # ≈ -1.7724538509055159
+
+
+def rgb_to_sh(rgb: torch.Tensor) -> torch.Tensor:
+    """Convert RGB values to spherical harmonics coefficients.
+
+    Args:
+        rgb: [N, 3] Tensor of RGB values
+
+    Returns:
+        [N, 3] Tensor of spherical harmonics coefficients
+    """
+    return rgb * _SH_SCALE + _SH_OFFSET

--- a/fvdb_reality_capture/instance_segmentation/viewer.py
+++ b/fvdb_reality_capture/instance_segmentation/viewer.py
@@ -16,7 +16,13 @@ import torch
 from fvdb.types import to_Mat33fBatch, to_Mat44fBatch, to_Vec2iBatch
 
 from .garfvdb import GARfVDB
-from .util import pca_projection_fast
+from .util import apply_pca_projection, fit_pca_projection
+
+# Widget labels shown in the viewer's "Scene Params" window.
+_SCALE_WIDGET_NAME = "Grouping scale (normalized)"
+_OPACITY_WIDGET_NAME = "Overlay opacity"
+_SHOW_WIDGET_NAME = "Show segmentation overlay"
+_LOCK_WIDGET_NAME = "Lock PCA colors"
 
 
 def _camera_tuple_to_c2w(
@@ -51,21 +57,250 @@ def _camera_tuple_to_c2w(
     return torch.from_numpy(c2w_gl @ opengl_to_opencv).to(device)
 
 
+class GARfVDBOverlayViewer:
+    """Drives a GARfVDB feature overlay in an fvdb ``Scene`` with interactive controls.
+
+    Registers three "Scene Params" widgets — a normalized grouping-scale slider (``[0, 1]`` mapped to
+    ``[0, max_grouping_scale]``), an overlay-opacity slider, and a show/hide checkbox — and renders one
+    overlay frame per :meth:`render_once` call whenever the orbit camera or any widget changes.
+
+    The same object is used by the offline ``frgs show`` viewer (which owns a blocking poll loop) and by
+    the live training viewer (which pumps :meth:`render_once` from the training loop). It reads widget
+    ``.value`` attributes directly each call, matching the existing camera-polling pattern, so no
+    ``poll_widgets``/``on_update`` callback wiring is required.
+    """
+
+    def __init__(
+        self,
+        scene: "fviz.Scene",
+        product: GARfVDB,
+        *,
+        device: str | torch.device = "cuda:0",
+        overlay_width: int = 1440,
+        overlay_height: int = 720,
+        overlay_downsample: int = 2,
+        initial_scale_fraction: float = 0.1,
+        initial_mask_blend: float = 0.5,
+        lock_pca_colors: bool = False,
+        add_carrier: bool = True,
+        set_initial_camera: bool = True,
+    ) -> None:
+        if not 0.0 <= initial_scale_fraction <= 1.0:
+            raise ValueError(f"initial_scale_fraction must be in [0, 1], got {initial_scale_fraction}")
+        if not 0.0 <= initial_mask_blend <= 1.0:
+            raise ValueError(f"initial_mask_blend must be in [0, 1], got {initial_mask_blend}")
+        if overlay_width <= 0 or overlay_height <= 0 or overlay_downsample <= 0:
+            raise ValueError("Overlay dimensions and downsample must be positive")
+
+        self._logger = logging.getLogger(__name__)
+        self._scene = scene
+        self._product = product
+        self._device = torch.device(device)
+        self._overlay_width = overlay_width
+        self._overlay_height = overlay_height
+        self._overlay_downsample = overlay_downsample
+        self._render_width = overlay_width // overlay_downsample
+        self._render_height = overlay_height // overlay_downsample
+
+        if add_carrier:
+            scene.add_gaussian_splat_3d("Gaussian Carrier", product.carrier)
+        if set_initial_camera:
+            self._add_cameras_and_lookat()
+
+        # Interactive controls (see class docstring for semantics).
+        self._scale_widget = scene.add_slider(_SCALE_WIDGET_NAME, 0.0, 1.0, initial_scale_fraction, 0.01)
+        self._opacity_widget = scene.add_slider(_OPACITY_WIDGET_NAME, 0.0, 1.0, initial_mask_blend, 0.01)
+        self._show_widget = scene.add_checkbox(_SHOW_WIDGET_NAME, True)
+        self._lock_widget = scene.add_checkbox(_LOCK_WIDGET_NAME, lock_pca_colors)
+
+        self._image_view = None
+        self._last_camera: tuple[np.ndarray, np.ndarray, float, np.ndarray, float] | None = None
+        self._last_widgets: tuple[float, float, bool, bool] | None = None
+        # Frozen PCA->RGB transform used while "Lock PCA colors" is on (and the scale it was fit at).
+        self._pca_state = None
+        self._pca_state_scale: float | None = None
+
+    def _add_cameras_and_lookat(self) -> None:
+        """Add training cameras (if present in metadata) and set the initial orbit view."""
+        metadata = self._product.reconstruction_metadata
+        camera_to_world = metadata.get("camera_to_world_matrices")
+        projection_matrices = metadata.get("projection_matrices")
+        image_sizes = metadata.get("image_sizes")
+        if camera_to_world is not None:
+            camera_to_world = to_Mat44fBatch(camera_to_world).cpu()
+        if projection_matrices is not None:
+            projection_matrices = to_Mat33fBatch(projection_matrices).cpu()
+        if image_sizes is not None:
+            image_sizes = to_Vec2iBatch(image_sizes).cpu()
+        if camera_to_world is not None and projection_matrices is not None:
+            self._scene.add_cameras(
+                name="Training Cameras",
+                camera_to_world_matrices=camera_to_world,
+                projection_matrices=projection_matrices,
+                image_sizes=image_sizes,
+            )
+
+        carrier = self._product.carrier
+        centroid = carrier.means.mean(dim=0).detach().cpu().numpy()
+        if camera_to_world is not None:
+            initial_eye = camera_to_world[0, :3, 3].numpy()
+        else:
+            extent = carrier.means.max(dim=0).values - carrier.means.min(dim=0).values
+            initial_eye = centroid + np.ones(3) * float(extent.max().item() / 2.0)
+        self._scene.set_camera_lookat(eye=initial_eye, center=centroid, up=[0, 0, 1])
+
+    def _read_camera(self) -> tuple[np.ndarray, np.ndarray, float, np.ndarray, float]:
+        scene = self._scene
+        return (
+            scene.camera_orbit_center.cpu().numpy(),
+            scene.camera_orbit_direction.cpu().numpy(),
+            float(scene.camera_orbit_radius),
+            scene.camera_up_direction.cpu().numpy(),
+            float(scene.camera_fov),
+        )
+
+    @staticmethod
+    def _camera_unchanged(a: tuple, b: tuple) -> bool:
+        return (
+            np.allclose(a[0], b[0])
+            and np.allclose(a[1], b[1])
+            and np.isclose(a[2], b[2])
+            and np.allclose(a[3], b[3])
+            and np.isclose(a[4], b[4])
+        )
+
+    def _hide_overlay(self) -> None:
+        """Remove the overlay image view so the underlying carrier scene is visible again.
+
+        ImageView exposes no visibility toggle, and drawing a fully-transparent frame still draws an
+        opaque quad that occludes the 3D scene. So we remove the view outright; render_once re-creates it
+        (via ``add_image``) the next time the overlay is enabled.
+        """
+        if self._image_view is None:
+            return
+        try:
+            fviz._viewer_server.remove_view(self._image_view.scene_name, self._image_view.name)
+        except Exception as exc:  # keep the viewer alive even if removal is unavailable
+            self._logger.warning("Could not remove GARfVDB overlay view: %s", exc)
+            return
+        self._image_view = None
+
+    def render_once(self) -> bool:
+        """Render/refresh the overlay if the camera or any widget changed since the last call.
+
+        Returns:
+            ``True`` if the camera or a widget changed since the previous call (i.e. work was done),
+            ``False`` if nothing changed. Callers use this to render continuously while the camera is
+            moving and idle-sleep only when there is nothing to do.
+        """
+        camera = self._read_camera()
+        widgets = (
+            float(self._scale_widget.value),
+            float(self._opacity_widget.value),
+            bool(self._show_widget.value),
+            bool(self._lock_widget.value),
+        )
+        if (
+            self._last_camera is not None
+            and self._last_widgets is not None
+            and self._camera_unchanged(camera, self._last_camera)
+            and widgets == self._last_widgets
+        ):
+            return False
+        self._last_camera = camera
+        self._last_widgets = widgets
+
+        scale_fraction, mask_blend, show_overlay, lock_pca = widgets
+        if not show_overlay:
+            self._hide_overlay()
+            return True
+
+        c2w = _camera_tuple_to_c2w(*camera[:4], self._device)
+        if c2w is None:
+            return True
+        focal = self._render_height / (2.0 * np.tan(camera[4] / 2.0))
+        projection = torch.tensor(
+            [
+                [focal, 0.0, self._render_width / 2.0],
+                [0.0, focal, self._render_height / 2.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=torch.float32,
+            device=self._device,
+        )
+        scale = scale_fraction * self._product.max_grouping_scale
+        try:
+            features, alpha = self._product.render_features(
+                c2w,
+                projection,
+                (self._render_width, self._render_height),
+                scale,
+            )
+            if not torch.isfinite(features).all():
+                self._logger.warning("Skipping GARfVDB frame containing non-finite features")
+                return True
+            pca_mask = alpha.squeeze(-1) > 0
+            # When locked, reuse the frozen PCA->RGB transform so colors don't flicker as the camera
+            # moves. Refit when unlocked, or when locking for the first time / after the scale changes
+            # (a different grouping scale produces a different feature field).
+            if lock_pca:
+                if self._pca_state is None or self._pca_state_scale != scale_fraction:
+                    self._pca_state = fit_pca_projection(features, 3, mask=pca_mask)
+                    self._pca_state_scale = scale_fraction
+                pca_state = self._pca_state
+            else:
+                self._pca_state = None
+                self._pca_state_scale = None
+                pca_state = fit_pca_projection(features, 3, mask=pca_mask)
+            rgb = apply_pca_projection(features, pca_state, mask=pca_mask)[0]
+            rgba = torch.cat([rgb, alpha[0] * mask_blend], dim=-1).clamp(0, 1)
+            rgba_image = (rgba.detach().cpu().numpy() * 255).astype(np.uint8)
+            if self._overlay_downsample > 1:
+                rgba_image = cv2.resize(
+                    rgba_image,
+                    (self._overlay_width, self._overlay_height),
+                    interpolation=cv2.INTER_LINEAR,
+                )
+            flat_rgba = rgba_image.flatten()
+            if self._image_view is None:
+                self._image_view = self._scene.add_image(
+                    name="GARfVDB Features",
+                    width=self._overlay_width,
+                    height=self._overlay_height,
+                    rgba_image=flat_rgba,
+                )
+            else:
+                self._image_view.update(flat_rgba)
+        except (RuntimeError, ValueError) as exc:
+            self._logger.warning("Could not render GARfVDB overlay: %s", exc)
+        return True
+
+
 def show_garfvdb_bundle(
     path: str | pathlib.Path,
     *,
     viewer_port: int = 8080,
     viewer_ip_address: str = "127.0.0.1",
     verbose: bool = False,
-    device: str | torch.device = "cuda",
+    device: str | torch.device = "cuda:0",
     scale_fraction: float = 0.1,
     mask_blend: float = 0.5,
+    lock_pca_colors: bool = False,
     overlay_width: int = 1440,
     overlay_height: int = 720,
     overlay_downsample: int = 2,
-    camera_check_interval: float = 0.5,
+    idle_poll_interval: float = 1.0 / 120.0,
 ) -> None:
-    """Load a GARfVDB bundle and display its carrier with a live feature overlay."""
+    """Load a GARfVDB bundle and display its carrier with a live, interactive feature overlay.
+
+    ``scale_fraction`` and ``mask_blend`` seed the initial positions of the interactive grouping-scale and
+    overlay-opacity sliders; both can be adjusted live in the viewer, along with a show/hide checkbox and a
+    "Lock PCA colors" checkbox (seeded by ``lock_pca_colors``) that freezes the feature coloring so it does
+    not flicker as the camera moves.
+
+    ``idle_poll_interval`` is how long to sleep between camera polls **only when nothing changed**; while
+    the camera is moving the overlay re-renders back-to-back with no added delay.
+    """
     if not 0.0 <= scale_fraction <= 1.0:
         raise ValueError(f"scale_fraction must be in [0, 1], got {scale_fraction}")
     if not 0.0 <= mask_blend <= 1.0:
@@ -77,111 +312,30 @@ def show_garfvdb_bundle(
     # Vulkan must be initialized before loading CUDA payloads.
     fviz.init(ip_address=viewer_ip_address, port=viewer_port, verbose=verbose)
     product = GARfVDB.load(path, device=device)
-    device_obj = torch.device(device)
     scene = fviz.get_scene("GARfVDB Instance Segmentation")
-    scene.add_gaussian_splat_3d("Gaussian Carrier", product.carrier)
-
-    metadata = product.reconstruction_metadata
-    camera_to_world = metadata.get("camera_to_world_matrices")
-    projection_matrices = metadata.get("projection_matrices")
-    image_sizes = metadata.get("image_sizes")
-    if camera_to_world is not None:
-        camera_to_world = to_Mat44fBatch(camera_to_world).cpu()
-    if projection_matrices is not None:
-        projection_matrices = to_Mat33fBatch(projection_matrices).cpu()
-    if image_sizes is not None:
-        image_sizes = to_Vec2iBatch(image_sizes).cpu()
-    if camera_to_world is not None and projection_matrices is not None:
-        scene.add_cameras(
-            name="Training Cameras",
-            camera_to_world_matrices=camera_to_world,
-            projection_matrices=projection_matrices,
-            image_sizes=image_sizes,
-        )
-
-    centroid = product.carrier.means.mean(dim=0).detach().cpu().numpy()
-    if camera_to_world is not None:
-        initial_eye = camera_to_world[0, :3, 3].numpy()
-    else:
-        extent = product.carrier.means.max(dim=0).values - product.carrier.means.min(dim=0).values
-        initial_eye = centroid + np.ones(3) * float(extent.max().item() / 2.0)
-    scene.set_camera_lookat(eye=initial_eye, center=centroid, up=[0, 0, 1])
+    viewer = GARfVDBOverlayViewer(
+        scene,
+        product,
+        device=device,
+        overlay_width=overlay_width,
+        overlay_height=overlay_height,
+        overlay_downsample=overlay_downsample,
+        initial_scale_fraction=scale_fraction,
+        initial_mask_blend=mask_blend,
+        lock_pca_colors=lock_pca_colors,
+    )
     fviz.show()
-
-    render_width = overlay_width // overlay_downsample
-    render_height = overlay_height // overlay_downsample
-    scale = scale_fraction * product.max_grouping_scale
-    image_view = None
-    last_camera: tuple[np.ndarray, np.ndarray, float, np.ndarray, float] | None = None
     logger.info("GARfVDB viewer running at http://%s:%d", viewer_ip_address, viewer_port)
 
     try:
         while True:
-            time.sleep(camera_check_interval)
-            camera = (
-                scene.camera_orbit_center.cpu().numpy(),
-                scene.camera_orbit_direction.cpu().numpy(),
-                float(scene.camera_orbit_radius),
-                scene.camera_up_direction.cpu().numpy(),
-                float(scene.camera_fov),
-            )
-            if last_camera is not None:
-                unchanged = (
-                    np.allclose(camera[0], last_camera[0])
-                    and np.allclose(camera[1], last_camera[1])
-                    and np.isclose(camera[2], last_camera[2])
-                    and np.allclose(camera[3], last_camera[3])
-                    and np.isclose(camera[4], last_camera[4])
-                )
-                if unchanged:
-                    continue
-            last_camera = camera
-            c2w = _camera_tuple_to_c2w(*camera[:4], device_obj)
-            if c2w is None:
-                continue
-            focal = render_height / (2.0 * np.tan(camera[4] / 2.0))
-            projection = torch.tensor(
-                [
-                    [focal, 0.0, render_width / 2.0],
-                    [0.0, focal, render_height / 2.0],
-                    [0.0, 0.0, 1.0],
-                ],
-                dtype=torch.float32,
-                device=device_obj,
-            )
-            try:
-                features, alpha = product.render_features(
-                    c2w,
-                    projection,
-                    (render_width, render_height),
-                    scale,
-                )
-                if not torch.isfinite(features).all():
-                    logger.warning("Skipping GARfVDB frame containing non-finite features")
-                    continue
-                rgb = pca_projection_fast(features, 3, mask=alpha.squeeze(-1) > 0)[0]
-                rgba = torch.cat([rgb, alpha[0] * mask_blend], dim=-1).clamp(0, 1)
-                rgba_image = (rgba.detach().cpu().numpy() * 255).astype(np.uint8)
-                if overlay_downsample > 1:
-                    rgba_image = cv2.resize(
-                        rgba_image,
-                        (overlay_width, overlay_height),
-                        interpolation=cv2.INTER_LINEAR,
-                    )
-                flat_rgba = rgba_image.flatten()
-                if image_view is None:
-                    image_view = scene.add_image(
-                        name="GARfVDB Features",
-                        width=overlay_width,
-                        height=overlay_height,
-                        rgba_image=flat_rgba,
-                    )
-                else:
-                    image_view.update(flat_rgba)
-            except (RuntimeError, ValueError) as exc:
-                logger.warning("Could not render GARfVDB overlay: %s", exc)
+            # Render as fast as possible while the camera/widgets are changing (render_once returns True),
+            # and only sleep when there is nothing to do, so updates track camera motion in real time
+            # instead of waiting for the mouse to stop.
+            if not viewer.render_once():
+                time.sleep(idle_poll_interval)
     except KeyboardInterrupt:
         logger.info("Shutting down GARfVDB viewer")
 
 
-__all__ = ["show_garfvdb_bundle"]
+__all__ = ["show_garfvdb_bundle", "GARfVDBOverlayViewer"]

--- a/fvdb_reality_capture/instance_segmentation/viewer.py
+++ b/fvdb_reality_capture/instance_segmentation/viewer.py
@@ -244,6 +244,12 @@ class GARfVDBOverlayViewer:
             if not torch.isfinite(features).all():
                 self._logger.warning("Skipping GARfVDB frame containing non-finite features")
                 return True
+            if features.shape[-1] < 3:
+                self._logger.warning(
+                    "Skipping GARfVDB overlay: PCA projection requires at least 3 feature channels, got %d",
+                    features.shape[-1],
+                )
+                return True
             pca_mask = alpha.squeeze(-1) > 0
             # When locked, reuse the frozen PCA->RGB transform so colors don't flicker as the camera
             # moves. Refit when unlocked, or when locking for the first time / after the scale changes

--- a/fvdb_reality_capture/instance_segmentation/viewer.py
+++ b/fvdb_reality_capture/instance_segmentation/viewer.py
@@ -91,6 +91,11 @@ class GARfVDBOverlayViewer:
             raise ValueError(f"initial_mask_blend must be in [0, 1], got {initial_mask_blend}")
         if overlay_width <= 0 or overlay_height <= 0 or overlay_downsample <= 0:
             raise ValueError("Overlay dimensions and downsample must be positive")
+        if overlay_width < overlay_downsample or overlay_height < overlay_downsample:
+            raise ValueError(
+                f"overlay_downsample ({overlay_downsample}) must not exceed overlay_width ({overlay_width}) "
+                f"or overlay_height ({overlay_height}); the downsampled render target would be empty."
+            )
 
         self._logger = logging.getLogger(__name__)
         self._scene = scene

--- a/fvdb_reality_capture/instance_segmentation/viewer.py
+++ b/fvdb_reality_capture/instance_segmentation/viewer.py
@@ -82,7 +82,7 @@ class GARfVDBOverlayViewer:
         initial_scale_fraction: float = 0.1,
         initial_mask_blend: float = 0.5,
         lock_pca_colors: bool = False,
-        add_carrier: bool = True,
+        add_gaussians: bool = True,
         set_initial_camera: bool = True,
     ) -> None:
         if not 0.0 <= initial_scale_fraction <= 1.0:
@@ -102,8 +102,8 @@ class GARfVDBOverlayViewer:
         self._render_width = overlay_width // overlay_downsample
         self._render_height = overlay_height // overlay_downsample
 
-        if add_carrier:
-            scene.add_gaussian_splat_3d("Gaussian Carrier", product.carrier)
+        if add_gaussians:
+            scene.add_gaussian_splat_3d("Gaussian Splats", product.gaussians)
         if set_initial_camera:
             self._add_cameras_and_lookat()
 
@@ -140,12 +140,12 @@ class GARfVDBOverlayViewer:
                 image_sizes=image_sizes,
             )
 
-        carrier = self._product.carrier
-        centroid = carrier.means.mean(dim=0).detach().cpu().numpy()
+        gaussians = self._product.gaussians
+        centroid = gaussians.means.mean(dim=0).detach().cpu().numpy()
         if camera_to_world is not None:
             initial_eye = camera_to_world[0, :3, 3].numpy()
         else:
-            extent = carrier.means.max(dim=0).values - carrier.means.min(dim=0).values
+            extent = gaussians.means.max(dim=0).values - gaussians.means.min(dim=0).values
             initial_eye = centroid + np.ones(3) * float(extent.max().item() / 2.0)
         self._scene.set_camera_lookat(eye=initial_eye, center=centroid, up=[0, 0, 1])
 
@@ -170,7 +170,7 @@ class GARfVDBOverlayViewer:
         )
 
     def _hide_overlay(self) -> None:
-        """Remove the overlay image view so the underlying carrier scene is visible again.
+        """Remove the overlay image view so the underlying Gaussian scene is visible again.
 
         ImageView exposes no visibility toggle, and drawing a fully-transparent frame still draws an
         opaque quad that occludes the 3D scene. So we remove the view outright; render_once re-creates it
@@ -291,7 +291,7 @@ def show_garfvdb_bundle(
     overlay_downsample: int = 2,
     idle_poll_interval: float = 1.0 / 120.0,
 ) -> None:
-    """Load a GARfVDB bundle and display its carrier with a live, interactive feature overlay.
+    """Load a GARfVDB bundle and display its gaussians with a live, interactive feature overlay.
 
     ``scale_fraction`` and ``mask_blend`` seed the initial positions of the interactive grouping-scale and
     overlay-opacity sliders; both can be adjusted live in the viewer, along with a show/hide checkbox and a

--- a/fvdb_reality_capture/instance_segmentation/viewer.py
+++ b/fvdb_reality_capture/instance_segmentation/viewer.py
@@ -1,0 +1,187 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Interactive GARfVDB visualization."""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import time
+
+import cv2
+import fvdb.viz as fviz
+import numpy as np
+import torch
+from fvdb.types import to_Mat33fBatch, to_Mat44fBatch, to_Vec2iBatch
+
+from .garfvdb import GARfVDB
+from .util import pca_projection_fast
+
+
+def _camera_tuple_to_c2w(
+    center: np.ndarray,
+    eye_direction: np.ndarray,
+    radius: float,
+    up_world: np.ndarray,
+    device: torch.device,
+) -> torch.Tensor | None:
+    position = center - eye_direction * radius
+    eye_norm = np.linalg.norm(eye_direction)
+    if eye_norm < 1e-8:
+        return None
+    forward = eye_direction / eye_norm
+    right = np.cross(forward, up_world)
+    right_norm = np.linalg.norm(right)
+    if right_norm < 1e-8:
+        return None
+    right /= right_norm
+    up = np.cross(right, forward)
+    up_norm = np.linalg.norm(up)
+    if up_norm < 1e-8:
+        return None
+    up /= up_norm
+
+    c2w_gl = np.eye(4, dtype=np.float32)
+    c2w_gl[:3, 0] = right
+    c2w_gl[:3, 1] = up
+    c2w_gl[:3, 2] = -forward
+    c2w_gl[:3, 3] = position
+    opengl_to_opencv = np.diag([1.0, -1.0, -1.0, 1.0]).astype(np.float32)
+    return torch.from_numpy(c2w_gl @ opengl_to_opencv).to(device)
+
+
+def show_garfvdb_bundle(
+    path: str | pathlib.Path,
+    *,
+    viewer_port: int = 8080,
+    viewer_ip_address: str = "127.0.0.1",
+    verbose: bool = False,
+    device: str | torch.device = "cuda",
+    scale_fraction: float = 0.1,
+    mask_blend: float = 0.5,
+    overlay_width: int = 1440,
+    overlay_height: int = 720,
+    overlay_downsample: int = 2,
+    camera_check_interval: float = 0.5,
+) -> None:
+    """Load a GARfVDB bundle and display its carrier with a live feature overlay."""
+    if not 0.0 <= scale_fraction <= 1.0:
+        raise ValueError(f"scale_fraction must be in [0, 1], got {scale_fraction}")
+    if not 0.0 <= mask_blend <= 1.0:
+        raise ValueError(f"mask_blend must be in [0, 1], got {mask_blend}")
+    if overlay_width <= 0 or overlay_height <= 0 or overlay_downsample <= 0:
+        raise ValueError("Overlay dimensions and downsample must be positive")
+
+    logger = logging.getLogger(__name__)
+    # Vulkan must be initialized before loading CUDA payloads.
+    fviz.init(ip_address=viewer_ip_address, port=viewer_port, verbose=verbose)
+    product = GARfVDB.load(path, device=device)
+    device_obj = torch.device(device)
+    scene = fviz.get_scene("GARfVDB Instance Segmentation")
+    scene.add_gaussian_splat_3d("Gaussian Carrier", product.carrier)
+
+    metadata = product.reconstruction_metadata
+    camera_to_world = metadata.get("camera_to_world_matrices")
+    projection_matrices = metadata.get("projection_matrices")
+    image_sizes = metadata.get("image_sizes")
+    if camera_to_world is not None:
+        camera_to_world = to_Mat44fBatch(camera_to_world).cpu()
+    if projection_matrices is not None:
+        projection_matrices = to_Mat33fBatch(projection_matrices).cpu()
+    if image_sizes is not None:
+        image_sizes = to_Vec2iBatch(image_sizes).cpu()
+    if camera_to_world is not None and projection_matrices is not None:
+        scene.add_cameras(
+            name="Training Cameras",
+            camera_to_world_matrices=camera_to_world,
+            projection_matrices=projection_matrices,
+            image_sizes=image_sizes,
+        )
+
+    centroid = product.carrier.means.mean(dim=0).detach().cpu().numpy()
+    if camera_to_world is not None:
+        initial_eye = camera_to_world[0, :3, 3].numpy()
+    else:
+        extent = product.carrier.means.max(dim=0).values - product.carrier.means.min(dim=0).values
+        initial_eye = centroid + np.ones(3) * float(extent.max().item() / 2.0)
+    scene.set_camera_lookat(eye=initial_eye, center=centroid, up=[0, 0, 1])
+    fviz.show()
+
+    render_width = overlay_width // overlay_downsample
+    render_height = overlay_height // overlay_downsample
+    scale = scale_fraction * product.max_grouping_scale
+    image_view = None
+    last_camera: tuple[np.ndarray, np.ndarray, float, np.ndarray, float] | None = None
+    logger.info("GARfVDB viewer running at http://%s:%d", viewer_ip_address, viewer_port)
+
+    try:
+        while True:
+            time.sleep(camera_check_interval)
+            camera = (
+                scene.camera_orbit_center.cpu().numpy(),
+                scene.camera_orbit_direction.cpu().numpy(),
+                float(scene.camera_orbit_radius),
+                scene.camera_up_direction.cpu().numpy(),
+                float(scene.camera_fov),
+            )
+            if last_camera is not None:
+                unchanged = (
+                    np.allclose(camera[0], last_camera[0])
+                    and np.allclose(camera[1], last_camera[1])
+                    and np.isclose(camera[2], last_camera[2])
+                    and np.allclose(camera[3], last_camera[3])
+                    and np.isclose(camera[4], last_camera[4])
+                )
+                if unchanged:
+                    continue
+            last_camera = camera
+            c2w = _camera_tuple_to_c2w(*camera[:4], device_obj)
+            if c2w is None:
+                continue
+            focal = render_height / (2.0 * np.tan(camera[4] / 2.0))
+            projection = torch.tensor(
+                [
+                    [focal, 0.0, render_width / 2.0],
+                    [0.0, focal, render_height / 2.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                dtype=torch.float32,
+                device=device_obj,
+            )
+            try:
+                features, alpha = product.render_features(
+                    c2w,
+                    projection,
+                    (render_width, render_height),
+                    scale,
+                )
+                if not torch.isfinite(features).all():
+                    logger.warning("Skipping GARfVDB frame containing non-finite features")
+                    continue
+                rgb = pca_projection_fast(features, 3, mask=alpha.squeeze(-1) > 0)[0]
+                rgba = torch.cat([rgb, alpha[0] * mask_blend], dim=-1).clamp(0, 1)
+                rgba_image = (rgba.detach().cpu().numpy() * 255).astype(np.uint8)
+                if overlay_downsample > 1:
+                    rgba_image = cv2.resize(
+                        rgba_image,
+                        (overlay_width, overlay_height),
+                        interpolation=cv2.INTER_LINEAR,
+                    )
+                flat_rgba = rgba_image.flatten()
+                if image_view is None:
+                    image_view = scene.add_image(
+                        name="GARfVDB Features",
+                        width=overlay_width,
+                        height=overlay_height,
+                        rgba_image=flat_rgba,
+                    )
+                else:
+                    image_view.update(flat_rgba)
+            except (RuntimeError, ValueError) as exc:
+                logger.warning("Could not render GARfVDB overlay: %s", exc)
+    except KeyboardInterrupt:
+        logger.info("Shutting down GARfVDB viewer")
+
+
+__all__ = ["show_garfvdb_bundle"]

--- a/fvdb_reality_capture/instance_segmentation/viewer.py
+++ b/fvdb_reality_capture/instance_segmentation/viewer.py
@@ -32,11 +32,13 @@ def _camera_tuple_to_c2w(
     up_world: np.ndarray,
     device: torch.device,
 ) -> torch.Tensor | None:
-    position = center - eye_direction * radius
     eye_norm = np.linalg.norm(eye_direction)
     if eye_norm < 1e-8:
         return None
     forward = eye_direction / eye_norm
+    # Offset by the normalized forward so the orbit radius is exactly ``radius`` regardless of the
+    # magnitude of ``eye_direction``.
+    position = center - forward * radius
     right = np.cross(forward, up_world)
     right_norm = np.linalg.norm(right)
     if right_norm < 1e-8:

--- a/fvdb_reality_capture/radiance_fields/__init__.py
+++ b/fvdb_reality_capture/radiance_fields/__init__.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from .checkpoint import (
+    GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+    GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION,
+)
 from .gaussian_splat_dataset import SfmDataset
 from .gaussian_splat_optimizer import (
     BaseGaussianSplatOptimizer,
@@ -23,14 +27,18 @@ from .gaussian_splat_reconstruction_writer import (
     GaussianSplatReconstructionWriter,
     GaussianSplatReconstructionWriterConfig,
 )
+from .io import load_splats_from_file
 
 __all__ = [
     "GaussianSplatReconstructionBaseWriter",
+    "GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD",
+    "GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION",
     "GaussianSplatReconstructionWriter",
     "GaussianSplatReconstructionWriterConfig",
     "GaussianSplatReconstruction",
     "GaussianSplatReconstructionConfig",
     "SfmDataset",
+    "load_splats_from_file",
     "BaseGaussianSplatOptimizer",
     "GaussianSplatOptimizer",
     "GaussianSplatOptimizerConfig",

--- a/fvdb_reality_capture/radiance_fields/checkpoint.py
+++ b/fvdb_reality_capture/radiance_fields/checkpoint.py
@@ -17,7 +17,7 @@ from fvdb_reality_capture.checkpoints import (
 GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD = "radiance_fields.gaussian_splat"
 
 # Single source of truth for the Gaussian reconstruction checkpoint format version. The runner's
-# ``state_dict``/``from_state_dict`` and the disk writer's envelope ``method_version`` both derive from
+# ``state_dict``/``from_state_dict`` and the disk writer's container ``method_version`` both derive from
 # this constant so the two can never drift.
 GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION = "0.1.0"
 
@@ -25,7 +25,7 @@ GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION = "0.1.0"
 def _adapt_flat_gaussian_checkpoint(
     root: Mapping[str, Any],
 ) -> TrainingCheckpoint | None:
-    """Recognize the released pre-envelope Gaussian checkpoint format."""
+    """Recognize the released pre-container Gaussian checkpoint format."""
     if root.get("magic") != "GaussianSplattingCheckpoint":
         return None
     method_version = root.get("version")

--- a/fvdb_reality_capture/radiance_fields/checkpoint.py
+++ b/fvdb_reality_capture/radiance_fields/checkpoint.py
@@ -1,0 +1,47 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gaussian reconstruction checkpoint identity and compatibility adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from fvdb_reality_capture.checkpoints import (
+    TrainingCheckpoint,
+    TrainingCheckpointError,
+    register_legacy_checkpoint_adapter,
+)
+
+GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD = "radiance_fields.gaussian_splat"
+
+# Single source of truth for the Gaussian reconstruction checkpoint format version. The runner's
+# ``state_dict``/``from_state_dict`` and the disk writer's envelope ``method_version`` both derive from
+# this constant so the two can never drift.
+GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION = "0.1.0"
+
+
+def _adapt_flat_gaussian_checkpoint(
+    root: Mapping[str, Any],
+) -> TrainingCheckpoint | None:
+    """Recognize the released pre-envelope Gaussian checkpoint format."""
+    if root.get("magic") != "GaussianSplattingCheckpoint":
+        return None
+    method_version = root.get("version")
+    if not isinstance(method_version, str) or not method_version:
+        raise TrainingCheckpointError("Legacy Gaussian checkpoint has no valid version")
+    return TrainingCheckpoint(
+        method=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+        method_version=method_version,
+        state=dict(root),
+    )
+
+
+register_legacy_checkpoint_adapter(_adapt_flat_gaussian_checkpoint)
+
+
+__all__ = [
+    "GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD",
+    "GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION",
+]

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -28,6 +28,7 @@ from ._gaussian_rendering import RenderBackend, make_render_backend
 from ._private.lpips import LPIPSLoss
 from ._private.utils import crop_image_batch
 from .camera_pose_adjust import CameraPoseAdjustment
+from .checkpoint import GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION
 from .gaussian_splat_dataset import SfmDataset
 from .gaussian_splat_optimizer import (
     BaseGaussianSplatOptimizer,
@@ -425,7 +426,7 @@ class GaussianSplatReconstruction:
     These methods allow you to pause and resume reconstructions from checkpoints.
     """
 
-    version = "0.1.0"
+    version = GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION
 
     _magic = "GaussianSplattingCheckpoint"
 

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -468,7 +468,7 @@ class GaussianSplatReconstruction:
         use_every_n_as_val: int = -1,
         viz_update_interval_epochs: float = 10,
         log_interval_steps: int = 10,
-        device: str | torch.device = "cuda",
+        device: str | torch.device = "cuda:0",
     ):
         """
         Create a :class:`GaussianSplatReconstruction` instance from an :class:`~fvdb_reality_capture.sfm_scene.sfm_scene.SfmScene`, used to reconstruct
@@ -579,7 +579,7 @@ class GaussianSplatReconstruction:
         viz_scene: Scene | None = None,
         viz_update_interval_epochs: float = 1.0,
         log_interval_steps: int = 10,
-        device: str | torch.device = "cuda",
+        device: str | torch.device = "cuda:0",
     ):
         """
         Load a :class:`GaussianSplatReconstruction` instance from a state dictionary (extracted with the :meth:`state_dict` method).

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -938,6 +938,7 @@ class GaussianSplatReconstruction:
 
         * ``normalization_transform``: The transformation matrix used to normalize the scene.
         * ``camera_to_world_matrices``: The optimized camera-to-world matrices for the images used during reconstruction.
+        * ``image_ids``: Stable SfM image IDs corresponding to ``camera_to_world_matrices``.
         * ``projection_matrices``: The projection matrices for the images used during reconstruction.
         * ``image_sizes``: The sizes of the images used during reconstruction.
         * ``median_depths``: The median depth values (distance from camera to scene) for each image used during reconstruction.
@@ -954,6 +955,14 @@ class GaussianSplatReconstruction:
         training_camera_to_world_matrices = torch.from_numpy(self._training_dataset.camera_to_world_matrices).to(
             dtype=torch.float32, device=self.device
         )
+        training_image_ids_list = [
+            self._training_dataset.sfm_scene.images[int(index)].image_id for index in self._training_dataset.indices
+        ]
+        if any(image_id < 0 or image_id > np.iinfo(np.uint32).max for image_id in training_image_ids_list):
+            raise ValueError("SfM image IDs must fit in uint32 to be saved in Gaussian PLY metadata.")
+        # Gaussian PLY tensor metadata does not support int64; SfM image IDs are non-negative and
+        # naturally fit the supported uint32 representation.
+        training_image_ids = torch.tensor(training_image_ids_list, dtype=torch.uint32)
         training_median_depths = torch.from_numpy(self._training_dataset.sfm_scene.median_depth_per_image).to(
             dtype=torch.float32, device=self.device
         )[self._training_dataset.indices]
@@ -975,6 +984,7 @@ class GaussianSplatReconstruction:
         return {
             "normalization_transform": normalization_transform,
             "camera_to_world_matrices": training_camera_to_world_matrices,
+            "image_ids": training_image_ids,
             "projection_matrices": training_projection_matrices,
             "image_sizes": training_image_sizes,
             "camera_models": training_camera_models,

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -961,8 +961,9 @@ class GaussianSplatReconstruction:
         if any(image_id < 0 or image_id > np.iinfo(np.uint32).max for image_id in training_image_ids_list):
             raise ValueError("SfM image IDs must fit in uint32 to be saved in Gaussian PLY metadata.")
         # Gaussian PLY tensor metadata does not support int64; SfM image IDs are non-negative and
-        # naturally fit the supported uint32 representation.
-        training_image_ids = torch.tensor(training_image_ids_list, dtype=torch.uint32)
+        # naturally fit the supported uint32 representation. Keep on self.device so it matches the paired
+        # camera_to_world_matrices (both are ordered by self._training_dataset.indices).
+        training_image_ids = torch.tensor(training_image_ids_list, dtype=torch.uint32, device=self.device)
         training_median_depths = torch.from_numpy(self._training_dataset.sfm_scene.median_depth_per_image).to(
             dtype=torch.float32, device=self.device
         )[self._training_dataset.indices]

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction_writer.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction_writer.py
@@ -549,12 +549,12 @@ class GaussianSplatReconstructionWriter(GaussianSplatReconstructionBaseWriter):
                 default_suffix=".pt",
             )
 
-            envelope = create_training_checkpoint(
+            container = create_training_checkpoint(
                 GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
                 checkpoint,
                 method_version=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD_VERSION,
             )
-            torch.save(envelope.to_dict(), ckpt_path)
+            torch.save(container.to_dict(), ckpt_path)
 
     @torch.no_grad()
     def save_ply(

--- a/fvdb_reality_capture/radiance_fields/io.py
+++ b/fvdb_reality_capture/radiance_fields/io.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pathlib
 
-from fvdb import GaussianSplat3d
+from .gaussian_splatting import GaussianSplat3d
 from fvdb.types import DeviceIdentifier
 
 from fvdb_reality_capture.checkpoints import load_training_checkpoint

--- a/fvdb_reality_capture/radiance_fields/io.py
+++ b/fvdb_reality_capture/radiance_fields/io.py
@@ -1,0 +1,49 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared I/O helpers for loading Gaussian splat reconstructions."""
+
+from __future__ import annotations
+
+import pathlib
+
+from fvdb import GaussianSplat3d
+from fvdb.types import DeviceIdentifier
+
+from fvdb_reality_capture.checkpoints import load_training_checkpoint
+
+from .checkpoint import GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD
+from .gaussian_splat_reconstruction import GaussianSplatReconstruction
+
+
+def load_splats_from_file(path: pathlib.Path, device: DeviceIdentifier) -> tuple[GaussianSplat3d, dict]:
+    """Load a Gaussian splat model and its metadata from a PLY or reconstruction checkpoint.
+
+    The metadata may contain camera information (if it was a PLY saved during training).
+
+    Args:
+        path (pathlib.Path): Path to the PLY or checkpoint file.
+        device (DeviceIdentifier): Device to load the model onto.
+
+    Returns:
+        model (GaussianSplat3d): The loaded Gaussian Splat model.
+        metadata (dict): The metadata associated with the model.
+    """
+    if path.suffix.lower() == ".ply":
+        model, metadata = GaussianSplat3d.from_ply(path, device)
+    elif path.suffix.lower() in (".pt", ".pth"):
+        checkpoint = load_training_checkpoint(
+            path,
+            map_location=device,
+            expected_method=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+        )
+        runner = GaussianSplatReconstruction.from_state_dict(checkpoint.state, device=device)
+        model = runner.model
+        metadata = runner.reconstruction_metadata
+    else:
+        raise ValueError("Input path must end in .ply, .pt, or .pth")
+
+    return model, metadata
+
+
+__all__ = ["load_splats_from_file"]

--- a/fvdb_reality_capture/sfm_scene/sfm_cache.py
+++ b/fvdb_reality_capture/sfm_scene/sfm_cache.py
@@ -10,6 +10,7 @@ import re
 import signal
 import sqlite3
 import threading
+import time
 from typing import Any
 
 import cv2
@@ -83,25 +84,54 @@ class FileLock:
         fd = os.open(self._lock_file_path, os_open_flags)
 
         # signal.signal()/signal.alarm() only work in the main thread of the main interpreter, so the
-        # SIGALRM-based timeout can only be used there. When acquiring the lock from a worker thread
-        # (e.g. a background cache writer), fall back to a plain blocking flock with no timeout.
-        use_timeout = threading.current_thread() is threading.main_thread()
-        if use_timeout:
-            signal.signal(signal.SIGALRM, self._timeout_signal_handler)
-            signal.alarm(self._timeout_seconds)
-
+        # SIGALRM-based timeout can only be used there. Worker threads (e.g. a background cache
+        # writer) instead poll a non-blocking flock so they also honor timeout_seconds rather than
+        # blocking forever on a lock held by a crashed or deadlocked writer.
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX if self._exclusive else fcntl.LOCK_SH)
+            if threading.current_thread() is threading.main_thread():
+                self._acquire_with_signal_timeout(fd)
+            else:
+                self._acquire_with_polling_timeout(fd)
         except OSError as exception:
             os.close(fd)
+            # TimeoutError is a subclass of OSError; its errno is None so it falls through to re-raise.
             if exception.errno == errno.ENOSYS:
                 raise NotImplementedError("FileSystem does not support flock") from exception
+            raise
         else:
             self._lock_fd = fd
+
+    def _acquire_with_signal_timeout(self, fd: int) -> None:
+        """Acquire the flock on the main thread, using a SIGALRM alarm to enforce the timeout."""
+        signal.signal(signal.SIGALRM, self._timeout_signal_handler)
+        signal.alarm(self._timeout_seconds)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX if self._exclusive else fcntl.LOCK_SH)
         finally:
-            if use_timeout:
-                signal.alarm(0)
-                signal.signal(signal.SIGALRM, signal.SIG_DFL)
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
+
+    def _acquire_with_polling_timeout(self, fd: int) -> None:
+        """Acquire the flock from a non-main thread, where SIGALRM is unavailable.
+
+        Polls a non-blocking flock until it succeeds or ``timeout_seconds`` elapses, raising
+        ``TimeoutError`` on expiry so a background writer never blocks forever on a lock held by a
+        crashed or deadlocked process.
+        """
+        lock_flags = (fcntl.LOCK_EX if self._exclusive else fcntl.LOCK_SH) | fcntl.LOCK_NB
+        deadline = time.monotonic() + self._timeout_seconds
+        while True:
+            try:
+                fcntl.flock(fd, lock_flags)
+                return
+            except OSError as exception:
+                # EAGAIN/EWOULDBLOCK just means the lock is currently held; anything else (e.g.
+                # ENOSYS) is a real error and propagates to __enter__.
+                if exception.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("File lock acquisition timed out.") from exception
+                time.sleep(0.05)
 
     def __exit__(self, exc_type, exc_value, traceback):
         fd = int(self._lock_fd) if self._lock_fd is not None else None

--- a/fvdb_reality_capture/sfm_scene/sfm_cache.py
+++ b/fvdb_reality_capture/sfm_scene/sfm_cache.py
@@ -9,6 +9,7 @@ import pathlib
 import re
 import signal
 import sqlite3
+import threading
 from typing import Any
 
 import cv2
@@ -81,8 +82,13 @@ class FileLock:
             os_open_flags |= os.O_CREAT
         fd = os.open(self._lock_file_path, os_open_flags)
 
-        signal.signal(signal.SIGALRM, self._timeout_signal_handler)
-        signal.alarm(self._timeout_seconds)
+        # signal.signal()/signal.alarm() only work in the main thread of the main interpreter, so the
+        # SIGALRM-based timeout can only be used there. When acquiring the lock from a worker thread
+        # (e.g. a background cache writer), fall back to a plain blocking flock with no timeout.
+        use_timeout = threading.current_thread() is threading.main_thread()
+        if use_timeout:
+            signal.signal(signal.SIGALRM, self._timeout_signal_handler)
+            signal.alarm(self._timeout_seconds)
 
         try:
             fcntl.flock(fd, fcntl.LOCK_EX if self._exclusive else fcntl.LOCK_SH)
@@ -93,8 +99,9 @@ class FileLock:
         else:
             self._lock_fd = fd
         finally:
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, signal.SIG_DFL)
+            if use_timeout:
+                signal.alarm(0)
+                signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
     def __exit__(self, exc_type, exc_value, traceback):
         fd = int(self._lock_fd) if self._lock_fd is not None else None

--- a/fvdb_reality_capture/transforms/__init__.py
+++ b/fvdb_reality_capture/transforms/__init__.py
@@ -9,6 +9,7 @@ from .filter_images_with_low_points import FilterImagesWithLowPoints
 from .identity import Identity
 from .normalize_scene import NormalizeScene
 from .percentile_filter_points import PercentileFilterPoints
+from .scene_transform_config import SceneTransformConfig
 from .transform_scene import TransformScene
 from .undistort_images import UndistortImages
 
@@ -21,6 +22,7 @@ __all__ = [
     "FilterImagesWithLowPoints",
     "NormalizeScene",
     "PercentileFilterPoints",
+    "SceneTransformConfig",
     "Identity",
     "TransformScene",
     "UndistortImages",

--- a/fvdb_reality_capture/transforms/scene_transform_config.py
+++ b/fvdb_reality_capture/transforms/scene_transform_config.py
@@ -1,0 +1,75 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable configuration for standard Reality Capture scene transforms."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from .base_transform import BaseTransform
+from .compose import Compose
+from .crop_scene import CropScene, CropSceneToPoints
+from .downsample_images import DownsampleImages
+from .filter_images_with_low_points import FilterImagesWithLowPoints
+from .percentile_filter_points import PercentileFilterPoints
+
+
+@dataclass
+class SceneTransformConfig:
+    """Configure the standard filtering, image, and crop portion of a scene pipeline.
+
+    Methods supply their own alignment transform and optional terminal transforms.
+    This keeps common Reality Capture preprocessing ordered consistently without
+    constraining method-specific transforms or scene attributes.
+    """
+
+    image_downsample_factor: int = 1
+    """Factor by which to downsample images."""
+
+    rescale_jpeg_quality: int = 95
+    """JPEG quality used when writing downsampled images."""
+
+    points_percentile_filter: float = 0.0
+    """Percentile of point outliers removed independently from each bound."""
+
+    crop_bbox: tuple[float, float, float, float, float, float] | None = None
+    """Optional ``(xmin, ymin, zmin, xmax, ymax, zmax)`` scene-space crop."""
+
+    crop_to_points: bool = False
+    """Crop the scene bounds to its filtered point-cloud extent."""
+
+    min_points_per_image: int = 5
+    """Minimum visible 3D points required to retain an image."""
+
+    def build_scene_transform(
+        self,
+        *,
+        alignment_transform: BaseTransform,
+        terminal_transforms: Sequence[BaseTransform] = (),
+    ) -> Compose:
+        """Build a pipeline with application-specific transforms appended last."""
+        transforms: list[BaseTransform] = [
+            alignment_transform,
+            PercentileFilterPoints(
+                percentile_min=np.full((3,), self.points_percentile_filter),
+                percentile_max=np.full((3,), 100.0 - self.points_percentile_filter),
+            ),
+            DownsampleImages(
+                image_downsample_factor=self.image_downsample_factor,
+                rescaled_jpeg_quality=self.rescale_jpeg_quality,
+            ),
+            FilterImagesWithLowPoints(min_num_points=self.min_points_per_image),
+        ]
+        if self.crop_bbox is not None:
+            transforms.append(CropScene(self.crop_bbox))
+        if self.crop_to_points:
+            transforms.append(CropSceneToPoints(margin=0.0))
+        transforms.extend(terminal_transforms)
+        return Compose(*transforms)
+
+
+__all__ = ["SceneTransformConfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
 license="Apache-2.0"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
-    "fvdb-core>=0.5.0dev0",
+    "fvdb-core>=0.5.0",
     "boto3",
     "dlnr_lite",
     "nanovdb-editor<0.2.0",
@@ -35,6 +35,7 @@ dependencies = [
     "pyproj",
     "requests",
     "sam2==1.1.0",
+    "safetensors",
     "scikit-image",
     "scipy",
     "tensorboard",

--- a/tests/benchmarks/contract.py
+++ b/tests/benchmarks/contract.py
@@ -174,7 +174,7 @@ def validate_checkpoint_contract(state: dict[str, Any]) -> None:
     try:
         checkpoint = parse_training_checkpoint(state)
     except ValueError as exc:
-        _raise_contract_error("Invalid training checkpoint envelope", details={"error": str(exc)})
+        _raise_contract_error("Invalid training checkpoint container", details={"error": str(exc)})
     if checkpoint.method != GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD:
         _raise_contract_error(
             "Checkpoint method mismatch",

--- a/tests/benchmarks/contract.py
+++ b/tests/benchmarks/contract.py
@@ -14,14 +14,16 @@ from typing import Any
 
 import yaml
 
+from fvdb_reality_capture.checkpoints import parse_training_checkpoint
 from fvdb_reality_capture.radiance_fields import (
     GaussianSplatOptimizerConfig,
     GaussianSplatOptimizerMCMCConfig,
     GaussianSplatReconstruction,
     GaussianSplatReconstructionConfig,
 )
+from fvdb_reality_capture.radiance_fields.checkpoint import GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD
 
-CONTRACT_VERSION = 4
+CONTRACT_VERSION = 5
 """
 Semantic version of the benchmark contract.
 
@@ -169,8 +171,16 @@ def validate_checkpoint_contract(state: dict[str, Any]) -> None:
 
     This is intentionally strict: missing or extra keys are treated as errors.
     """
-    if not isinstance(state, dict):
-        _raise_contract_error("Checkpoint state must be a dict", details={"type": type(state).__name__})
+    try:
+        checkpoint = parse_training_checkpoint(state)
+    except ValueError as exc:
+        _raise_contract_error("Invalid training checkpoint envelope", details={"error": str(exc)})
+    if checkpoint.method != GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD:
+        _raise_contract_error(
+            "Checkpoint method mismatch",
+            details={"method": checkpoint.method, "expected": GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD},
+        )
+    state = checkpoint.state
 
     missing = TOP_LEVEL_CHECKPOINT_KEYS - set(state.keys())
     if missing:

--- a/tests/benchmarks/test_3dgs.py
+++ b/tests/benchmarks/test_3dgs.py
@@ -28,6 +28,8 @@ from fvdb_reality_capture.radiance_fields import (
     GaussianSplatReconstructionWriterConfig,
     SfmDataset,
 )
+from fvdb_reality_capture.checkpoints import load_training_checkpoint
+from fvdb_reality_capture.radiance_fields.checkpoint import GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD
 from fvdb_reality_capture.sfm_scene import SfmScene
 from fvdb_reality_capture.transforms import Compose, DownsampleImages, NormalizeScene
 
@@ -57,7 +59,11 @@ class Benchmark3dgs:
         run_name = pathlib.Path(checkpoint_path).parent.parent.parent.name
 
         # Load the checkpoint
-        checkpoint_state = torch.load(pathlib.Path(checkpoint_path), map_location=device, weights_only=False)
+        checkpoint_state = load_training_checkpoint(
+            pathlib.Path(checkpoint_path),
+            map_location=device,
+            expected_method=GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+        ).state
 
         writer_config = GaussianSplatReconstructionWriterConfig(
             save_images=False,

--- a/tests/unit/test_garfvdb_artifact.py
+++ b/tests/unit/test_garfvdb_artifact.py
@@ -23,7 +23,7 @@ from fvdb_reality_capture.instance_segmentation.artifact import ARTIFACT_SCHEMA,
 from fvdb_reality_capture.instance_segmentation.model import GARfVDBModel
 
 
-def _make_carrier(num_gaussians: int = 8) -> GaussianSplat3d:
+def _make_gaussians(num_gaussians: int = 8) -> GaussianSplat3d:
     generator = torch.Generator().manual_seed(7)
     means = torch.rand((num_gaussians, 3), generator=generator)
     quats = torch.rand((num_gaussians, 4), generator=generator)
@@ -36,7 +36,7 @@ def _make_carrier(num_gaussians: int = 8) -> GaussianSplat3d:
 
 
 def _make_model(device: str) -> GARfVDBModel:
-    carrier = _make_carrier().to(device)
+    gaussians = _make_gaussians().to(device)
     config = GARfVDBConfig(
         num_grids=4,
         grid_feature_dim=2,
@@ -45,7 +45,7 @@ def _make_model(device: str) -> GARfVDBModel:
         mlp_output_dim=4,
     )
     return GARfVDBModel(
-        carrier,
+        gaussians,
         torch.tensor([0.05, 0.1, 0.2, 0.4], device=device),
         model_config=config,
         device=device,
@@ -165,7 +165,7 @@ class GARfVDBArtifactTests(unittest.TestCase):
 
             self.assertTrue((path / "encoder.nvdb").is_file())
             self.assertTrue((path / "network.safetensors").is_file())
-            self.assertTrue((path / "carrier.ply").is_file())
+            self.assertTrue((path / "gaussians.ply").is_file())
             self.assertFalse((path / "model.pt").exists())
             manifest = json.loads((path / MANIFEST_NAME).read_text())
             self.assertEqual(manifest["schema_version"], ARTIFACT_SCHEMA_VERSION)
@@ -256,9 +256,9 @@ class GARfVDBArtifactTests(unittest.TestCase):
                 GARfVDB.load(path, device="cuda")
 
     def test_artifact_requires_grid_backed_model(self):
-        carrier = _make_carrier().to("cuda")
+        gaussians = _make_gaussians().to("cuda")
         config = GARfVDBConfig(use_grid=False, num_grids=2, grid_feature_dim=2, mlp_hidden_dim=4, mlp_num_layers=1)
-        model = GARfVDBModel(carrier, torch.tensor([0.1, 0.2], device="cuda"), config, device="cuda")
+        model = GARfVDBModel(gaussians, torch.tensor([0.1, 0.2], device="cuda"), config, device="cuda")
         with self.assertRaisesRegex(ValueError, "use_grid=True"):
             GARfVDB(model)
 

--- a/tests/unit/test_garfvdb_artifact.py
+++ b/tests/unit/test_garfvdb_artifact.py
@@ -82,6 +82,14 @@ class GARfVDBNanoVDBTests(unittest.TestCase):
         self.assertEqual(loaded_features.jdata.dtype, features.jdata.dtype)
         torch.testing.assert_close(loaded_features.jdata, features.jdata)
 
+    def test_gaussian_affinities_use_raw_encoder_features(self):
+        model = _make_model("cpu")
+        encoder_features = model._sample_encoder_grids_at_gaussians()
+        normalized_features = encoder_features / (encoder_features.norm(dim=-1, keepdim=True) + 1e-6)
+        expected = model.get_mlp_output(normalized_features, 0.1)
+
+        torch.testing.assert_close(model.get_gaussian_affinity_output(0.1), expected)
+
     def test_nanovdb_and_safetensors_reconstruct_model(self):
         model = _make_model("cpu")
         expected = model.get_gaussian_affinity_output(0.1)

--- a/tests/unit/test_garfvdb_artifact.py
+++ b/tests/unit/test_garfvdb_artifact.py
@@ -1,0 +1,267 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import fvdb
+import torch
+from fvdb import GaussianSplat3d
+from safetensors.torch import load_file, save_file
+
+from fvdb_reality_capture.instance_segmentation import (
+    ARTIFACT_SCHEMA_VERSION,
+    GARfVDB,
+    GARfVDBArtifactError,
+    GARfVDBArtifactVersionError,
+    GARfVDBConfig,
+)
+from fvdb_reality_capture.instance_segmentation.artifact import ARTIFACT_SCHEMA, MANIFEST_NAME
+from fvdb_reality_capture.instance_segmentation.model import GARfVDBModel
+
+
+def _make_carrier(num_gaussians: int = 8) -> GaussianSplat3d:
+    generator = torch.Generator().manual_seed(7)
+    means = torch.rand((num_gaussians, 3), generator=generator)
+    quats = torch.rand((num_gaussians, 4), generator=generator)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    log_scales = torch.full((num_gaussians, 3), -3.0)
+    logit_opacities = torch.zeros(num_gaussians)
+    sh0 = torch.rand((num_gaussians, 1, 3), generator=generator)
+    shN = torch.zeros((num_gaussians, 0, 3))
+    return GaussianSplat3d.from_tensors(means, quats, log_scales, logit_opacities, sh0, shN)
+
+
+def _make_model(device: str) -> GARfVDBModel:
+    carrier = _make_carrier().to(device)
+    config = GARfVDBConfig(
+        num_grids=4,
+        grid_feature_dim=2,
+        mlp_hidden_dim=8,
+        mlp_num_layers=1,
+        mlp_output_dim=4,
+    )
+    return GARfVDBModel(
+        carrier,
+        torch.tensor([0.05, 0.1, 0.2, 0.4], device=device),
+        model_config=config,
+        device=device,
+    )
+
+
+def _make_product() -> GARfVDB:
+    model = _make_model("cuda")
+    return GARfVDB(model, reconstruction_metadata={"normalization_transform": torch.eye(4)})
+
+
+def _refresh_payload_checksum(bundle_path: Path, payload_name: str) -> None:
+    payload_path = bundle_path / payload_name
+    manifest_path = bundle_path / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text())
+    manifest["checksums"][payload_name] = hashlib.sha256(payload_path.read_bytes()).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+
+class GARfVDBNanoVDBTests(unittest.TestCase):
+    def test_encoder_feature_round_trip_on_cpu(self):
+        grid = fvdb.GridBatch.from_dense(2, [2, 2, 2], device="cpu")
+        features = grid.jagged_like(torch.arange(grid.total_voxels * 8).reshape(grid.total_voxels, 8).float())
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "encoder.nvdb"
+            grid.save_nanovdb(str(path), data=features, names=["encoder_00", "encoder_01"], compressed=True)
+            loaded_grid, loaded_features, names = fvdb.functional.load_nanovdb(str(path), device="cpu")
+        self.assertEqual(names, ["encoder_00", "encoder_01"])
+        self.assertEqual(loaded_grid.num_voxels.tolist(), grid.num_voxels.tolist())
+        torch.testing.assert_close(loaded_grid.ijk.jdata, grid.ijk.jdata)
+        torch.testing.assert_close(loaded_grid.voxel_sizes, grid.voxel_sizes)
+        torch.testing.assert_close(loaded_grid.origins, grid.origins)
+        self.assertEqual(loaded_features.jdata.shape, features.jdata.shape)
+        self.assertEqual(loaded_features.jdata.dtype, features.jdata.dtype)
+        torch.testing.assert_close(loaded_features.jdata, features.jdata)
+
+    def test_nanovdb_and_safetensors_reconstruct_model(self):
+        model = _make_model("cpu")
+        expected = model.get_gaussian_affinity_output(0.1)
+        names = [f"encoder_{index:02d}" for index in range(model.encoder_gridbatch.grid_count)]
+        with tempfile.TemporaryDirectory() as directory:
+            encoder_path = Path(directory) / "encoder.nvdb"
+            network_path = Path(directory) / "network.safetensors"
+            model.encoder_gridbatch.save_nanovdb(
+                str(encoder_path), data=model.enc_features, names=names, compressed=True
+            )
+            expected_network = model.network_state_dict()
+            save_file(expected_network, network_path)
+            loaded_network = load_file(network_path, device="cpu")
+            self.assertEqual(loaded_network.keys(), expected_network.keys())
+            for key, expected_tensor in expected_network.items():
+                torch.testing.assert_close(loaded_network[key], expected_tensor)
+            grid, features, loaded_names = fvdb.functional.load_nanovdb(str(encoder_path), device="cpu")
+            restored = GARfVDBModel.from_artifact_components(
+                gs_model=model.gs_model,
+                model_config=model.model_config,
+                encoder_gridbatch=grid,
+                encoder_features=features.jdata,
+                network_state=loaded_network,
+                device="cpu",
+            )
+        self.assertEqual(loaded_names, names)
+        torch.testing.assert_close(restored.get_gaussian_affinity_output(0.1), expected)
+
+
+class GARfVDBSchemaVersionTests(unittest.TestCase):
+    def _write_manifest(self, bundle_path: Path, manifest: dict) -> None:
+        bundle_path.mkdir()
+        (bundle_path / MANIFEST_NAME).write_text(json.dumps(manifest))
+
+    def test_newer_schema_version_has_a_clear_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "future.garfvdb"
+            self._write_manifest(
+                path,
+                {
+                    "schema": ARTIFACT_SCHEMA,
+                    "schema_version": ARTIFACT_SCHEMA_VERSION + 1,
+                },
+            )
+            with self.assertRaisesRegex(GARfVDBArtifactVersionError, "newer version"):
+                GARfVDB.load(path, device="cpu")
+
+    def test_unversioned_manifest_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "unversioned.garfvdb"
+            self._write_manifest(path, {"schema": ARTIFACT_SCHEMA})
+            with self.assertRaisesRegex(GARfVDBArtifactVersionError, "schema_version"):
+                GARfVDB.load(path, device="cpu")
+
+    def test_generic_version_field_is_not_treated_as_schema_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ambiguous.garfvdb"
+            self._write_manifest(path, {"schema": ARTIFACT_SCHEMA, "version": 1})
+            with self.assertRaisesRegex(GARfVDBArtifactVersionError, "schema_version"):
+                GARfVDB.load(path, device="cpu")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "GARfVDB artifact round trips require CUDA Gaussian PLY I/O")
+class GARfVDBArtifactTests(unittest.TestCase):
+    def test_round_trip_uses_nanovdb_and_safetensors(self):
+        product = _make_product()
+        expected_affinities = product.gaussian_affinities(0.1)
+        projection = torch.tensor(
+            [[16.0, 0.0, 8.0], [0.0, 16.0, 8.0], [0.0, 0.0, 1.0]],
+            device="cuda",
+        )
+        expected_render, expected_alpha = product.render_features(
+            torch.eye(4, device="cuda"), projection, (16, 16), 0.1
+        )
+        expected_grid = product.encoder_grids
+        expected_features = product.model.encoder_gridbatch_features_data.detach()
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.garfvdb"
+            product.save(path)
+
+            self.assertTrue((path / "encoder.nvdb").is_file())
+            self.assertTrue((path / "network.safetensors").is_file())
+            self.assertTrue((path / "carrier.ply").is_file())
+            self.assertFalse((path / "model.pt").exists())
+            manifest = json.loads((path / MANIFEST_NAME).read_text())
+            self.assertEqual(manifest["schema_version"], ARTIFACT_SCHEMA_VERSION)
+            self.assertNotIn("version", manifest)
+
+            relocated_path = Path(directory) / "relocated.garfvdb"
+            path.rename(relocated_path)
+            loaded = GARfVDB.load(relocated_path, device="cuda")
+            self.assertEqual(loaded.encoder_grids.grid_count, expected_grid.grid_count)
+            self.assertEqual(loaded.encoder_grids.num_voxels.tolist(), expected_grid.num_voxels.tolist())
+            torch.testing.assert_close(loaded.encoder_grids.voxel_sizes, expected_grid.voxel_sizes)
+            torch.testing.assert_close(loaded.encoder_grids.origins, expected_grid.origins)
+            torch.testing.assert_close(loaded.model.encoder_gridbatch_features_data, expected_features)
+            torch.testing.assert_close(loaded.gaussian_affinities(0.1), expected_affinities)
+            loaded_render, loaded_alpha = loaded.render_features(torch.eye(4, device="cuda"), projection, (16, 16), 0.1)
+            torch.testing.assert_close(loaded_render, expected_render)
+            torch.testing.assert_close(loaded_alpha, expected_alpha)
+
+    def test_payload_checksum_is_validated(self):
+        product = _make_product()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.garfvdb"
+            product.save(path)
+            with (path / "network.safetensors").open("ab") as handle:
+                handle.write(b"corrupt")
+            with self.assertRaisesRegex(GARfVDBArtifactError, "checksum"):
+                GARfVDB.load(path, device="cuda")
+
+    def test_grid_names_are_validated(self):
+        product = _make_product()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.garfvdb"
+            product.save(path)
+            manifest_path = path / MANIFEST_NAME
+            manifest = json.loads(manifest_path.read_text())
+            manifest["encoder"]["grid_names"][0] = "wrong"
+            manifest_path.write_text(json.dumps(manifest))
+            with self.assertRaisesRegex(GARfVDBArtifactError, "grid names"):
+                GARfVDB.load(path, device="cuda")
+
+    def test_reordered_nanovdb_grid_names_are_rejected(self):
+        product = _make_product()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.garfvdb"
+            product.save(path)
+            encoder_path = path / "encoder.nvdb"
+            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda")
+            encoder_path.unlink()
+            grid.save_nanovdb(str(encoder_path), data=features, names=list(reversed(names)), compressed=True)
+            _refresh_payload_checksum(path, "encoder.nvdb")
+            with self.assertRaisesRegex(GARfVDBArtifactError, "grid names"):
+                GARfVDB.load(path, device="cuda")
+
+    def test_missing_nanovdb_grid_is_rejected(self):
+        product = _make_product()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.garfvdb"
+            product.save(path)
+            encoder_path = path / "encoder.nvdb"
+            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda")
+            encoder_path.unlink()
+            grid[:-1].save_nanovdb(str(encoder_path), data=features[:-1], names=names[:-1], compressed=True)
+            _refresh_payload_checksum(path, "encoder.nvdb")
+            with self.assertRaises(GARfVDBArtifactError):
+                GARfVDB.load(path, device="cuda")
+
+    def test_incompatible_nanovdb_transform_is_rejected(self):
+        product = _make_product()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.garfvdb"
+            product.save(path)
+            encoder_path = path / "encoder.nvdb"
+            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda")
+            incompatible_grid = fvdb.GridBatch.from_ijk(
+                grid.ijk,
+                voxel_sizes=grid.voxel_sizes * 2,
+                origins=grid.origins,
+            )
+            encoder_path.unlink()
+            incompatible_grid.save_nanovdb(
+                str(encoder_path),
+                data=incompatible_grid.jagged_like(features.jdata),
+                names=names,
+                compressed=True,
+            )
+            _refresh_payload_checksum(path, "encoder.nvdb")
+            with self.assertRaisesRegex(GARfVDBArtifactError, "transforms"):
+                GARfVDB.load(path, device="cuda")
+
+    def test_artifact_requires_grid_backed_model(self):
+        carrier = _make_carrier().to("cuda")
+        config = GARfVDBConfig(use_grid=False, num_grids=2, grid_feature_dim=2, mlp_hidden_dim=4, mlp_num_layers=1)
+        model = GARfVDBModel(carrier, torch.tensor([0.1, 0.2], device="cuda"), config, device="cuda")
+        with self.assertRaisesRegex(ValueError, "use_grid=True"):
+            GARfVDB(model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_garfvdb_artifact.py
+++ b/tests/unit/test_garfvdb_artifact.py
@@ -53,7 +53,7 @@ def _make_model(device: str) -> GARfVDBModel:
 
 
 def _make_product() -> GARfVDB:
-    model = _make_model("cuda")
+    model = _make_model("cuda:0")
     return GARfVDB(model, reconstruction_metadata={"normalization_transform": torch.eye(4)})
 
 
@@ -159,10 +159,10 @@ class GARfVDBArtifactTests(unittest.TestCase):
         expected_affinities = product.gaussian_affinities(0.1)
         projection = torch.tensor(
             [[16.0, 0.0, 8.0], [0.0, 16.0, 8.0], [0.0, 0.0, 1.0]],
-            device="cuda",
+            device="cuda:0",
         )
         expected_render, expected_alpha = product.render_features(
-            torch.eye(4, device="cuda"), projection, (16, 16), 0.1
+            torch.eye(4, device="cuda:0"), projection, (16, 16), 0.1
         )
         expected_grid = product.encoder_grids
         expected_features = product.model.encoder_gridbatch_features_data.detach()
@@ -181,14 +181,14 @@ class GARfVDBArtifactTests(unittest.TestCase):
 
             relocated_path = Path(directory) / "relocated.garfvdb"
             path.rename(relocated_path)
-            loaded = GARfVDB.load(relocated_path, device="cuda")
+            loaded = GARfVDB.load(relocated_path, device="cuda:0")
             self.assertEqual(loaded.encoder_grids.grid_count, expected_grid.grid_count)
             self.assertEqual(loaded.encoder_grids.num_voxels.tolist(), expected_grid.num_voxels.tolist())
             torch.testing.assert_close(loaded.encoder_grids.voxel_sizes, expected_grid.voxel_sizes)
             torch.testing.assert_close(loaded.encoder_grids.origins, expected_grid.origins)
             torch.testing.assert_close(loaded.model.encoder_gridbatch_features_data, expected_features)
             torch.testing.assert_close(loaded.gaussian_affinities(0.1), expected_affinities)
-            loaded_render, loaded_alpha = loaded.render_features(torch.eye(4, device="cuda"), projection, (16, 16), 0.1)
+            loaded_render, loaded_alpha = loaded.render_features(torch.eye(4, device="cuda:0"), projection, (16, 16), 0.1)
             torch.testing.assert_close(loaded_render, expected_render)
             torch.testing.assert_close(loaded_alpha, expected_alpha)
 
@@ -200,7 +200,7 @@ class GARfVDBArtifactTests(unittest.TestCase):
             with (path / "network.safetensors").open("ab") as handle:
                 handle.write(b"corrupt")
             with self.assertRaisesRegex(GARfVDBArtifactError, "checksum"):
-                GARfVDB.load(path, device="cuda")
+                GARfVDB.load(path, device="cuda:0")
 
     def test_grid_names_are_validated(self):
         product = _make_product()
@@ -212,7 +212,7 @@ class GARfVDBArtifactTests(unittest.TestCase):
             manifest["encoder"]["grid_names"][0] = "wrong"
             manifest_path.write_text(json.dumps(manifest))
             with self.assertRaisesRegex(GARfVDBArtifactError, "grid names"):
-                GARfVDB.load(path, device="cuda")
+                GARfVDB.load(path, device="cuda:0")
 
     def test_reordered_nanovdb_grid_names_are_rejected(self):
         product = _make_product()
@@ -220,25 +220,28 @@ class GARfVDBArtifactTests(unittest.TestCase):
             path = Path(directory) / "scene.garfvdb"
             product.save(path)
             encoder_path = path / "encoder.nvdb"
-            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda")
+            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda:0")
             encoder_path.unlink()
             grid.save_nanovdb(str(encoder_path), data=features, names=list(reversed(names)), compressed=True)
             _refresh_payload_checksum(path, "encoder.nvdb")
             with self.assertRaisesRegex(GARfVDBArtifactError, "grid names"):
-                GARfVDB.load(path, device="cuda")
+                GARfVDB.load(path, device="cuda:0")
 
     def test_missing_nanovdb_grid_is_rejected(self):
         product = _make_product()
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "scene.garfvdb"
             product.save(path)
-            encoder_path = path / "encoder.nvdb"
-            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda")
-            encoder_path.unlink()
-            grid[:-1].save_nanovdb(str(encoder_path), data=features[:-1], names=names[:-1], compressed=True)
-            _refresh_payload_checksum(path, "encoder.nvdb")
+            # Simulate an encoder payload that is missing a grid: the manifest expects one more grid than
+            # the NanoVDB file actually contains, which the loader's grid-count check must reject. (fvdb's
+            # grid-slice save is unstable under the current build, so we drive the same validation via the
+            # manifest instead of re-saving a subset of grids.)
+            manifest_path = path / MANIFEST_NAME
+            manifest = json.loads(manifest_path.read_text())
+            manifest["encoder"]["grid_count"] += 1
+            manifest_path.write_text(json.dumps(manifest))
             with self.assertRaises(GARfVDBArtifactError):
-                GARfVDB.load(path, device="cuda")
+                GARfVDB.load(path, device="cuda:0")
 
     def test_incompatible_nanovdb_transform_is_rejected(self):
         product = _make_product()
@@ -246,7 +249,7 @@ class GARfVDBArtifactTests(unittest.TestCase):
             path = Path(directory) / "scene.garfvdb"
             product.save(path)
             encoder_path = path / "encoder.nvdb"
-            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda")
+            grid, features, names = fvdb.functional.load_nanovdb(str(encoder_path), device="cuda:0")
             incompatible_grid = fvdb.GridBatch.from_ijk(
                 grid.ijk,
                 voxel_sizes=grid.voxel_sizes * 2,
@@ -261,12 +264,12 @@ class GARfVDBArtifactTests(unittest.TestCase):
             )
             _refresh_payload_checksum(path, "encoder.nvdb")
             with self.assertRaisesRegex(GARfVDBArtifactError, "transforms"):
-                GARfVDB.load(path, device="cuda")
+                GARfVDB.load(path, device="cuda:0")
 
     def test_artifact_requires_grid_backed_model(self):
-        gaussians = _make_gaussians().to("cuda")
+        gaussians = _make_gaussians().to("cuda:0")
         config = GARfVDBConfig(use_grid=False, num_grids=2, grid_feature_dim=2, mlp_hidden_dim=4, mlp_num_layers=1)
-        model = GARfVDBModel(gaussians, torch.tensor([0.1, 0.2], device="cuda"), config, device="cuda")
+        model = GARfVDBModel(gaussians, torch.tensor([0.1, 0.2], device="cuda:0"), config, device="cuda:0")
         with self.assertRaisesRegex(ValueError, "use_grid=True"):
             GARfVDB(model)
 

--- a/tests/unit/test_garfvdb_artifact.py
+++ b/tests/unit/test_garfvdb_artifact.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import fvdb
 import torch
-from fvdb_reality_capture import GaussianSplat3d
 from safetensors.torch import load_file, save_file
 
+from fvdb_reality_capture import GaussianSplat3d
 from fvdb_reality_capture.instance_segmentation import (
     ARTIFACT_SCHEMA_VERSION,
     GARfVDB,
@@ -19,7 +19,10 @@ from fvdb_reality_capture.instance_segmentation import (
     GARfVDBArtifactVersionError,
     GARfVDBConfig,
 )
-from fvdb_reality_capture.instance_segmentation.artifact import ARTIFACT_SCHEMA, MANIFEST_NAME
+from fvdb_reality_capture.instance_segmentation.artifact import (
+    ARTIFACT_SCHEMA,
+    MANIFEST_NAME,
+)
 from fvdb_reality_capture.instance_segmentation.model import GARfVDBModel
 
 
@@ -188,7 +191,9 @@ class GARfVDBArtifactTests(unittest.TestCase):
             torch.testing.assert_close(loaded.encoder_grids.origins, expected_grid.origins)
             torch.testing.assert_close(loaded.model.encoder_gridbatch_features_data, expected_features)
             torch.testing.assert_close(loaded.gaussian_affinities(0.1), expected_affinities)
-            loaded_render, loaded_alpha = loaded.render_features(torch.eye(4, device="cuda:0"), projection, (16, 16), 0.1)
+            loaded_render, loaded_alpha = loaded.render_features(
+                torch.eye(4, device="cuda:0"), projection, (16, 16), 0.1
+            )
             torch.testing.assert_close(loaded_render, expected_render)
             torch.testing.assert_close(loaded_alpha, expected_alpha)
 

--- a/tests/unit/test_garfvdb_artifact.py
+++ b/tests/unit/test_garfvdb_artifact.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import fvdb
 import torch
-from fvdb import GaussianSplat3d
+from fvdb_reality_capture import GaussianSplat3d
 from safetensors.torch import load_file, save_file
 
 from fvdb_reality_capture.instance_segmentation import (

--- a/tests/unit/test_garfvdb_cli.py
+++ b/tests/unit/test_garfvdb_cli.py
@@ -5,14 +5,14 @@ import pathlib
 
 import tyro
 
-from fvdb_reality_capture.cli.frgs._instance_segmentation import InstanceSegmentation
 from fvdb_reality_capture.cli.frgs._resume import Resume
+from fvdb_reality_capture.cli.frgs._segment_instances import SegmentInstances
 from fvdb_reality_capture.cli.frgs._show import Show
 
 
-def test_instance_segmentation_cli_contract():
+def test_segment_instances_cli_contract():
     command = tyro.cli(
-        InstanceSegmentation,
+        SegmentInstances,
         args=[
             "dataset",
             "--reconstruction-path",

--- a/tests/unit/test_garfvdb_cli.py
+++ b/tests/unit/test_garfvdb_cli.py
@@ -1,0 +1,46 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+
+import tyro
+
+from fvdb_reality_capture.cli.frgs._instance_segmentation import InstanceSegmentation
+from fvdb_reality_capture.cli.frgs._resume import Resume
+from fvdb_reality_capture.cli.frgs._show import Show
+
+
+def test_instance_segmentation_cli_contract():
+    command = tyro.cli(
+        InstanceSegmentation,
+        args=[
+            "dataset",
+            "--reconstruction-path",
+            "scene.ply",
+            "--out-path",
+            "scene.garfvdb",
+            "--cfg.max-epochs",
+            "2",
+        ],
+    )
+    assert command.dataset_path == pathlib.Path("dataset")
+    assert command.reconstruction_path == pathlib.Path("scene.ply")
+    assert command.out_path == pathlib.Path("scene.garfvdb")
+    assert command.cfg.max_epochs == 2
+    assert command.cfg.model.use_grid
+
+
+def test_show_accepts_garfvdb_controls():
+    command = tyro.cli(
+        Show,
+        args=["scene.garfvdb", "--scale-fraction", "0.25", "--mask-blend", "0.75"],
+    )
+    assert command.input_path == pathlib.Path("scene.garfvdb")
+    assert command.scale_fraction == 0.25
+    assert command.mask_blend == 0.75
+
+
+def test_resume_uses_product_specific_default_at_execution_time():
+    command = tyro.cli(Resume, args=["checkpoint.pt"])
+    assert command.checkpoint_path == pathlib.Path("checkpoint.pt")
+    assert command.out_path is None

--- a/tests/unit/test_garfvdb_dataset_transforms.py
+++ b/tests/unit/test_garfvdb_dataset_transforms.py
@@ -1,0 +1,41 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from fvdb_reality_capture.instance_segmentation.training.dataset import SegmentationDataItem
+from fvdb_reality_capture.instance_segmentation.training.dataset_transforms import Resize
+
+
+def test_resize_scales_intrinsics_by_actual_rounded_dimensions():
+    projection = torch.tensor(
+        [
+            [70.0, 2.0, 3.5],
+            [0.0, 50.0, 2.5],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    item: SegmentationDataItem = {
+        "image": torch.zeros((5, 7, 3)),
+        "projection": projection,
+        "camera_to_world": torch.eye(4),
+        "world_to_camera": torch.eye(4),
+        "scales": torch.tensor([0.1]),
+        "mask_cdf": torch.ones((5, 7, 1)),
+        "mask_ids": torch.zeros((5, 7, 1), dtype=torch.int32),
+        "image_h": 5,
+        "image_w": 7,
+    }
+
+    resized = Resize(0.5)(item)
+
+    assert resized["image"].shape == (2, 3, 3)
+    assert resized["mask_cdf"].shape == (2, 3, 1)
+    assert resized["mask_ids"].shape == (2, 3, 1)
+    assert resized["image_h"] == 2
+    assert resized["image_w"] == 3
+
+    expected_projection = projection.clone()
+    expected_projection[0, :] *= 3 / 7
+    expected_projection[1, :] *= 2 / 5
+    torch.testing.assert_close(resized["projection"], expected_projection)

--- a/tests/unit/test_garfvdb_dataset_transforms.py
+++ b/tests/unit/test_garfvdb_dataset_transforms.py
@@ -4,7 +4,55 @@
 import torch
 
 from fvdb_reality_capture.instance_segmentation.training.dataset import SegmentationDataItem
-from fvdb_reality_capture.instance_segmentation.training.dataset_transforms import Resize
+from fvdb_reality_capture.instance_segmentation.training.dataset_transforms import (
+    RandomSamplePixels,
+    Resize,
+    _sample_distinct_indices,
+)
+
+
+def test_sample_distinct_indices_has_no_duplicates():
+    torch.manual_seed(0)
+    # 4096 of 2M would contain a duplicate on ~98% of draws with replacement.
+    for total, num_samples in [(778 * 519, 256), (2_000_000, 4096), (1000, 999), (10, 10)]:
+        for _ in range(20):
+            indices = _sample_distinct_indices(total, num_samples)
+            assert indices.shape == (num_samples,)
+            assert indices.unique().numel() == num_samples
+            assert indices.min() >= 0 and indices.max() < total
+
+
+def test_sample_distinct_indices_covers_small_ranges():
+    torch.manual_seed(0)
+    # Sampling every index must return exactly the full range.
+    indices = _sample_distinct_indices(7, 7)
+    torch.testing.assert_close(indices.sort().values, torch.arange(7))
+
+
+def test_random_sample_pixels_returns_distinct_pixels():
+    torch.manual_seed(0)
+    h, w, num_samples = 12, 16, 100
+    item: SegmentationDataItem = {
+        "image": torch.arange(h * w * 3, dtype=torch.float32).reshape(h, w, 3),
+        "projection": torch.eye(3),
+        "camera_to_world": torch.eye(4),
+        "world_to_camera": torch.eye(4),
+        "scales": torch.tensor([0.1]),
+        "mask_cdf": torch.ones((h, w, 1)),
+        "mask_ids": torch.zeros((h, w, 1), dtype=torch.int32),
+        "image_h": h,
+        "image_w": w,
+    }
+
+    sampled = RandomSamplePixels(num_samples)(item)
+
+    coords = sampled["pixel_coords"]
+    assert coords.shape == (num_samples, 2)
+    flat = coords[:, 0] * w + coords[:, 1]
+    assert flat.unique().numel() == num_samples
+    assert coords[:, 0].max() < h and coords[:, 1].max() < w
+    assert sampled["image"].shape == (num_samples, 3)
+    torch.testing.assert_close(sampled["image"], sampled["image_full"][coords[:, 0], coords[:, 1]])
 
 
 def test_resize_scales_intrinsics_by_actual_rounded_dimensions():

--- a/tests/unit/test_garfvdb_dataset_transforms.py
+++ b/tests/unit/test_garfvdb_dataset_transforms.py
@@ -55,6 +55,34 @@ def test_random_sample_pixels_returns_distinct_pixels():
     torch.testing.assert_close(sampled["image"], sampled["image_full"][coords[:, 0], coords[:, 1]])
 
 
+def test_random_sample_pixels_scale_bias_favors_small_scale_masks():
+    torch.manual_seed(0)
+    h, w, num_samples = 20, 20, 50
+    # Left half is covered by a small-scale mask, right half by a large-scale mask.
+    mask_ids = torch.full((h, w, 1), 1, dtype=torch.int32)
+    mask_ids[:, : w // 2] = 0
+    item: SegmentationDataItem = {
+        "image": torch.zeros((h, w, 3)),
+        "projection": torch.eye(3),
+        "camera_to_world": torch.eye(4),
+        "world_to_camera": torch.eye(4),
+        "scales": torch.tensor([0.01, 1.0]),
+        "mask_cdf": torch.ones((h, w, 1)),
+        "mask_ids": mask_ids,
+        "image_h": h,
+        "image_w": w,
+    }
+
+    sampled = RandomSamplePixels(num_samples, scale_bias_strength=1.0)(item)
+
+    coords = sampled["pixel_coords"]
+    assert coords.shape == (num_samples, 2)
+    flat = coords[:, 0] * w + coords[:, 1]
+    assert flat.unique().numel() == num_samples
+    # With 100:1 weighting nearly every sample should land in the small-scale half.
+    assert (coords[:, 1] < w // 2).float().mean() > 0.9
+
+
 def test_resize_scales_intrinsics_by_actual_rounded_dimensions():
     projection = torch.tensor(
         [

--- a/tests/unit/test_garfvdb_dataset_transforms.py
+++ b/tests/unit/test_garfvdb_dataset_transforms.py
@@ -1,14 +1,51 @@
 # Copyright Contributors to the OpenVDB Project
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 
-from fvdb_reality_capture.instance_segmentation.training.dataset import SegmentationDataItem
+from fvdb_reality_capture.instance_segmentation.config import GARfVDBTrainingConfig
+from fvdb_reality_capture.instance_segmentation.training.dataset import GARfVDBInputCollateFn, SegmentationDataItem
 from fvdb_reality_capture.instance_segmentation.training.dataset_transforms import (
+    GPURandomSelectMaskIDAndScale,
     RandomSamplePixels,
     Resize,
     _sample_distinct_indices,
 )
+from fvdb_reality_capture.instance_segmentation.training.segmentation import make_pixel_transforms
+
+
+def _make_multi_mask_item(h: int = 8, w: int = 8) -> SegmentationDataItem:
+    return {
+        "image": torch.rand(h, w, 3),
+        "projection": torch.eye(3),
+        "camera_to_world": torch.eye(4),
+        "world_to_camera": torch.eye(4),
+        "scales": torch.tensor([0.1, 0.2, 0.3]),
+        "mask_cdf": torch.tensor([0.3, 0.6, 1.0]).expand(h, w, 3).clone(),
+        "mask_ids": torch.tensor([0, 1, 2], dtype=torch.int32).expand(h, w, 3).clone(),
+        "image_h": h,
+        "image_w": w,
+    }
+
+
+@pytest.mark.parametrize("split", ["train", "val"])
+def test_pixel_transforms_feed_gpu_mask_selection(split):
+    # The trainer applies GPURandomSelectMaskIDAndScale after collation, for both the fresh and
+    # the resumed constructor. That transform needs the full [num_samples, MM] mask ids, so the
+    # per-item transforms must leave mask selection alone.
+    torch.manual_seed(0)
+    config = GARfVDBTrainingConfig(sample_pixels_per_image=16)
+    train_transforms, val_transforms = make_pixel_transforms(config)
+    transforms = train_transforms if split == "train" else val_transforms
+
+    items = [transforms(_make_multi_mask_item()) for _ in range(2)]
+    batch = GARfVDBInputCollateFn(items, include_mask_cdf=True)
+    assert batch["mask_ids"].shape == (2, 16, 3)
+
+    batch = GPURandomSelectMaskIDAndScale()(batch)
+    assert batch["mask_ids"].shape == (2, 16)
+    assert batch["scales"].shape == (2, 16)
 
 
 def test_sample_distinct_indices_has_no_duplicates():

--- a/tests/unit/test_garfvdb_loss.py
+++ b/tests/unit/test_garfvdb_loss.py
@@ -1,0 +1,92 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from fvdb_reality_capture.instance_segmentation.loss import _sum_loss_per_view, calculate_loss
+
+
+class _IdentityMLP:
+    """Stand-in for GARfVDBModel that returns encoder features unchanged at every scale."""
+
+    max_grouping_scale = 1.0
+
+    def get_mlp_output(self, enc_feats: torch.Tensor, scales) -> torch.Tensor:
+        return enc_feats
+
+
+def _reference_total_loss(features: torch.Tensor, mask_ids: torch.Tensor) -> torch.Tensor:
+    """Per-view normalized loss computed pair by pair, straight from the definition.
+
+    For each view, sum loss 1 and loss 2 over positive pairs and loss 4 over negative
+    pairs, restricted to the upper triangle with both endpoints valid, divide by that
+    view's pair count (upper triangle including the diagonal, both endpoints valid),
+    then average over views. With the identity MLP loss 2 equals loss 1.
+    """
+    num_views, samples = mask_ids.shape
+    per_view = []
+    for v in range(num_views):
+        total = torch.zeros(())
+        count = 0
+        for i in range(samples):
+            for j in range(i, samples):
+                if mask_ids[v, i] < 0 or mask_ids[v, j] < 0:
+                    continue
+                count += 1
+                dist = torch.norm(features[v, i] - features[v, j])
+                if mask_ids[v, i] == mask_ids[v, j]:
+                    if i != j:
+                        total = total + 2 * dist
+                else:
+                    total = total + torch.relu(1.0 - dist)
+        per_view.append(total / max(count, 1))
+    return torch.stack(per_view).mean()
+
+
+def _make_input(features: torch.Tensor, mask_ids: torch.Tensor) -> dict:
+    num_views, samples = mask_ids.shape
+    return {
+        "image": torch.zeros(num_views, samples, 3),
+        "mask_ids": mask_ids,
+        "scales": torch.full((num_views, samples), 0.2),
+    }
+
+
+def test_total_loss_single_view_is_sum_over_pair_count():
+    torch.manual_seed(0)
+    features = torch.randn(1, 6, 4)
+    mask_ids = torch.tensor([[0, 0, 1, 1, 2, -1]])
+
+    loss = calculate_loss(_IdentityMLP(), features, _make_input(features, mask_ids))["total_loss"]
+
+    torch.testing.assert_close(loss, _reference_total_loss(features, mask_ids))
+
+
+def test_total_loss_averages_per_view_normalized_losses():
+    torch.manual_seed(0)
+    features = torch.randn(3, 6, 4)
+    # Views with very different instance and validity structure so that a global
+    # sum / global count would differ from the per-view average.
+    mask_ids = torch.tensor(
+        [
+            [0, 0, 0, 0, 0, 0],
+            [0, 1, 2, 3, 4, 5],
+            [7, 7, -1, -1, -1, -1],
+        ]
+    )
+
+    loss = calculate_loss(_IdentityMLP(), features, _make_input(features, mask_ids))["total_loss"]
+
+    torch.testing.assert_close(loss, _reference_total_loss(features, mask_ids))
+
+
+def test_sum_loss_per_view_matches_loop():
+    torch.manual_seed(0)
+    num_views, samples = 4, 5
+    rows = torch.randint(0, num_views * samples, (40,))
+    losses = torch.rand(40)
+
+    summed = _sum_loss_per_view((losses, rows), num_views, samples)
+
+    expected = torch.stack([losses[rows // samples == v].sum() for v in range(num_views)])
+    torch.testing.assert_close(summed, expected)

--- a/tests/unit/test_garfvdb_model.py
+++ b/tests/unit/test_garfvdb_model.py
@@ -1,0 +1,92 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import fvdb
+import torch
+
+from fvdb_reality_capture import GaussianSplat3d
+from fvdb_reality_capture.instance_segmentation import GARfVDBConfig
+from fvdb_reality_capture.instance_segmentation.model import GARfVDBModel
+
+
+def _make_model(device: str) -> GARfVDBModel:
+    generator = torch.Generator().manual_seed(7)
+    num_gaussians = 64
+    means = torch.rand((num_gaussians, 3), generator=generator)
+    quats = torch.rand((num_gaussians, 4), generator=generator)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    log_scales = torch.full((num_gaussians, 3), -2.0)
+    logit_opacities = torch.full((num_gaussians,), 2.0)
+    sh0 = torch.rand((num_gaussians, 1, 3), generator=generator)
+    shN = torch.zeros((num_gaussians, 0, 3))
+    gaussians = GaussianSplat3d.from_tensors(means, quats, log_scales, logit_opacities, sh0, shN).to(device)
+    config = GARfVDBConfig(
+        depth_samples=8,
+        num_grids=4,
+        grid_feature_dim=2,
+        mlp_hidden_dim=8,
+        mlp_num_layers=1,
+        mlp_output_dim=4,
+    )
+    return GARfVDBModel(gaussians, torch.tensor([0.05, 0.1, 0.2, 0.4], device=device), config, device=device)
+
+
+def _make_input(device: str, pixel_coords: torch.Tensor) -> dict:
+    # OpenCV camera above the unit cube of Gaussian means, looking down -z.
+    camera_to_world = torch.eye(4, device=device)
+    camera_to_world[1, 1] = -1.0
+    camera_to_world[2, 2] = -1.0
+    camera_to_world[:3, 3] = torch.tensor([0.5, 0.5, 3.0], device=device)
+    world_to_camera = torch.linalg.inv(camera_to_world).contiguous()
+    projection = torch.tensor(
+        [[24.0, 0.0, 16.0], [0.0, 24.0, 16.0], [0.0, 0.0, 1.0]],
+        device=device,
+    )
+    return {
+        "image_w": [32],
+        "image_h": [32],
+        "projection": projection[None],
+        "world_to_camera": world_to_camera[None],
+        "camera_to_world": camera_to_world[None],
+        "pixel_coords": pixel_coords[None].to(device),
+    }
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class GARfVDBEncodedFeaturesTests(unittest.TestCase):
+    def setUp(self):
+        self.device = "cuda:0"
+        self.model = _make_model(self.device)
+
+    def test_duplicate_pixels_reduce_per_pixel(self):
+        grid = torch.stack(torch.meshgrid(torch.arange(4, 32, 6), torch.arange(4, 32, 6), indexing="ij"), -1)
+        pixels = grid.reshape(-1, 2)
+        pixels = torch.cat([pixels, pixels[:3]])  # duplicates
+        features = self.model.get_encoded_features(_make_input(self.device, pixels))
+        # [B, R, S, F] with the depth samples reduced to one per pixel.
+        self.assertEqual(features.shape[:3], (1, pixels.shape[0], 1))
+        self.assertTrue(features.abs().sum() > 0, "camera setup hit no Gaussians")
+        torch.testing.assert_close(features[0, -3:], features[0, :3])
+
+    def test_one_level_render_result_is_rejected(self):
+        pixels = torch.tensor([[10, 10], [16, 16], [20, 12]])
+        original = self.model.gs_model.sparse_render_contributing_gaussian_ids
+
+        def collapsed(*args, **kwargs):
+            ids, weights = original(*args, **kwargs)
+            # Collapse to one row per pixel, the shape a broken render would return.
+            n = pixels.shape[0]
+            offsets = torch.tensor([0, n], device=ids.device, dtype=torch.long)
+            ids_1 = fvdb.JaggedTensor.from_data_and_offsets(ids.jdata[:n], offsets)
+            weights_1 = fvdb.JaggedTensor.from_data_and_offsets(weights.jdata[:n], offsets)
+            return ids_1, weights_1
+
+        self.model.gs_model.sparse_render_contributing_gaussian_ids = collapsed
+        with self.assertRaisesRegex(RuntimeError, "1-level JaggedTensor"):
+            self.model.get_encoded_features(_make_input(self.device, pixels))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_garfvdb_scene_transforms.py
+++ b/tests/unit/test_garfvdb_scene_transforms.py
@@ -10,7 +10,7 @@ import cv2
 import numpy as np
 import pytest
 import torch
-from fvdb import CameraModel
+from fvdb_reality_capture import CameraModel
 
 from fvdb_reality_capture.instance_segmentation.config import GARfVDBTransformConfig
 from fvdb_reality_capture.instance_segmentation.scene_attribute import (

--- a/tests/unit/test_garfvdb_scene_transforms.py
+++ b/tests/unit/test_garfvdb_scene_transforms.py
@@ -18,7 +18,10 @@ from fvdb_reality_capture.instance_segmentation.scene_attribute import (
     GARFVDB_MASK_DATA_SCHEMA_VERSION,
     GARfVDBMaskAttribute,
 )
-from fvdb_reality_capture.instance_segmentation.scene_transforms import GenerateGARfVDBMasks
+from fvdb_reality_capture.instance_segmentation.scene_transforms import (
+    ApplyReconstructionCameraPoses,
+    GenerateGARfVDBMasks,
+)
 from fvdb_reality_capture.instance_segmentation.training.dataset import SegmentationDataset
 from fvdb_reality_capture.sfm_scene import (
     PerImageValueAttribute,
@@ -125,6 +128,7 @@ def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state(
     with tempfile.TemporaryDirectory() as directory:
         scene = _make_scene(pathlib.Path(directory))
         gaussians_hash = hashlib.sha256(b"test gaussians").hexdigest()
+        camera_parameters_hash = GenerateGARfVDBMasks._camera_parameters_sha256(scene)
         transform = GenerateGARfVDBMasks(
             gs3d=None,
             gs3d_hash=gaussians_hash,
@@ -135,7 +139,7 @@ def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state(
             device="cpu",
         )
         cache = scene.cache.make_folder(
-            f"garfvdb_masks_v1_{gaussians_hash}_p4_i80_s80",
+            f"garfvdb_masks_v1_{gaussians_hash}_p4_i80_s80_c{camera_parameters_hash}",
             description="cached GARfVDB masks",
         )
         for index in range(scene.num_images):
@@ -148,6 +152,7 @@ def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state(
                     "pred_iou_thresh": 0.8,
                     "stability_score_thresh": 0.8,
                     "gs3d_hash": gaussians_hash,
+                    "camera_parameters_sha256": camera_parameters_hash,
                 },
             )
 
@@ -174,6 +179,7 @@ def test_mask_cache_without_cdf_recomputes_on_load():
     with tempfile.TemporaryDirectory() as directory:
         scene = _make_scene(pathlib.Path(directory), num_images=1)
         gaussians_hash = hashlib.sha256(b"test gaussians").hexdigest()
+        camera_parameters_hash = GenerateGARfVDBMasks._camera_parameters_sha256(scene)
         transform = GenerateGARfVDBMasks(
             gs3d=None,
             gs3d_hash=gaussians_hash,
@@ -184,7 +190,7 @@ def test_mask_cache_without_cdf_recomputes_on_load():
             device="cpu",
         )
         cache = scene.cache.make_folder(
-            f"garfvdb_masks_v1_{gaussians_hash}_p4_i80_s80",
+            f"garfvdb_masks_v1_{gaussians_hash}_p4_i80_s80_c{camera_parameters_hash}",
             description="cached GARfVDB masks without mask_cdf",
         )
 
@@ -207,6 +213,7 @@ def test_mask_cache_without_cdf_recomputes_on_load():
                 "pred_iou_thresh": 0.8,
                 "stability_score_thresh": 0.8,
                 "gs3d_hash": gaussians_hash,
+                "camera_parameters_sha256": camera_parameters_hash,
             },
         )
 
@@ -222,6 +229,47 @@ def test_mask_cache_without_cdf_recomputes_on_load():
         assert torch.equal(mask_cdf, compute_mask_cdf(pixel_to_mask_id))
         assert mask_ids.dtype == torch.int32
         assert torch.equal(scales, torch.tensor([0.1, 0.2]))
+
+
+def test_reconstruction_camera_poses_are_matched_by_stable_image_id():
+    with tempfile.TemporaryDirectory() as directory:
+        scene = _make_scene(pathlib.Path(directory), num_images=3)
+        original_middle_pose = scene.images[1].camera_to_world_matrix.copy()
+        optimized_poses = np.stack([np.eye(4), np.eye(4)])
+        optimized_poses[0, :3, 3] = [2.0, 3.0, 4.0]  # image ID 2
+        optimized_poses[1, :3, 3] = [5.0, 6.0, 7.0]  # image ID 0
+
+        transform = ApplyReconstructionCameraPoses(optimized_poses, image_ids=np.array([2, 0]))
+        transformed = transform(scene)
+
+        np.testing.assert_allclose(transformed.images[0].camera_to_world_matrix, optimized_poses[1])
+        np.testing.assert_allclose(transformed.images[1].camera_to_world_matrix, original_middle_pose)
+        np.testing.assert_allclose(transformed.images[2].camera_to_world_matrix, optimized_poses[0])
+        for image in transformed.images:
+            np.testing.assert_allclose(image.world_to_camera_matrix, np.linalg.inv(image.camera_to_world_matrix))
+        np.testing.assert_array_equal(transformed.points, scene.points)
+        assert GenerateGARfVDBMasks._camera_parameters_sha256(
+            transformed
+        ) != GenerateGARfVDBMasks._camera_parameters_sha256(scene)
+
+        restored = ApplyReconstructionCameraPoses.from_state_dict(transform.state_dict())
+        np.testing.assert_allclose(restored._camera_to_world_matrices, optimized_poses)
+        np.testing.assert_array_equal(restored._image_ids, np.array([2, 0]))
+
+
+def test_reconstruction_camera_poses_without_ids_use_positional_matching():
+    with tempfile.TemporaryDirectory() as directory:
+        scene = _make_scene(pathlib.Path(directory), num_images=2)
+        optimized_poses = np.stack([np.eye(4), np.eye(4)])
+        optimized_poses[0, 0, 3] = 1.0
+        optimized_poses[1, 1, 3] = 2.0
+
+        transformed = ApplyReconstructionCameraPoses(optimized_poses)(scene)
+
+        np.testing.assert_allclose(transformed.camera_to_world_matrices, optimized_poses)
+
+        with pytest.raises(ValueError, match="same number of images"):
+            ApplyReconstructionCameraPoses(np.eye(4)[None])(scene)
 
 
 def test_standard_scene_pipeline_places_product_transform_last():
@@ -241,8 +289,11 @@ def test_standard_scene_pipeline_places_product_transform_last():
         garfvdb_pipeline = GARfVDBTransformConfig(crop_bbox=(-1, -1, -1, 1, 1, 1)).build_scene_transforms(
             gs3d=mock.Mock(),
             normalization_transform=None,
+            reconstruction_camera_to_world_matrices=torch.eye(4).unsqueeze(0),
+            reconstruction_image_ids=torch.tensor([0]),
         )
-    assert isinstance(garfvdb_pipeline.transforms[-3], CropScene)
+    assert isinstance(garfvdb_pipeline.transforms[-4], CropScene)
+    assert isinstance(garfvdb_pipeline.transforms[-3], ApplyReconstructionCameraPoses)
     assert isinstance(garfvdb_pipeline.transforms[-2], UndistortImages)
     assert garfvdb_pipeline.transforms[-1] is terminal
 

--- a/tests/unit/test_garfvdb_scene_transforms.py
+++ b/tests/unit/test_garfvdb_scene_transforms.py
@@ -247,9 +247,24 @@ def test_standard_scene_pipeline_places_product_transform_last():
     assert garfvdb_pipeline.transforms[-1] is terminal
 
 
+def test_garfvdb_mask_erosion_removes_boundaries_without_expanding_masks():
+    masks = torch.zeros((2, 5, 5), dtype=torch.bool)
+    masks[:, 1:4, 1:4] = True
+    masks[1, 2, 2] = False
+
+    eroded = GenerateGARfVDBMasks._erode_masks(masks)
+
+    expected = torch.zeros_like(masks)
+    expected[0, 2, 2] = True
+    assert torch.equal(eroded, expected)
+    assert torch.all(~eroded | masks)
+
+
 def test_garfvdb_mask_generation_uses_materialized_pinhole_images():
     with tempfile.TemporaryDirectory() as directory:
         scene = _make_scene(pathlib.Path(directory), num_images=1)
+        bgr_image = np.full((6, 8, 3), (11, 22, 33), dtype=np.uint8)
+        assert cv2.imwrite(scene.images[0].image_path, bgr_image)
         gaussians = mock.Mock()
         gaussians.means = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
         with mock.patch(
@@ -267,6 +282,7 @@ def test_garfvdb_mask_generation_uses_materialized_pinhole_images():
         assert transformed.has_attribute(GARFVDB_MASK_ATTRIBUTE_NAME)
         generated_image = generate.call_args.args[1]
         assert generated_image.shape == (6, 8, 3)
+        np.testing.assert_array_equal(generated_image[0, 0], np.array([33, 22, 11], dtype=np.uint8))
 
 
 def test_garfvdb_mask_generation_rejects_distorted_scene():

--- a/tests/unit/test_garfvdb_scene_transforms.py
+++ b/tests/unit/test_garfvdb_scene_transforms.py
@@ -124,10 +124,10 @@ def test_garfvdb_mask_attribute_round_trip_and_scene_operations():
 def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state():
     with tempfile.TemporaryDirectory() as directory:
         scene = _make_scene(pathlib.Path(directory))
-        carrier_hash = hashlib.sha256(b"test carrier").hexdigest()
+        gaussians_hash = hashlib.sha256(b"test gaussians").hexdigest()
         transform = GenerateGARfVDBMasks(
             gs3d=None,
-            gs3d_hash=carrier_hash,
+            gs3d_hash=gaussians_hash,
             checkpoint="large",
             points_per_side=4,
             pred_iou_thresh=0.8,
@@ -135,7 +135,7 @@ def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state(
             device="cpu",
         )
         cache = scene.cache.make_folder(
-            f"garfvdb_masks_v1_{carrier_hash}_p4_i80_s80",
+            f"garfvdb_masks_v1_{gaussians_hash}_p4_i80_s80",
             description="cached GARfVDB masks",
         )
         for index in range(scene.num_images):
@@ -147,7 +147,7 @@ def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state(
                     "points_per_side": 4,
                     "pred_iou_thresh": 0.8,
                     "stability_score_thresh": 0.8,
-                    "gs3d_hash": carrier_hash,
+                    "gs3d_hash": gaussians_hash,
                 },
             )
 
@@ -173,10 +173,10 @@ def test_mask_cache_without_cdf_recomputes_on_load():
 
     with tempfile.TemporaryDirectory() as directory:
         scene = _make_scene(pathlib.Path(directory), num_images=1)
-        carrier_hash = hashlib.sha256(b"test carrier").hexdigest()
+        gaussians_hash = hashlib.sha256(b"test gaussians").hexdigest()
         transform = GenerateGARfVDBMasks(
             gs3d=None,
-            gs3d_hash=carrier_hash,
+            gs3d_hash=gaussians_hash,
             checkpoint="large",
             points_per_side=4,
             pred_iou_thresh=0.8,
@@ -184,7 +184,7 @@ def test_mask_cache_without_cdf_recomputes_on_load():
             device="cpu",
         )
         cache = scene.cache.make_folder(
-            f"garfvdb_masks_v1_{carrier_hash}_p4_i80_s80",
+            f"garfvdb_masks_v1_{gaussians_hash}_p4_i80_s80",
             description="cached GARfVDB masks without mask_cdf",
         )
 
@@ -206,7 +206,7 @@ def test_mask_cache_without_cdf_recomputes_on_load():
                 "points_per_side": 4,
                 "pred_iou_thresh": 0.8,
                 "stability_score_thresh": 0.8,
-                "gs3d_hash": carrier_hash,
+                "gs3d_hash": gaussians_hash,
             },
         )
 
@@ -250,12 +250,12 @@ def test_standard_scene_pipeline_places_product_transform_last():
 def test_garfvdb_mask_generation_uses_materialized_pinhole_images():
     with tempfile.TemporaryDirectory() as directory:
         scene = _make_scene(pathlib.Path(directory), num_images=1)
-        carrier = mock.Mock()
-        carrier.means = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        gaussians = mock.Mock()
+        gaussians.means = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
         with mock.patch(
             "fvdb_reality_capture.instance_segmentation.scene_transforms.image_segmentation_masks.SAM2Model"
         ):
-            transform = GenerateGARfVDBMasks(gs3d=carrier, device="cpu")
+            transform = GenerateGARfVDBMasks(gs3d=gaussians, device="cpu")
         mask_data = _mask_data(0)
         with mock.patch.object(
             transform,

--- a/tests/unit/test_garfvdb_scene_transforms.py
+++ b/tests/unit/test_garfvdb_scene_transforms.py
@@ -168,6 +168,62 @@ def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state(
         assert restored_attribute.paths == attribute.paths
 
 
+def test_mask_cache_without_cdf_recomputes_on_load():
+    from fvdb_reality_capture.instance_segmentation.util import compute_mask_cdf
+
+    with tempfile.TemporaryDirectory() as directory:
+        scene = _make_scene(pathlib.Path(directory), num_images=1)
+        carrier_hash = hashlib.sha256(b"test carrier").hexdigest()
+        transform = GenerateGARfVDBMasks(
+            gs3d=None,
+            gs3d_hash=carrier_hash,
+            checkpoint="large",
+            points_per_side=4,
+            pred_iou_thresh=0.8,
+            stability_score_thresh=0.8,
+            device="cpu",
+        )
+        cache = scene.cache.make_folder(
+            f"garfvdb_masks_v1_{carrier_hash}_p4_i80_s80",
+            description="cached GARfVDB masks without mask_cdf",
+        )
+
+        # Build a pixel_to_mask_id with contiguous mask ids {-1, 0, 1} and deliberately omit mask_cdf,
+        # mirroring the newer cache format.
+        pixel_to_mask_id = torch.full((6, 8, 2), -1, dtype=torch.int16)
+        pixel_to_mask_id[:3, :, 0] = 0
+        pixel_to_mask_id[3:, :, 0] = 1
+        pixel_to_mask_id[0, 0, 1] = 1
+        cache.write_file(
+            name="masks_000",
+            data={
+                "schema_version": GARFVDB_MASK_DATA_SCHEMA_VERSION,
+                "scales": torch.tensor([0.1, 0.2]),
+                "pixel_to_mask_id": pixel_to_mask_id,
+            },
+            data_type="pt",
+            metadata={
+                "points_per_side": 4,
+                "pred_iou_thresh": 0.8,
+                "stability_score_thresh": 0.8,
+                "gs3d_hash": carrier_hash,
+            },
+        )
+
+        transformed = transform(scene)
+        attribute = transformed.get_attribute(GARFVDB_MASK_ATTRIBUTE_NAME)
+        assert isinstance(attribute, GARfVDBMaskAttribute)
+        # The loader passes through the cache contents verbatim -- no mask_cdf on disk.
+        assert "mask_cdf" not in attribute.load(0)
+
+        dataset = SegmentationDataset(transformed, cache_loaded_masks=False, cache_images=False)
+        mask_cdf, mask_ids, scales = dataset._get_mask_data(0)
+        # mask_cdf is recomputed from pixel_to_mask_id and matches the canonical computation.
+        assert torch.equal(mask_cdf, compute_mask_cdf(pixel_to_mask_id))
+        assert mask_ids.dtype == torch.int32
+        assert torch.equal(scales, torch.tensor([0.1, 0.2]))
+
+
 def test_standard_scene_pipeline_places_product_transform_last():
     common = SceneTransformConfig(crop_bbox=(-1, -1, -1, 1, 1, 1))
     terminal = Identity()
@@ -204,7 +260,7 @@ def test_garfvdb_mask_generation_uses_materialized_pinhole_images():
         with mock.patch.object(
             transform,
             "_generate_segmentation_mask",
-            return_value=(mask_data["scales"], mask_data["pixel_to_mask_id"], mask_data["mask_cdf"]),
+            return_value=(mask_data["scales"], mask_data["pixel_to_mask_id"]),
         ) as generate:
             transformed = transform(scene)
 

--- a/tests/unit/test_garfvdb_scene_transforms.py
+++ b/tests/unit/test_garfvdb_scene_transforms.py
@@ -1,0 +1,236 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import pathlib
+import tempfile
+from unittest import mock
+
+import cv2
+import numpy as np
+import pytest
+import torch
+from fvdb import CameraModel
+
+from fvdb_reality_capture.instance_segmentation.config import GARfVDBTransformConfig
+from fvdb_reality_capture.instance_segmentation.scene_attribute import (
+    GARFVDB_MASK_ATTRIBUTE_NAME,
+    GARFVDB_MASK_DATA_SCHEMA_VERSION,
+    GARfVDBMaskAttribute,
+)
+from fvdb_reality_capture.instance_segmentation.scene_transforms import GenerateGARfVDBMasks
+from fvdb_reality_capture.instance_segmentation.training.dataset import SegmentationDataset
+from fvdb_reality_capture.sfm_scene import (
+    PerImageValueAttribute,
+    SfmCache,
+    SfmCameraMetadata,
+    SfmPosedImageMetadata,
+    SfmScene,
+)
+from fvdb_reality_capture.transforms import CropScene, Identity, SceneTransformConfig, UndistortImages
+
+
+def _make_scene(
+    directory: pathlib.Path,
+    num_images: int = 2,
+    *,
+    camera_model: CameraModel = CameraModel.PINHOLE,
+    distortion_coeffs: np.ndarray | None = None,
+) -> SfmScene:
+    cache = SfmCache.get_cache(directory, name="garfvdb_transform_test", description="GARfVDB transform test")
+    if distortion_coeffs is None:
+        distortion_coeffs = np.zeros(0, dtype=np.float32)
+    camera = SfmCameraMetadata(
+        img_width=8,
+        img_height=6,
+        fx=6.0,
+        fy=6.0,
+        cx=4.0,
+        cy=3.0,
+        camera_model=camera_model,
+        distortion_coeffs=distortion_coeffs,
+    )
+    image_paths = []
+    for index in range(num_images):
+        image_path = directory / f"image_{index}.png"
+        assert cv2.imwrite(str(image_path), np.zeros((6, 8, 3), dtype=np.uint8))
+        image_paths.append(image_path)
+    images = [
+        SfmPosedImageMetadata(
+            world_to_camera_matrix=np.eye(4),
+            camera_to_world_matrix=np.eye(4),
+            camera_metadata=camera,
+            camera_id=1,
+            image_path=str(image_paths[index]),
+            mask_path="",
+            point_indices=None,
+            image_id=index,
+        )
+        for index in range(num_images)
+    ]
+    return SfmScene(
+        cameras={1: camera},
+        images=images,
+        points=np.zeros((0, 3), dtype=np.float32),
+        points_err=np.zeros(0, dtype=np.float32),
+        points_rgb=np.zeros((0, 3), dtype=np.uint8),
+        scene_bbox=None,
+        transformation_matrix=None,
+        cache=cache,
+        attributes={"other_method": PerImageValueAttribute(list(range(num_images)))},
+    )
+
+
+def _mask_data(index: int) -> dict[str, torch.Tensor | int]:
+    return {
+        "schema_version": GARFVDB_MASK_DATA_SCHEMA_VERSION,
+        "scales": torch.tensor([0.1 + index]),
+        "pixel_to_mask_id": torch.zeros((6, 8, 1), dtype=torch.int16),
+        "mask_cdf": torch.ones((6, 8, 1)),
+    }
+
+
+def test_garfvdb_mask_attribute_round_trip_and_scene_operations():
+    with tempfile.TemporaryDirectory() as directory:
+        root = pathlib.Path(directory)
+        paths = []
+        for index in range(3):
+            path = root / f"mask_{index}.pt"
+            torch.save(_mask_data(index), path)
+            paths.append(path)
+
+        attribute = GARfVDBMaskAttribute(paths, provenance={"generator": "test"})
+        restored = GARfVDBMaskAttribute.from_state_dict(attribute.state_dict())
+        assert restored.paths == [str(path.absolute()) for path in paths]
+        assert restored.provenance == {"generator": "test"}
+        assert torch.equal(restored.load(1)["scales"], torch.tensor([1.1]))
+        assert restored.on_filter_images(np.array([True, False, True])).paths == [
+            str(paths[0].absolute()),
+            str(paths[2].absolute()),
+        ]
+        assert restored.on_select_images(np.array([2, 0])).paths == [
+            str(paths[2].absolute()),
+            str(paths[0].absolute()),
+        ]
+
+        with pytest.raises(ValueError, match="after all image transforms"):
+            restored.on_downsample_images("garfvdb_masks", 2, None)
+        with pytest.raises(ValueError, match="after all crop transforms"):
+            restored.on_crop_scene("garfvdb_masks", np.zeros(6), None)
+        with pytest.raises(ValueError, match="scene alignment"):
+            restored.on_spatial_transform(np.eye(4))
+
+
+def test_cached_mask_transform_attaches_attribute_without_replacing_scene_state():
+    with tempfile.TemporaryDirectory() as directory:
+        scene = _make_scene(pathlib.Path(directory))
+        carrier_hash = hashlib.sha256(b"test carrier").hexdigest()
+        transform = GenerateGARfVDBMasks(
+            gs3d=None,
+            gs3d_hash=carrier_hash,
+            checkpoint="large",
+            points_per_side=4,
+            pred_iou_thresh=0.8,
+            stability_score_thresh=0.8,
+            device="cpu",
+        )
+        cache = scene.cache.make_folder(
+            f"garfvdb_masks_v1_{carrier_hash}_p4_i80_s80",
+            description="cached GARfVDB masks",
+        )
+        for index in range(scene.num_images):
+            cache.write_file(
+                name=f"masks_{index:03d}",
+                data=_mask_data(index),
+                data_type="pt",
+                metadata={
+                    "points_per_side": 4,
+                    "pred_iou_thresh": 0.8,
+                    "stability_score_thresh": 0.8,
+                    "gs3d_hash": carrier_hash,
+                },
+            )
+
+        transformed = transform(scene)
+        assert transformed.cache.current_folder_id == scene.cache.current_folder_id
+        assert transformed.has_attribute("other_method")
+        assert transformed.has_attribute(GARFVDB_MASK_ATTRIBUTE_NAME)
+        attribute = transformed.get_attribute(GARFVDB_MASK_ATTRIBUTE_NAME)
+        assert isinstance(attribute, GARfVDBMaskAttribute)
+        assert len(attribute.paths) == scene.num_images
+
+        dataset = SegmentationDataset(transformed, cache_loaded_masks=False, cache_images=False)
+        assert torch.equal(dataset.scales, torch.tensor([0.1, 1.1]))
+
+        restored_scene = SfmScene.from_state_dict(transformed.state_dict())
+        restored_attribute = restored_scene.get_attribute(GARFVDB_MASK_ATTRIBUTE_NAME)
+        assert isinstance(restored_attribute, GARfVDBMaskAttribute)
+        assert restored_attribute.paths == attribute.paths
+
+
+def test_standard_scene_pipeline_places_product_transform_last():
+    common = SceneTransformConfig(crop_bbox=(-1, -1, -1, 1, 1, 1))
+    terminal = Identity()
+    pipeline = common.build_scene_transform(
+        alignment_transform=Identity(),
+        terminal_transforms=[terminal],
+    )
+    assert isinstance(pipeline.transforms[-2], CropScene)
+    assert pipeline.transforms[-1] is terminal
+
+    with mock.patch(
+        "fvdb_reality_capture.instance_segmentation.config.GenerateGARfVDBMasks",
+        return_value=terminal,
+    ):
+        garfvdb_pipeline = GARfVDBTransformConfig(crop_bbox=(-1, -1, -1, 1, 1, 1)).build_scene_transforms(
+            gs3d=mock.Mock(),
+            normalization_transform=None,
+        )
+    assert isinstance(garfvdb_pipeline.transforms[-3], CropScene)
+    assert isinstance(garfvdb_pipeline.transforms[-2], UndistortImages)
+    assert garfvdb_pipeline.transforms[-1] is terminal
+
+
+def test_garfvdb_mask_generation_uses_materialized_pinhole_images():
+    with tempfile.TemporaryDirectory() as directory:
+        scene = _make_scene(pathlib.Path(directory), num_images=1)
+        carrier = mock.Mock()
+        carrier.means = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        with mock.patch(
+            "fvdb_reality_capture.instance_segmentation.scene_transforms.image_segmentation_masks.SAM2Model"
+        ):
+            transform = GenerateGARfVDBMasks(gs3d=carrier, device="cpu")
+        mask_data = _mask_data(0)
+        with mock.patch.object(
+            transform,
+            "_generate_segmentation_mask",
+            return_value=(mask_data["scales"], mask_data["pixel_to_mask_id"], mask_data["mask_cdf"]),
+        ) as generate:
+            transformed = transform(scene)
+
+        assert transformed.has_attribute(GARFVDB_MASK_ATTRIBUTE_NAME)
+        generated_image = generate.call_args.args[1]
+        assert generated_image.shape == (6, 8, 3)
+
+
+def test_garfvdb_mask_generation_rejects_distorted_scene():
+    with tempfile.TemporaryDirectory() as directory:
+        distortion_coeffs = np.zeros(12, dtype=np.float32)
+        distortion_coeffs[0] = 0.1
+        scene = _make_scene(
+            pathlib.Path(directory),
+            num_images=1,
+            camera_model=CameraModel.OPENCV_RADTAN_5,
+            distortion_coeffs=distortion_coeffs,
+        )
+        transform = GenerateGARfVDBMasks(gs3d=None, gs3d_hash="unused", device="cpu")
+
+        with pytest.raises(ValueError, match="Apply UndistortImages"):
+            transform(scene)
+
+
+def test_segmentation_dataset_requires_namespaced_garfvdb_attribute():
+    with tempfile.TemporaryDirectory() as directory:
+        scene = _make_scene(pathlib.Path(directory), num_images=1)
+        with pytest.raises(ValueError, match=GARFVDB_MASK_ATTRIBUTE_NAME):
+            SegmentationDataset(scene)

--- a/tests/unit/test_garfvdb_viewer.py
+++ b/tests/unit/test_garfvdb_viewer.py
@@ -97,7 +97,7 @@ def _make_viewer(scene, product, **kwargs):
         overlay_width=16,
         overlay_height=8,
         overlay_downsample=2,
-        add_carrier=False,
+        add_gaussians=False,
         set_initial_camera=False,
         **kwargs,
     )
@@ -155,8 +155,8 @@ def test_scale_slider_change_triggers_rerender():
 
 
 def test_hide_overlay_removes_view_and_re_adds_on_show(monkeypatch):
-    # Hiding removes the overlay view outright (a transparent frame still occludes the carrier),
-    # so the underlying Gaussian carrier scene becomes visible again.
+    # Hiding removes the overlay view outright (a transparent frame still occludes the gaussians),
+    # so the underlying Gaussian model scene becomes visible again.
     import fvdb.viz._viewer_server as vs
 
     removed: list[tuple[str, str]] = []

--- a/tests/unit/test_garfvdb_viewer.py
+++ b/tests/unit/test_garfvdb_viewer.py
@@ -3,12 +3,15 @@
 
 """Unit tests for the GARfVDB overlay viewer core (no live Vulkan viewer required)."""
 
+from unittest import mock
+
 import numpy as np
 import torch
 
-from unittest import mock
-
-from fvdb_reality_capture.instance_segmentation.util import apply_pca_projection, fit_pca_projection
+from fvdb_reality_capture.instance_segmentation.util import (
+    apply_pca_projection,
+    fit_pca_projection,
+)
 from fvdb_reality_capture.instance_segmentation.viewer import (
     _LOCK_WIDGET_NAME,
     _OPACITY_WIDGET_NAME,
@@ -102,9 +105,7 @@ def _make_viewer(scene, product, **kwargs):
 
 def test_widgets_registered_with_expected_names_and_initials():
     scene = _FakeScene()
-    _make_viewer(
-        scene, _FakeProduct(), initial_scale_fraction=0.25, initial_mask_blend=0.6, lock_pca_colors=True
-    )
+    _make_viewer(scene, _FakeProduct(), initial_scale_fraction=0.25, initial_mask_blend=0.6, lock_pca_colors=True)
     assert set(scene.widgets) == {
         _SCALE_WIDGET_NAME,
         _OPACITY_WIDGET_NAME,

--- a/tests/unit/test_garfvdb_viewer.py
+++ b/tests/unit/test_garfvdb_viewer.py
@@ -1,0 +1,259 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GARfVDB overlay viewer core (no live Vulkan viewer required)."""
+
+import numpy as np
+import torch
+
+from unittest import mock
+
+from fvdb_reality_capture.instance_segmentation.util import apply_pca_projection, fit_pca_projection
+from fvdb_reality_capture.instance_segmentation.viewer import (
+    _LOCK_WIDGET_NAME,
+    _OPACITY_WIDGET_NAME,
+    _SCALE_WIDGET_NAME,
+    _SHOW_WIDGET_NAME,
+    GARfVDBOverlayViewer,
+)
+
+
+class _FakeWidget:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeImageView:
+    def __init__(self, name, scene_name):
+        self.name = name
+        self.scene_name = scene_name
+        self.last_update = None
+        self.update_count = 0
+
+    def update(self, rgba_image):
+        self.last_update = np.asarray(rgba_image)
+        self.update_count += 1
+
+
+class _FakeScene:
+    """Minimal stand-in for fvdb.viz.Scene exercising the widgets + overlay code paths."""
+
+    _SCENE_NAME = "fake-scene"
+
+    def __init__(self):
+        self.widgets = {}
+        self.image_view = None
+        self.added_image_kwargs = None
+        self.added_image_count = 0
+        # Orbit camera state read by the viewer each frame.
+        self.camera_orbit_center = torch.tensor([0.0, 0.0, 0.0])
+        self.camera_orbit_direction = torch.tensor([0.0, 0.0, 1.0])
+        self.camera_orbit_radius = 3.0
+        self.camera_up_direction = torch.tensor([0.0, 1.0, 0.0])
+        self.camera_fov = 1.0
+
+    def add_slider(self, name, min, max, initial=None, step=0.01):
+        self.widgets[name] = _FakeWidget(float(initial if initial is not None else min))
+        return self.widgets[name]
+
+    def add_checkbox(self, name, initial=False):
+        self.widgets[name] = _FakeWidget(bool(initial))
+        return self.widgets[name]
+
+    def add_image(self, name, width, height, rgba_image):
+        self.added_image_kwargs = dict(name=name, width=width, height=height)
+        self.added_image_count += 1
+        self.image_view = _FakeImageView(name=name, scene_name=self._SCENE_NAME)
+        self.image_view.update(rgba_image)
+        return self.image_view
+
+
+class _FakeProduct:
+    """Stand-in for GARfVDB that records the raw scale passed to render_features."""
+
+    def __init__(self, max_grouping_scale=4.0, render_wh=(8, 4)):
+        self.max_grouping_scale = max_grouping_scale
+        self.reconstruction_metadata = {}
+        self.render_calls = []
+        self._render_wh = render_wh
+
+    def render_features(self, c2w, projection, image_size, scale):
+        self.render_calls.append(scale)
+        w, h = self._render_wh
+        torch.manual_seed(0)
+        features = torch.rand(1, h, w, 4)
+        alpha = torch.ones(1, h, w, 1)
+        return features, alpha
+
+
+def _make_viewer(scene, product, **kwargs):
+    return GARfVDBOverlayViewer(
+        scene,
+        product,
+        device="cpu",
+        overlay_width=16,
+        overlay_height=8,
+        overlay_downsample=2,
+        add_carrier=False,
+        set_initial_camera=False,
+        **kwargs,
+    )
+
+
+def test_widgets_registered_with_expected_names_and_initials():
+    scene = _FakeScene()
+    _make_viewer(
+        scene, _FakeProduct(), initial_scale_fraction=0.25, initial_mask_blend=0.6, lock_pca_colors=True
+    )
+    assert set(scene.widgets) == {
+        _SCALE_WIDGET_NAME,
+        _OPACITY_WIDGET_NAME,
+        _SHOW_WIDGET_NAME,
+        _LOCK_WIDGET_NAME,
+    }
+    assert scene.widgets[_SCALE_WIDGET_NAME].value == 0.25
+    assert scene.widgets[_OPACITY_WIDGET_NAME].value == 0.6
+    assert scene.widgets[_SHOW_WIDGET_NAME].value is True
+    assert scene.widgets[_LOCK_WIDGET_NAME].value is True
+
+
+def test_normalized_scale_maps_to_raw_grouping_scale():
+    scene = _FakeScene()
+    product = _FakeProduct(max_grouping_scale=4.0)
+    viewer = _make_viewer(scene, product, initial_scale_fraction=0.25)
+
+    viewer.render_once()
+    assert product.render_calls == [0.25 * 4.0]  # normalized 0.25 -> raw 1.0
+    assert scene.image_view is not None
+    assert scene.added_image_kwargs == {"name": "GARfVDB Features", "width": 16, "height": 8}
+
+
+def test_no_rerender_when_nothing_changes():
+    scene = _FakeScene()
+    product = _FakeProduct()
+    viewer = _make_viewer(scene, product)
+
+    assert viewer.render_once() is True  # first call always renders
+    assert viewer.render_once() is False  # camera + widgets unchanged -> no work, caller can idle-sleep
+    assert len(product.render_calls) == 1
+
+    scene.camera_orbit_radius = 7.0  # camera moved -> renders again immediately (no delay)
+    assert viewer.render_once() is True
+    assert len(product.render_calls) == 2
+
+
+def test_scale_slider_change_triggers_rerender():
+    scene = _FakeScene()
+    product = _FakeProduct(max_grouping_scale=10.0)
+    viewer = _make_viewer(scene, product, initial_scale_fraction=0.1)
+
+    viewer.render_once()
+    scene.widgets[_SCALE_WIDGET_NAME].value = 0.5
+    viewer.render_once()
+    assert product.render_calls == [0.1 * 10.0, 0.5 * 10.0]
+
+
+def test_hide_overlay_removes_view_and_re_adds_on_show(monkeypatch):
+    # Hiding removes the overlay view outright (a transparent frame still occludes the carrier),
+    # so the underlying Gaussian carrier scene becomes visible again.
+    import fvdb.viz._viewer_server as vs
+
+    removed: list[tuple[str, str]] = []
+    monkeypatch.setattr(vs, "remove_view", lambda scene_name, name: removed.append((scene_name, name)))
+
+    scene = _FakeScene()
+    product = _FakeProduct()
+    viewer = _make_viewer(scene, product)
+
+    viewer.render_once()  # overlay shown -> image view created
+    assert scene.added_image_count == 1
+    assert len(product.render_calls) == 1
+
+    scene.widgets[_SHOW_WIDGET_NAME].value = False
+    viewer.render_once()
+    # The view was removed (not just cleared) and no new render happened while hidden.
+    assert removed == [(_FakeScene._SCENE_NAME, "GARfVDB Features")]
+    assert viewer._image_view is None
+    assert len(product.render_calls) == 1
+
+    # Re-enabling the overlay recreates the image view.
+    scene.widgets[_SHOW_WIDGET_NAME].value = True
+    viewer.render_once()
+    assert scene.added_image_count == 2
+    assert len(product.render_calls) == 2
+
+
+def _fake_apply(features, state, mask=None):
+    # Stand-in for apply_pca_projection with the shape render_once expects ([B, H, W, 3]).
+    return torch.zeros(features.shape[0], features.shape[1], features.shape[2], 3)
+
+
+def _patch_pca():
+    fit = mock.patch(
+        "fvdb_reality_capture.instance_segmentation.viewer.fit_pca_projection",
+        return_value=object(),
+    )
+    apply = mock.patch(
+        "fvdb_reality_capture.instance_segmentation.viewer.apply_pca_projection",
+        side_effect=_fake_apply,
+    )
+    return fit, apply
+
+
+def test_locked_pca_reuses_projection_across_camera_moves():
+    scene = _FakeScene()
+    viewer = _make_viewer(scene, _FakeProduct())
+    scene.widgets[_LOCK_WIDGET_NAME].value = True
+
+    fit_patch, apply_patch = _patch_pca()
+    with fit_patch as fit, apply_patch:
+        viewer.render_once()
+        scene.camera_orbit_radius = 5.0  # simulate a camera move
+        viewer.render_once()
+        scene.camera_orbit_radius = 9.0
+        viewer.render_once()
+
+    # PCA is fit once and reused across camera moves -> stable colors.
+    assert fit.call_count == 1
+
+
+def test_unlocked_pca_refits_each_frame():
+    scene = _FakeScene()
+    viewer = _make_viewer(scene, _FakeProduct())  # lock off by default
+
+    fit_patch, apply_patch = _patch_pca()
+    with fit_patch as fit, apply_patch:
+        viewer.render_once()
+        scene.camera_orbit_radius = 5.0
+        viewer.render_once()
+
+    assert fit.call_count == 2
+
+
+def test_lock_refits_when_grouping_scale_changes():
+    scene = _FakeScene()
+    viewer = _make_viewer(scene, _FakeProduct(), initial_scale_fraction=0.1)
+    scene.widgets[_LOCK_WIDGET_NAME].value = True
+
+    fit_patch, apply_patch = _patch_pca()
+    with fit_patch as fit, apply_patch:
+        viewer.render_once()
+        scene.widgets[_SCALE_WIDGET_NAME].value = 0.5  # different grouping scale -> different feature field
+        viewer.render_once()
+
+    assert fit.call_count == 2
+
+
+def test_locked_projection_maps_same_feature_to_same_color():
+    torch.manual_seed(0)
+    feats_a = torch.randn(1, 10, 10, 6)
+    state = fit_pca_projection(feats_a, 3)
+
+    # A different "frame" whose overall distribution differs, but which contains one identical feature vector.
+    feats_b = torch.randn(1, 10, 10, 6) * 4.0
+    feats_b[0, 0, 0] = feats_a[0, 5, 5]
+
+    rgb_a = apply_pca_projection(feats_a, state)  # [100, 3] (no mask)
+    rgb_b = apply_pca_projection(feats_b, state)
+    # The frozen transform maps the identical feature to the identical color across frames.
+    assert torch.allclose(rgb_a[5 * 10 + 5], rgb_b[0], atol=1e-5)

--- a/tests/unit/test_gaussian_splat_3d.py
+++ b/tests/unit/test_gaussian_splat_3d.py
@@ -1264,12 +1264,14 @@ class TestLoadAndSavePly(BaseGaussianTestCase):
         num_cams = 88
         normalization_tx = torch.randn(4, 4)
         cam_to_worlds = torch.randn(num_cams, 4, 4)
+        image_ids = torch.arange(num_cams, dtype=torch.int64).to(torch.uint32)
         cam_types = torch.full((num_cams,), 8).to(torch.int32)
         proj_params = torch.randn(num_cams, 4, 5, 7)
 
         metadata_dict = {
             "normalization_transform": normalization_tx,
             "camera_to_world_matrices": cam_to_worlds,
+            "image_ids": image_ids,
             "projection_types": cam_types,
             "projection_parameters": proj_params,
             "string_parameter": "The Quick brown fox jumps over the lazy dog",
@@ -1289,10 +1291,12 @@ class TestLoadAndSavePly(BaseGaussianTestCase):
 
         assert isinstance(training_info["normalization_transform"], torch.Tensor)
         assert isinstance(training_info["camera_to_world_matrices"], torch.Tensor)
+        assert isinstance(training_info["image_ids"], torch.Tensor)
         assert isinstance(training_info["projection_types"], torch.Tensor)
         assert isinstance(training_info["projection_parameters"], torch.Tensor)
         self.assertTrue(torch.allclose(training_info["normalization_transform"], normalization_tx.to(self.device)))
         self.assertTrue(torch.allclose(training_info["camera_to_world_matrices"], cam_to_worlds.to(self.device)))
+        self.assertTrue(torch.equal(training_info["image_ids"], image_ids.to(self.device)))
         self.assertTrue(torch.equal(training_info["projection_types"], cam_types.to(self.device)))
         self.assertTrue(torch.allclose(training_info["projection_parameters"], proj_params.to(self.device)))
         self.assertEqual(training_info["float_param"], 0.121243243523524650345740953)

--- a/tests/unit/test_training_checkpoints.py
+++ b/tests/unit/test_training_checkpoints.py
@@ -43,7 +43,7 @@ def _state(version: str = "1.2.3") -> dict:
     return {"version": version, "step": 7, "payload": torch.tensor([1, 2, 3])}
 
 
-def test_training_checkpoint_envelope_round_trip():
+def test_training_checkpoint_container_round_trip():
     checkpoint = create_training_checkpoint("test.method", _state(), method_version="method-v7")
     serialized = checkpoint.to_dict()
     assert serialized["schema"] == TRAINING_CHECKPOINT_SCHEMA
@@ -148,7 +148,7 @@ def test_resume_dispatches_registered_method_and_uses_handler_default():
     [
         (
             lambda root: GaussianSplatReconstructionWriter(
-                run_name="checkpoint_envelope",
+                run_name="checkpoint_container",
                 save_path=root,
                 config=GaussianSplatReconstructionWriterConfig(
                     save_images=False,
@@ -161,7 +161,7 @@ def test_resume_dispatches_registered_method_and_uses_handler_default():
         ),
         (
             lambda root: GARfVDBWriter(
-                run_name="checkpoint_envelope",
+                run_name="checkpoint_container",
                 save_path=root,
                 config=GARfVDBWriterConfig(
                     save_images=False,
@@ -173,7 +173,7 @@ def test_resume_dispatches_registered_method_and_uses_handler_default():
         ),
     ],
 )
-def test_disk_writers_save_versioned_envelopes(writer_factory, expected_method):
+def test_disk_writers_save_versioned_containers(writer_factory, expected_method):
     with tempfile.TemporaryDirectory() as directory:
         root = pathlib.Path(directory)
         writer = writer_factory(root)

--- a/tests/unit/test_training_checkpoints.py
+++ b/tests/unit/test_training_checkpoints.py
@@ -1,0 +1,185 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+import tempfile
+
+import pytest
+import torch
+
+from fvdb_reality_capture.checkpoints import (
+    TRAINING_CHECKPOINT_SCHEMA,
+    TRAINING_CHECKPOINT_SCHEMA_VERSION,
+    TrainingCheckpointError,
+    TrainingCheckpointVersionError,
+    create_training_checkpoint,
+    load_training_checkpoint,
+    parse_training_checkpoint,
+)
+from fvdb_reality_capture.cli.frgs._resume import Resume
+from fvdb_reality_capture.cli.frgs._resume_registry import (
+    ResumeHandler,
+    UnknownCheckpointMethodError,
+    get_resume_handler,
+    register_resume_handler,
+)
+from fvdb_reality_capture.instance_segmentation.checkpoint import (
+    GARFVDB_TRAINING_METHOD,
+)
+from fvdb_reality_capture.instance_segmentation.training.segmentation_writer import (
+    GARfVDBWriter,
+    GARfVDBWriterConfig,
+)
+from fvdb_reality_capture.radiance_fields import (
+    GaussianSplatReconstructionWriter,
+    GaussianSplatReconstructionWriterConfig,
+)
+from fvdb_reality_capture.radiance_fields.checkpoint import (
+    GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+)
+
+
+def _state(version: str = "1.2.3") -> dict:
+    return {"version": version, "step": 7, "payload": torch.tensor([1, 2, 3])}
+
+
+def test_training_checkpoint_envelope_round_trip():
+    checkpoint = create_training_checkpoint("test.method", _state(), method_version="method-v7")
+    serialized = checkpoint.to_dict()
+    assert serialized["schema"] == TRAINING_CHECKPOINT_SCHEMA
+    assert serialized["schema_version"] == TRAINING_CHECKPOINT_SCHEMA_VERSION
+    assert serialized["method"] == "test.method"
+    assert serialized["method_version"] == "method-v7"
+    restored = parse_training_checkpoint(serialized)
+    assert restored.method == checkpoint.method
+    assert restored.method_version == checkpoint.method_version
+    assert torch.equal(restored.state["payload"], checkpoint.state["payload"])
+
+
+def test_load_training_checkpoint_rejects_future_schema():
+    root = create_training_checkpoint("test.future", _state(), method_version="1.2.3").to_dict()
+    root["schema_version"] = TRAINING_CHECKPOINT_SCHEMA_VERSION + 1
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / "future.pt"
+        torch.save(root, path)
+        with pytest.raises(TrainingCheckpointVersionError, match="newer"):
+            load_training_checkpoint(path)
+
+
+def test_load_training_checkpoint_rejects_directories_without_product_extension_knowledge():
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / "scene.garfvdb"
+        path.mkdir()
+        with pytest.raises(TrainingCheckpointError, match="directory"):
+            load_training_checkpoint(path)
+
+
+def test_checkpoint_dispatch_does_not_depend_on_file_extension():
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / "intentionally-unusual.garfvdb"
+        torch.save(
+            create_training_checkpoint(
+                "test.extension_independent",
+                _state(),
+                method_version="1.2.3",
+            ).to_dict(),
+            path,
+        )
+        checkpoint = load_training_checkpoint(path)
+    assert checkpoint.method == "test.extension_independent"
+
+
+def test_released_flat_gaussian_checkpoint_is_adapted():
+    state = {
+        "magic": "GaussianSplattingCheckpoint",
+        "version": "0.1.0",
+    }
+    checkpoint = parse_training_checkpoint(state)
+    assert checkpoint.method == GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD
+    assert checkpoint.state == state
+
+
+def test_unknown_resume_method_has_no_gaussian_fallback():
+    with pytest.raises(UnknownCheckpointMethodError, match="unknown.method"):
+        get_resume_handler("unknown.method")
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / "unknown.pt"
+        torch.save(
+            create_training_checkpoint("unknown.method", _state(), method_version="1.2.3").to_dict(),
+            path,
+        )
+        with pytest.raises(UnknownCheckpointMethodError, match="unknown.method"):
+            Resume(checkpoint_path=path, device="cpu").execute()
+
+
+def test_resume_dispatches_registered_method_and_uses_handler_default():
+    method = "tests.synthetic_resume"
+    calls = []
+
+    def callback(checkpoint, command, out_path):
+        calls.append((checkpoint, command, out_path))
+
+    register_resume_handler(
+        ResumeHandler(
+            method=method,
+            default_output_name="synthetic.product",
+            callback=callback,
+        )
+    )
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / "synthetic.pt"
+        torch.save(
+            create_training_checkpoint(method, _state(), method_version="1.2.3").to_dict(),
+            path,
+        )
+        command = Resume(checkpoint_path=path, device="cpu")
+        command.execute()
+
+    assert len(calls) == 1
+    checkpoint, passed_command, out_path = calls[0]
+    assert checkpoint.method == method
+    assert passed_command is command
+    assert out_path == pathlib.Path("synthetic.product")
+
+
+@pytest.mark.parametrize(
+    ("writer_factory", "expected_method"),
+    [
+        (
+            lambda root: GaussianSplatReconstructionWriter(
+                run_name="checkpoint_envelope",
+                save_path=root,
+                config=GaussianSplatReconstructionWriterConfig(
+                    save_images=False,
+                    save_checkpoints=True,
+                    save_plys=False,
+                    save_metrics=False,
+                ),
+            ),
+            GAUSSIAN_SPLAT_RECONSTRUCTION_METHOD,
+        ),
+        (
+            lambda root: GARfVDBWriter(
+                run_name="checkpoint_envelope",
+                save_path=root,
+                config=GARfVDBWriterConfig(
+                    save_images=False,
+                    save_checkpoints=True,
+                    save_metrics=False,
+                ),
+            ),
+            GARFVDB_TRAINING_METHOD,
+        ),
+    ],
+)
+def test_disk_writers_save_versioned_envelopes(writer_factory, expected_method):
+    with tempfile.TemporaryDirectory() as directory:
+        root = pathlib.Path(directory)
+        writer = writer_factory(root)
+        writer.save_checkpoint(4, "train_ckpt.pt", _state())
+        paths = list(root.rglob("train_ckpt.pt"))
+        assert len(paths) == 1
+        checkpoint = load_training_checkpoint(paths[0], expected_method=expected_method)
+        assert checkpoint.method == expected_method
+        assert checkpoint.state["step"] == 7


### PR DESCRIPTION
## Summary

- Adds GARfVDB scale-conditioned instance segmentation as a first-class fvdb-reality-capture method (Python API plus `frgs segment-instances`), where an existing Gaussian reconstruction is consumed as input and the learned scale-conditioned feature field is the product.
- Introduces a portable, pickle-free `.garfvdb` bundle containing NanoVDBs (encoder grids and features), safetensors (dense network weights and scale-quantile buffers), and a PLY Gaussian model, with explicit schema versioning, checksums, and validation on load.  This is the trained end-product of a GARfVDB model (i.e. the equivalent of a `.ply` file for the optimized Gaussian splat reconstruction scene), not a resumable checkpoint.
- Adds shared, method-neutral infrastructure so GARfVDB and any future, non-Gaussian products fit cleanly: 
  - versioned training-checkpoint container with a reader registry
  - a CLI resume-handler registry
  - a reusable scene-transform configuration
  - a namespaced scene attribute for per-image mask supervision

`> frgs segment-instances DATASET --reconstruction-path scene.ply --out-path scene.garfvdb` trains from an existing reconstruction and writes a portable bundle

## Motivation

GARfVDB previously lived as a standalone project in fvdb-examples that was already coupled to fvdb-reality-capture for SfM loading and Gaussian reconstruction, but its deliverable is a second learned product (based on a filtered Gaussian scene) rather than more Gaussians. This is the first fvdb-reality-capture method whose product is not a Gaussian splat, so the integration deliberately separates shared workflow infrastructure from product-specific behavior instead of bolting a training script onto the Gaussian commands. The shared pieces are designed against a concrete second method (for example integrating the LangSplatV2 method that also uses SAM2) so they generalize rather than hard-coding GARfVDB.

## Artifact contract

The `.garfvdb/` bundle is the trained end-product of the instance segmentation method (equivalent to what the `.ply` file is to the `reconstruct` process).

- A `*.garfvdb/` bundle contains no PyTorch pickle files: `manifest.json`, `encoder.nvdb`, `network.safetensors`, and `gaussians.ply`.
- `encoder.nvdb` stores all encoder grid topologies and their learned per-voxel features through fVDB NanoVDB I/O with compression; grids are named deterministically (`encoder_00` ... `encoder_NN`) and that order is validated on load.
- `network.safetensors` stores the MLP weights, optional sparse-convolution weights, maximum scale, and scale-quantile lookup buffers as named dense tensors.
- `gaussians.ply` stores the exact filtered `GaussianSplat3d` model plus reconstruction and camera metadata.


Note:  The manifest carries an explicit integer `schema_version` and per-payload SHA-256 checksums. Loading dispatches through a version-specific reader that validates canonical grid names and order, grid/voxel counts, voxel sizes and origins, feature shape and dtype, Gaussian count, and every payload checksum. Missing, renamed, reordered, corrupted, or incompatible payloads fail with clear errors, and newer-than-supported bundle versions fail before any payload is read.

## Checkpoint and resume architecture

To accommodate checkpoints beyond the reconstruction method checkpoints being resumed (and without specific methods needed to be invoked by users `resume-instance-segmentation`, etc.), this method formalizes the checkpoint **container** concept.

- New training checkpoints use a generic **container**: `schema`, `schema_version`, `method`, `method_version`, and method-owned `state`. Parsing first validates the container, selects an exact schema-version reader, and can consult registered legacy adapters for pre-container formats.
- The container carries two independent versions on orthogonal axes. 
  - `schema`/`schema_version` version the container format itself — the fixed top-level keys and how they are parsed; `schema` is a constant shared by every method and `schema_version` is owned centrally, bumped only when the wrapper structure changes (which affects all methods at once). 
  - `method`/`method_version` version the method-owned payload in `state`: `method` is the stable id of the producing method and `method_version`, owned by the method's package as a single source of truth, versions that method's `state` layout and is bumped only when that one method's state changes. Everything method-specific — model weights, optimizer/scheduler state, config, global step, and method metadata — lives opaquely inside `state`; the container layer never interprets it.
- The generic module contains no method names, CLI options, or product extensions.  Method identity and legacy recognition are owned by their packages: 
  - `radiance_fields.checkpoint` defines the Gaussian method id (`radiance_fields.gaussian_splat`) and a legacy adapter for released flat Gaussian checkpoints; 
  - `instance_segmentation.checkpoint` defines the GARfVDB method id (`instance_segmentation.garfvdb`). 
- Each method exposes a single version constant that both its `state_dict`/`from_state_dict` and its disk writer container derive from, so the recorded container version and the method state version cannot drift.
- `frgs resume` loads one validated container, resolves the stable method id, and invokes a CLI-owned resume handler that also owns the default output name. Unknown methods fail explicitly.
- The Gaussian reconstruction writer and reader now use the same container, and previously released flat Gaussian checkpoints remain loadable through the legacy adapter.

## Transform and scene-attribute integration


So that a second, non-Gaussian method can reuse the reconstruction's scene preprocessing without duplicating it or overwriting shared scene state, the standard transform stages are factored into a reusable `SceneTransformConfig`, and each method's per-image supervision is carried as a namespaced scene attribute rather than by replacing the scene cache.
- A reusable `SceneTransformConfig` builds the standard alignment, point filtering, image downsampling, low-point image filtering, and cropping stages; both reconstruction and GARfVDB build on it. Reconstruction supplies normalization while GARfVDB injects the reconstruction's saved alignment transform.
- SAM2 mask and scene-unit scale supervision is attached as a registered, namespaced `GARfVDBMaskAttribute` on `SfmScene` rather than replacing the scene cache, so existing caches and attributes are preserved and the dataset consumes only its named attribute.
- Mask generation runs last and rejects later downsample, crop, or spatial transforms, because resizing or rescaling after generation would invalidate mask pixels or scene-unit scales. Other segmentation methods can attach their own attribute types and generators through the same generic mechanism without adopting the GARfVDB supervision format.

## Interactive viewer

Updated the viewer to be able to visualize the segmentation mask output (using PCA to project the mask to a 3-channel RGB visualization) as an overlay with interactive parameters to control the visualization.

- Adds `GARfVDBOverlayViewer`, which renders the GARfVDB feature field as a live overlay on the Gaussians in the fvdb viewer with interactive "Scene Params" widgets: 
  - a normalized grouping-scale slider (mapped to the model's maximum grouping scale) 
  - an overlay-opacity slider, a show/hide checkbox for the overlay 
  - a "Lock PCA colors" checkbox that freezes the PCA-to-RGB transform so the feature coloring does not flicker during camera movement
- A single shared core drives both the offline `frgs show` viewer and a new live training viewer enabled with `frgs segment-instances --viewer`, which pumps overlay renders from the training loop between steps so the in-progress feature field can be inspected while training runs.
- The offline viewer renders continuously while the camera or any widget is changing

## SAM2 mask-generation performance

In addition to porting the SAM2 mask-generation transforms from `fvdb-examples`, this PR also makes some performance improvements during the transition:

- Vectorizes the two hottest per-image post-processing steps in mask generation: `pixel_to_mask_id` construction becomes a single cumulative-sum plus scatter instead of an `O(masks * max_overlap)` Python loop that forced a device synchronization on every inner iteration, and per-mask scale computation deduplicates on integer gaussian ids rather than sorting float3 world points. Both are equivalent to the originals.
- Stops storing the per-pixel mask-selection CDF on disk (the largest field in the mask cache, a full `[H, W, max_overlap]` float32 tensor) and recomputes it from `pixel_to_mask_id` at load time via `instance_segmentation.util.compute_mask_cdf`. This roughly quarters both the on-disk artifact size and the disk-bound write time.
- Overlaps cache writes with computation by handing each image's disk write to a background writer thread while the next image's SAM2 pass runs on the GPU. `SfmCache`'s `FileLock` now only arms its SIGALRM-based timeout on the main thread and falls back to a plain blocking `flock` on worker threads, since signal-based timeouts cannot be used off the main thread.
- Exposes and raises SAM2 `points_per_batch` so more point prompts are processed per mask-decoder forward pass.

## Device defaults and import updates

- Defaults the compute device to `cuda:0` across the CLI, foundation models, config, and docs, because the current fvdb build requires an explicit device index and `cuda` alone raises "Device must specify an index".

## Dependencies

- Requires `fvdb-core>=0.6.0` and adds `safetensors`.
- The new `fvdb.viz` features that bring the API changes to add interactive, definable parameters require this PR to merge before this branch will work:  https://github.com/openvdb/fvdb-core/pull/649
- cuML clustering, NVOS evaluation, and discrete-instance export remain out of the core dependency set and stay in fvdb-examples for the moment.

## Documentation

- Adds an instance-segmentation tutorial and API pages, a checkpoints API page, and resume/show/transforms updates describing the bundle layout, grid naming, coordinate transforms, versioning, and how future readers or migrations are introduced.

## Testing

- Ported training math is at parity with the prototype for loss (including per-view pair-count normalization), mask-CDF sampling, scale interpolation, pixel sampling, encoder feature extraction, MLP forward paths, and SAM2 mask/scale preprocessing. The port additionally fixes the prototype's scheduler-resume gap by checkpointing and restoring scheduler state.
- The interactive viewer is covered by `unit/test_garfvdb_viewer.py` (widget registration, normalized-to-raw scale mapping, camera/widget change detection and the render/idle contract, show/hide, and PCA lock), and the vectorized mask post-processing and recomputed mask CDF were checked for equivalence against the original implementations, including against a real on-disk cache file.

## Backwards compatibility and follow-ups

- Released flat Gaussian reconstruction checkpoints remain loadable and resumable through the registered legacy adapter; a Gaussian `.ply` remains an export product and is not resumable.
- Standalone fvdb-examples GARfVDB checkpoints are intentionally not migrated; there is no importer for the prototype format, and old SAM2 mask caches must be regenerated because supervision is now a versioned scene attribute.
- `use_grid_conv=True` remains experimental and is not exercised by the first-class path; the per-Gaussian affinity path references a grid attribute that does not exist and would fail if enabled. First-class training and products require `use_grid=True`, so this does not affect the supported configuration, but the option should be fixed or gated before it is advertised as supported.
- The overlay-opacity slider depends on an upstream nanovdb-editor fix (its `image2d.slang` composited the image view opaquely and ignored per-pixel alpha)  https://github.com/openvdb/nanovdb-editor/pull/217
