### PR TITLE
Add scale regularization

### DIFF
--- a/fvdb_reality_capture/radiance_fields/base_gaussian_splat_optimizer.py
+++ b/fvdb_reality_capture/radiance_fields/base_gaussian_splat_optimizer.py
@@ -15,6 +15,28 @@ REGISTERED_OPTIMIZERS = {}
 DerivedOptimizer = TypeVar("DerivedOptimizer", bound=type)
 
 
+def gaussian_scale_regularization_loss(
+    log_scales: torch.Tensor,
+    scale_regularization: float,
+) -> torch.Tensor:
+    """
+    Compute scale regularization for a set of Gaussians.
+
+    Args:
+        log_scales: Gaussian log scales with shape ``(N, 3)``.
+        scale_regularization: Weight applied to the mean linear scale.
+
+    Returns:
+        A scalar regularization loss.
+    """
+    if log_scales.numel() == 0:
+        return log_scales.new_zeros(())
+
+    if scale_regularization <= 0.0:
+        return log_scales.new_zeros(())
+    return scale_regularization * torch.exp(log_scales).mean()
+
+
 def splat_optimizer(cls: DerivedOptimizer) -> DerivedOptimizer:
     """
     Decorator to register an optimizer class which inherits from :class:`BaseGaussianSplatOptimizer`.

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer.py
@@ -16,7 +16,11 @@ from scipy.special import logit
 
 from fvdb_reality_capture.sfm_scene import SfmScene, SpatialScaleMode
 
-from .base_gaussian_splat_optimizer import BaseGaussianSplatOptimizer, splat_optimizer
+from .base_gaussian_splat_optimizer import (
+    BaseGaussianSplatOptimizer,
+    gaussian_scale_regularization_loss,
+    splat_optimizer,
+)
 from .gaussian_splatting import GaussianSplat3d
 
 
@@ -65,6 +69,14 @@ class GaussianSplatOptimizerConfig:
     """
     Initial scale of each Gaussian. This controls the initial size of the Gaussians in the scene.
     Each Gaussian's covariance matrix will be initialized to a diagonal matrix with this value on the diagonal.
+    """
+
+    scale_regularization: float = 0.0
+    """
+    Weight for scale regularization. The loss is the mean of the three linear scales of all Gaussians and continuously
+    discourages Gaussians from growing large.
+
+    Default: ``0.0`` (disabled).
     """
 
     max_gaussians: int = -1
@@ -231,6 +243,10 @@ class GaussianSplatOptimizerConfig:
     """
     Learning rate for the specular spherical harmonics (order > 0).
     """
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.scale_regularization) or self.scale_regularization < 0.0:
+            raise ValueError("scale_regularization must be finite and >= 0.0")
 
     def make_optimizer(self, model: GaussianSplat3d, sfm_scene: SfmScene) -> BaseGaussianSplatOptimizer:
         return GaussianSplatOptimizer.from_model_and_scene(
@@ -687,12 +703,15 @@ class GaussianSplatOptimizer(BaseGaussianSplatOptimizer):
 
     def regularization_loss(self) -> torch.Tensor:
         """
-        No-op regularization loss for the basic optimizer.
+        Compute scale regularization for the current model.
 
         Returns:
-            regularization_loss (torch.Tensor): A zero tensor.
+            regularization_loss (torch.Tensor): A scalar regularization loss.
         """
-        return torch.zeros((), device=self._model.means.device)
+        return gaussian_scale_regularization_loss(
+            self._model.log_scales,
+            scale_regularization=self._config.scale_regularization,
+        )
 
     @torch.no_grad()
     def _reset_opacities(self):

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer_mcmc.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_optimizer_mcmc.py
@@ -12,6 +12,7 @@ import torch
 
 from fvdb_reality_capture.radiance_fields.base_gaussian_splat_optimizer import (
     BaseGaussianSplatOptimizer,
+    gaussian_scale_regularization_loss,
     splat_optimizer,
 )
 from fvdb_reality_capture.radiance_fields.gaussian_splat_optimizer import (
@@ -80,10 +81,7 @@ class GaussianSplatOptimizerMCMCConfig(GaussianSplatOptimizerConfig):
 
     scale_regularization: float = 0.01
     """
-    Weight for scale regularization loss :math:`L_{scale} = \\frac{1}{N} \\sum_i |scale_i|`.
-
-    This loss encourages the scales of the Gaussians to be small, which in turn encourages Gaussians to
-    disapear in areas where they are not needed.
+    Weight for scale regularization. This overrides the base optimizer default for MCMC optimization.
 
     Default: ``0.01``.
     """
@@ -367,12 +365,13 @@ class GaussianSplatOptimizerMCMC(BaseGaussianSplatOptimizer):
             reg_loss (torch.Tensor): A scalar tensor representing the regularization loss.
         """
 
-        # Rgularize opacity to ensure Gaussian's don't become too opaque
+        # Regularize opacity to ensure Gaussians don't become too opaque.
         loss = self._config.opacity_regularization * self._model.opacities.mean()
 
-        # Regularize scales to ensure Gaussians don't become too large
-        loss = loss + self._config.scale_regularization * self._model.scales.mean()
-
+        loss = loss + gaussian_scale_regularization_loss(
+            self._model.log_scales,
+            scale_regularization=self._config.scale_regularization,
+        )
         return loss
 
     @staticmethod

--- a/tests/benchmarks/contract.py
+++ b/tests/benchmarks/contract.py
@@ -94,6 +94,7 @@ but the contract constrains the *set* of valid keys.
 OPTIMIZER_CONFIG_KEYS = {
     "initial_opacity",
     "initial_covariance_scale",
+    "scale_regularization",
     "max_gaussians",
     "insertion_grad_2d_threshold_mode",
     "deletion_opacity_threshold",
@@ -128,7 +129,6 @@ MCMC_OPTIMIZER_EXTRA_KEYS = {
     "insertion_rate",
     "binomial_coeffs_n_max",
     "opacity_regularization",
-    "scale_regularization",
 }
 """
 Extra fields allowed only when using `GaussianSplatOptimizerMCMCConfig`.


### PR DESCRIPTION
This adds/restores scale regularization to `frgs reconstruct` where it was previously removed.  It was already present in `frgs reconstruct_mcmc` so we've simply moved it to the shared base class. Default behavior for both remains unchanged.