### PR TITLE
Generate benchmark env pins from fvdb-core instead of gating on drift

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -75,3 +75,21 @@ jobs:
           set +e
           git grep -n "	" -- ':!*/codestyle.yml' ':!*.svg' ':!*.cmd' ':!*.png' ':!*.wlt' ':!*.jpg' ':!*.gif' ':!*.mp4' ':!*.pt' ':!*.pth' ':!*.nvdb' ':!*.npz' ':!*.gitmodules'
           test $? -eq 1
+
+  # The nightly builds the fvdb-core wheel from fvdb-core's env/build_environment.yml
+  # and installs it into the benchmark env in this repo. If those pins disagree the
+  # wheel is compiled against one libtorch and loaded against another, and the run
+  # dies at `import fvdb`. The nightly regenerates the pins itself, so a stale file
+  # no longer breaks CI -- but it still breaks `docker build` and anyone creating the
+  # env locally, so keep the committed file honest here.
+  #
+  # This blocks rather than warns: a GitHub `::warning::` is an annotation, so a
+  # green check would hide it and the staleness would persist.
+  check-benchmark-env-current:
+    name: Benchmark env pins current
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check pins match fvdb-core
+      run: python3 scripts/generate_benchmark_env.py --check
+

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -287,6 +287,33 @@ jobs:
           role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
           aws-region: us-east-2
 
+      - name: Generate benchmark env from fvdb-core pins
+        env:
+          FVDB_CORE_SHA: ${{ needs.get-fvdb-core-commit-hash.outputs.fvdb_core_commit_hash }}
+        run: |
+          set -euo pipefail
+          # Derive pytorch-gpu/cuda-version/python from the exact fvdb-core commit
+          # this run builds the wheel from, so the wheel and the environment it is
+          # installed into cannot disagree. A failure here (unreachable ref,
+          # unreadable pin) is fatal; a merely stale committed file is not, it is
+          # corrected in the working copy and reported below.
+          python3 scripts/generate_benchmark_env.py --ref "${FVDB_CORE_SHA}"
+          if git diff --quiet -- tests/benchmarks/comparative/docker/benchmark_environment.yml; then
+            echo "Committed benchmark env already matches fvdb-core." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Benchmark env pins were stale"
+              echo "Regenerated from fvdb-core \`${FVDB_CORE_SHA}\`. This run is unaffected,"
+              echo "but the committed file should be refreshed by running:"
+              echo '```'
+              echo 'scripts/generate_benchmark_env.py'
+              echo '```'
+              echo '```diff'
+              git --no-pager diff -- tests/benchmarks/comparative/docker/benchmark_environment.yml
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Set up benchmark Conda env
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -475,6 +502,33 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch || 'main' }}
+
+      - name: Generate benchmark env from fvdb-core pins
+        env:
+          FVDB_CORE_SHA: ${{ needs.get-fvdb-core-commit-hash.outputs.fvdb_core_commit_hash }}
+        run: |
+          set -euo pipefail
+          # Derive pytorch-gpu/cuda-version/python from the exact fvdb-core commit
+          # this run builds the wheel from, so the wheel and the environment it is
+          # installed into cannot disagree. A failure here (unreachable ref,
+          # unreadable pin) is fatal; a merely stale committed file is not, it is
+          # corrected in the working copy and reported below.
+          python3 scripts/generate_benchmark_env.py --ref "${FVDB_CORE_SHA}"
+          if git diff --quiet -- tests/benchmarks/comparative/docker/benchmark_environment.yml; then
+            echo "Committed benchmark env already matches fvdb-core." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Benchmark env pins were stale"
+              echo "Regenerated from fvdb-core \`${FVDB_CORE_SHA}\`. This run is unaffected,"
+              echo "but the committed file should be refreshed by running:"
+              echo '```'
+              echo 'scripts/generate_benchmark_env.py'
+              echo '```'
+              echo '```diff'
+              git --no-pager diff -- tests/benchmarks/comparative/docker/benchmark_environment.yml
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Set up benchmark Conda env
         uses: mamba-org/setup-micromamba@v2

--- a/scripts/generate_benchmark_env.py
+++ b/scripts/generate_benchmark_env.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Derive the benchmark conda environment's pins from fvdb-core.
+
+The nightly benchmarks build the fvdb-core wheel using fvdb-core's
+``env/build_environment.yml`` and install it into the environment described by
+``tests/benchmarks/comparative/docker/benchmark_environment.yml``. If the two
+disagree the wheel is compiled against one libtorch and loaded against another,
+and the run dies at ``import fvdb`` with an undefined-symbol ImportError.
+
+Rather than keeping the two in sync by hand, this script rewrites the pinned
+lines in the benchmark environment from fvdb-core. Only those lines are
+touched; the file stays a normal, readable, committed conda environment so the
+Dockerfile and local users keep working unchanged.
+
+Examples::
+
+    # match fvdb-core main
+    scripts/generate_benchmark_env.py
+
+    # match a specific fvdb-core commit (what CI does)
+    scripts/generate_benchmark_env.py --ref 419fcb67e82d63c53bcbf7410c4c825969ac288a
+
+    # match a local checkout, e.g. the one you just built a wheel from
+    scripts/generate_benchmark_env.py --from-local ../fvdb-core
+
+    # fail if the committed file is stale, without modifying it
+    scripts/generate_benchmark_env.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# fvdb-core's build environment is the source of truth: it is the environment
+# the nightly compiles the wheel in, so it determines the resulting ABI. The
+# other env files (dev/test/learn) usually agree but are not what gets built.
+CORE_REPO = "openvdb/fvdb-core"
+CORE_ENV_RELPATH = "env/build_environment.yml"
+BENCH_ENV_RELPATH = "tests/benchmarks/comparative/docker/benchmark_environment.yml"
+
+# Pins that affect the compiled ABI or the interpreter the wheel is built for.
+PINNED_KEYS = ("pytorch-gpu", "cuda-version", "python")
+
+TIMEOUT_SECONDS = 30
+
+
+def _pin_pattern(key: str) -> re.Pattern[str]:
+    return re.compile(rf"^(?P<prefix>\s*-\s*{re.escape(key)}=)(?P<value>\S+)\s*$", re.MULTILINE)
+
+
+def read_pins(text: str, source: str) -> dict[str, str]:
+    """Return the pinned value for each key, failing if any is unreadable."""
+    pins: dict[str, str] = {}
+    missing: list[str] = []
+    for key in PINNED_KEYS:
+        match = _pin_pattern(key).search(text)
+        if match is None:
+            missing.append(key)
+        else:
+            pins[key] = match.group("value")
+    if missing:
+        raise SystemExit(
+            f"error: could not read {', '.join(missing)} from {source}.\n"
+            f"       Expected lines of the form '  - <key>=<value>'.\n"
+            f"       If the pin format changed, update PINNED_KEYS/_pin_pattern in this script."
+        )
+    return pins
+
+
+def fetch_core_env(ref: str) -> str:
+    url = f"https://raw.githubusercontent.com/{CORE_REPO}/{ref}/{CORE_ENV_RELPATH}"
+    try:
+        with urllib.request.urlopen(url, timeout=TIMEOUT_SECONDS) as response:  # noqa: S310
+            return response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"error: fetching {url} failed with HTTP {exc.code}. Is '{ref}' a valid ref?") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"error: could not reach {url}: {exc.reason}") from exc
+
+
+def load_local_core_env(checkout: Path) -> str:
+    path = checkout / CORE_ENV_RELPATH
+    if not path.is_file():
+        raise SystemExit(f"error: {path} not found. Is '{checkout}' an fvdb-core checkout?")
+    return path.read_text(encoding="utf-8")
+
+
+def apply_pins(text: str, pins: dict[str, str]) -> str:
+    for key, value in pins.items():
+        pattern = _pin_pattern(key)
+        text, count = pattern.subn(lambda m: f"{m.group('prefix')}{value}", text)
+        if count != 1:
+            raise SystemExit(f"error: expected exactly one '{key}=' line in the benchmark env, found {count}.")
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--ref", default="main", help="fvdb-core git ref to read pins from (default: main)")
+    source.add_argument("--from-local", type=Path, metavar="PATH", help="read pins from a local fvdb-core checkout")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="do not write; exit 1 and print a diff if the committed file is stale",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    bench_path = repo_root / BENCH_ENV_RELPATH
+    if not bench_path.is_file():
+        raise SystemExit(f"error: {bench_path} not found.")
+
+    if args.from_local is not None:
+        core_text = load_local_core_env(args.from_local)
+        origin = f"{args.from_local}/{CORE_ENV_RELPATH}"
+    else:
+        core_text = fetch_core_env(args.ref)
+        origin = f"{CORE_REPO}@{args.ref}:{CORE_ENV_RELPATH}"
+
+    core_pins = read_pins(core_text, origin)
+    before = bench_path.read_text(encoding="utf-8")
+    bench_pins = read_pins(before, str(bench_path))
+    after = apply_pins(before, core_pins)
+
+    print(f"source: {origin}")
+    for key in PINNED_KEYS:
+        arrow = "" if bench_pins[key] == core_pins[key] else f"  (was {bench_pins[key]})"
+        print(f"  {key:<14} {core_pins[key]}{arrow}")
+
+    if before == after:
+        print(f"{bench_path.relative_to(repo_root)} is already up to date.")
+        return 0
+
+    if args.check:
+        diff = difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=f"a/{BENCH_ENV_RELPATH}",
+            tofile=f"b/{BENCH_ENV_RELPATH}",
+        )
+        sys.stdout.writelines(diff)
+        print(
+            f"\nerror: {BENCH_ENV_RELPATH} is out of date with {origin}.\n"
+            f"       Run scripts/generate_benchmark_env.py and commit the result.",
+            file=sys.stderr,
+        )
+        return 1
+
+    bench_path.write_text(after, encoding="utf-8")
+    print(f"updated {bench_path.relative_to(repo_root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/comparative/docker/benchmark_environment.yml
+++ b/tests/benchmarks/comparative/docker/benchmark_environment.yml
@@ -51,9 +51,12 @@ dependencies:
   - pycolmap>=3.11,<4
   - pytest-benchmark
   - python=3.12
-  # Keep in sync with fvdb-core's env/build_environment.yml: the nightly builds the
-  # fvdb-core wheel in that env and installs it here, so a mismatch is an ABI break
-  # (undefined libtorch symbols at `import fvdb`), not a version warning.
+  # python, cuda-version and pytorch-gpu are DERIVED from fvdb-core's
+  # env/build_environment.yml -- the environment its wheel is compiled in. A
+  # mismatch is an ABI break (undefined libtorch symbols at `import fvdb`), not a
+  # version warning. Do not hand-edit these three; run:
+  #     scripts/generate_benchmark_env.py                 # match fvdb-core main
+  #     scripts/generate_benchmark_env.py --from-local ../fvdb-core
   - pytorch-gpu=2.13.0
   - rich
   - scikit-build-core


### PR DESCRIPTION
## Problem

The nightly builds the fvdb-core wheel using fvdb-core's `env/build_environment.yml`, then installs it into the benchmark env in this repo. When those pins disagree, the wheel is compiled against one libtorch and loaded against another and the run dies at `import fvdb`:

```
ImportError: .../site-packages/fvdb/libfvdb.so: undefined symbol:
  _ZN3c1010ValueErrorC1ENS_14SourceLocationENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
```

This has happened three times: `1b6956f` (2.8→2.10), `6c2ede6` (2.10→2.11), and #318 (2.11→2.13).

## Change of approach

This PR originally added a gate that failed the nightly on drift. Per review feedback from @swahtz, **detection is the weaker answer** — a gate still needs a human to notice and hand-edit a version, which is precisely the toil that kept recurring. Derive the value instead.

`scripts/generate_benchmark_env.py` reads `pytorch-gpu`, `cuda-version` and `python` from fvdb-core and rewrites those three lines in the benchmark env.

It **rewrites lines rather than rendering a template**, deliberately: the file stays a normal committed conda environment, so `docker/Dockerfile` (which `COPY`s it) and anyone creating the env by hand keep working unchanged. Standard library only, so it needs no environment to bootstrap.

```
scripts/generate_benchmark_env.py                          # match fvdb-core main
scripts/generate_benchmark_env.py --ref <sha>              # match a specific commit
scripts/generate_benchmark_env.py --from-local ../fvdb-core
scripts/generate_benchmark_env.py --check                  # stale? exit 1 + diff
```

## Wiring

| Where | Behaviour |
|---|---|
| Both nightly benchmark jobs | Regenerate from the **exact fvdb-core commit the run builds the wheel from**, so wheel and env cannot disagree even if the committed file is stale |
| `check-benchmark-env-current` (PR) | Blocks if the committed file is stale, with a one-command fix |
| Dockerfile / local use | Unchanged — the file is still committed and valid |

**On what happens when CI has to update the pins** (asked during review): the nightly does *not* fail. Once it derives, staleness no longer breaks the run, so failing would reintroduce the "nightly red for a reason unrelated to the benchmarks" problem this removes. It corrects the working copy, proceeds, and reports the diff to the job summary. The enforcing signal is the PR check, where the fix is one command. A scheduled bot could open that PR automatically later — note it would need a PAT or App token, since PRs created with `GITHUB_TOKEN` do not trigger workflows.

`--from-local` matches a locally built wheel and needs no network — something CI-side derivation alone could not offer.

## Testing

- `--check` passes when synced; fails with a unified diff when not
- With a **committed** stale pin (2.11.0), the nightly step corrects the env to 2.13.0 so the run is unaffected, and reports the staleness to the job summary
- `--from-local ../fvdb-core` resolves correctly offline
- `black --target-version=py311 --line-length=120` clean

## Supersedes

openvdb/fvdb-core#746 (the mirror-image gate on the fvdb-core side) is closed in favour of this — with derivation, that gate protects nothing in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)