### PR TITLE
Pin pycolmap<4 in benchmark env to fix nightly libfaiss ABI break

### DIFF
--- a/tests/benchmarks/comparative/docker/benchmark_environment.yml
+++ b/tests/benchmarks/comparative/docker/benchmark_environment.yml
@@ -42,7 +42,13 @@ dependencies:
   - psutil
   - pybind11
   - py-opencv>=4.10[build=headless*]
-  - pycolmap>=3.11
+  # Upper bound pending conda-forge pycolmap 4.x / libfaiss ABI fix: the 4.x conda builds
+  # declare only `libfaiss >=1.9.0,<2`, which is looser than faiss's actual ABI stability.
+  # libfaiss 1.14.3 (cuda130, uploaded 2026-08-04) satisfies that pin but drops the
+  # faiss::IndexIVFFlat ctor symbol pycolmap 4.1.1 was built against, so `import pycolmap`
+  # fails with an undefined symbol. The PyPI wheels are self-contained and unaffected, so
+  # this bound is deliberately scoped to the conda benchmark env and not to pyproject.toml.
+  - pycolmap>=3.11,<4
   - pytest-benchmark
   - python=3.12
   - pytorch-gpu=2.11.0


### PR DESCRIPTION
## Problem

The nightly benchmark jobs have failed since 2026-08-05 (e.g. [run 31002481527](https://github.com/openvdb/fvdb-reality-capture/actions/runs/31002481527)). Both **Unit Benchmarks** and **Comparative Benchmarks** fail at the step named *"Download mipnerf360 dataset"*, but the download is not what breaks — that step imports `fvdb_reality_capture`, which imports `pycolmap`:

```
ImportError: .../pycolmap/_core.cpython-312-x86_64-linux-gnu.so:
  undefined symbol: _ZN5faiss12IndexIVFFlatC1EPNS_5IndexEmmNS_10MetricTypeE
```

Demangled: `faiss::IndexIVFFlat::IndexIVFFlat(faiss::Index*, size_t, size_t, faiss::MetricType)`.

## Root cause

No repository change triggered this — the last edit to `benchmark_environment.yml` was in June.

| Nightly | `pycolmap` | `libfaiss` | Result |
|---|---|---|---|
| Aug 4 | 3.13.0 | *(not installed — 3.x has no faiss dep)* | pass |
| Aug 5 | 4.1.1 `cpu_py312hc257519_1` | 1.14.3 `cuda130h51947b1_200_cuda` | fail |

conda-forge `pycolmap` 4.x requires `libfaiss * *_cuda` and `libfaiss >=1.9.0,<2`, and this env pins `cuda-version=13.0`. The only linux-64 CUDA-13 `libfaiss` build ever published — `1.14.3 cuda130h51947b1_200_cuda` — was uploaded **2026-08-04**, exactly between the last passing and first failing nightly.

Before that build existed, `pycolmap` 4.x was unsatisfiable under `cuda-version=13.0` and the solver silently fell back to 3.13.0. Once it landed, the solver resolved `pycolmap` 4.1.1 (built 2026-07-24 against an older faiss) against an ABI-incompatible `libfaiss`.

`libfaiss >=1.9.0,<2` is far looser than faiss's actual ABI stability across minor versions, so this is an upstream conda-forge feedstock packaging issue. An issue will be filed against `conda-forge/pycolmap-feedstock`.

## Fix

Pin `pycolmap>=3.11,<4` in the benchmark conda env, restoring the 3.13.0 resolution that passed on Aug 4.

**Scope:** deliberately limited to this conda env. The PyPI `pycolmap` wheels are self-contained (27.8 MB, no external faiss linkage) and unaffected — Unit Tests on `main` install 4.1.1 from PyPI and pass — so `pyproject.toml` is intentionally left unpinned so as not to constrain users.

This one file is used by both failing nightly jobs (`nightly.yml` lines 296 and 487) and by `gsplat-l4-tests.yml`, so a single change covers all of them.

The pin should be removed once the feedstock ships `pycolmap` 4.x builds with a correct `libfaiss` run-export pin.

## Testing

- YAML parses and the dependency list resolves as expected (`pycolmap>=3.11,<4`, `cuda-version=13.0` unchanged).
- Verified no `pip:` entry in this env re-specifies `pycolmap`, and that `pip install` of `fvdb_reality_capture` (`pycolmap>=3.11`) is satisfied by the conda-installed 3.13.0 and will not upgrade it.
- Full verification requires a nightly benchmark run; happy to trigger a manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)