### PR TITLE
Add option to cache training images on the host

### DIFF
--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 import torch.utils.data
 import torchvision
+import tqdm
 
 from fvdb_reality_capture.sfm_scene import (
     DepthMapAttribute,
@@ -45,6 +46,7 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         patch_size: int | None = None,
         return_visible_points: bool = False,
         load_attributes: list[str] | None = None,
+        cache_images: bool = False,
     ):
         """
         Create a new SfmDataset instance.
@@ -57,6 +59,9 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
             load_attributes: Optional list of custom attribute names to load and include in each datum.
                 For :class:`PerImageRasterAttribute`, the raster file is loaded and included as a tensor.
                 For :class:`PerImageValueAttribute`, the in-memory value is included directly.
+            cache_images: If True, decode the dataset's images and masks once into shared host memory.
+                DataLoader worker processes then reuse the same read-only tensors instead of decoding the files
+                on every epoch. This can require substantial shared memory for high-resolution datasets.
         """
         self._logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
@@ -117,6 +122,100 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         dataset_indices = dataset_indices.astype(np.int64)
 
         self._indices: np.ndarray = dataset_indices
+        self._cached_images: dict[int, torch.Tensor] | None = None
+        self._cached_masks: dict[int, torch.Tensor] | None = None
+        if cache_images:
+            self._cache_images()
+
+    @staticmethod
+    def _decode_image(path: str) -> torch.Tensor:
+        """Decode an image into a contiguous HWC RGB tensor on the CPU."""
+        path_lower = path.lower()
+        if path_lower.endswith((".jpg", ".jpeg")):
+            encoded = torchvision.io.read_file(path)
+            image = torchvision.io.decode_jpeg(encoded, device="cpu")
+            assert isinstance(image, torch.Tensor)
+            image = image.permute(1, 2, 0)
+        elif path_lower.endswith(".png"):
+            encoded = torchvision.io.read_file(path)
+            image = torchvision.io.decode_png(encoded).permute(1, 2, 0)
+        else:
+            image_np = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+            assert image_np is not None, f"Failed to load image: {path}"
+            image_np = cv2.cvtColor(image_np, cv2.COLOR_BGR2RGB)
+            image = torch.from_numpy(image_np)
+
+        if image.ndim == 2:
+            image = image[:, :, None]
+        return image.contiguous()
+
+    @staticmethod
+    def _decode_mask(path: str) -> torch.Tensor:
+        """Decode a mask into a contiguous HW boolean tensor on the CPU."""
+        path_lower = path.lower()
+        if path_lower.endswith((".jpg", ".jpeg")):
+            encoded = torchvision.io.read_file(path)
+            mask = torchvision.io.decode_jpeg(encoded, device="cpu")[0]
+        elif path_lower.endswith(".png"):
+            encoded = torchvision.io.read_file(path)
+            mask = torchvision.io.decode_png(encoded)[0]
+        else:
+            mask_np = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+            assert mask_np is not None, f"Failed to load mask: {path}"
+            mask = torch.from_numpy(mask_np)
+        return (mask > 127).contiguous()
+
+    def _cache_images(self) -> None:
+        """Decode this dataset's images and masks into read-only shared-memory tensors."""
+        unique_indices = list(dict.fromkeys(self._indices.tolist()))
+        self._logger.info(f"Caching {len(unique_indices):,} decoded images in shared host memory.")
+
+        cached_images_by_path: dict[str, torch.Tensor] = {}
+        cached_masks_by_path: dict[str, torch.Tensor] = {}
+        cached_images: dict[int, torch.Tensor] = {}
+        cached_masks: dict[int, torch.Tensor] = {}
+
+        try:
+            progress = tqdm.tqdm(unique_indices, unit="imgs", desc="Caching decoded training images")
+            for index in progress:
+                image_meta = self._sfm_scene.images[index]
+                image = cached_images_by_path.get(image_meta.image_path)
+                if image is None:
+                    image = self._decode_image(image_meta.image_path)
+                    image.share_memory_()
+                    cached_images_by_path[image_meta.image_path] = image
+                cached_images[index] = image
+
+                if image_meta.mask_path != "":
+                    mask = cached_masks_by_path.get(image_meta.mask_path)
+                    if mask is None:
+                        mask = self._decode_mask(image_meta.mask_path)
+                        mask.share_memory_()
+                        cached_masks_by_path[image_meta.mask_path] = mask
+                    cached_masks[index] = mask
+        except RuntimeError as error:
+            cached_images.clear()
+            cached_masks.clear()
+            cached_images_by_path.clear()
+            cached_masks_by_path.clear()
+            raise RuntimeError(
+                "Failed to cache decoded training images in shared memory. Increase the host/shared-memory "
+                "capacity or disable cache_training_images."
+            ) from error
+
+        self._cached_images = cached_images
+        self._cached_masks = cached_masks
+        image_bytes = sum(image.numel() * image.element_size() for image in cached_images_by_path.values())
+        mask_bytes = sum(mask.numel() * mask.element_size() for mask in cached_masks_by_path.values())
+        self._logger.info(
+            f"Cached {len(cached_images_by_path):,} decoded images and {len(cached_masks_by_path):,} masks "
+            f"using {(image_bytes + mask_bytes) / 2**30:.2f} GiB of shared host memory."
+        )
+
+    @property
+    def images_cached(self) -> bool:
+        """Whether images for this dataset are cached in shared host memory."""
+        return self._cached_images is not None
 
     @property
     def sfm_scene(self) -> SfmScene:
@@ -311,21 +410,10 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         image_meta: SfmPosedImageMetadata = self._sfm_scene.images[index]
         camera_meta: SfmCameraMetadata = image_meta.camera_metadata
 
-        if image_meta.image_path.endswith(".jpg") or image_meta.image_path.endswith(".jpeg"):
-            data = torchvision.io.read_file(image_meta.image_path)
-            image = torchvision.io.decode_jpeg(data, device="cpu")
-            assert isinstance(image, torch.Tensor)
-            image = image.permute(1, 2, 0).numpy()
-        elif image_meta.image_path.endswith(".png"):
-            data = torchvision.io.read_file(image_meta.image_path)
-            image = torchvision.io.decode_png(data).permute(1, 2, 0).numpy()
+        if self._cached_images is not None:
+            image: torch.Tensor | np.ndarray = self._cached_images[index]
         else:
-            image = cv2.imread(image_meta.image_path, cv2.IMREAD_UNCHANGED)
-            assert image is not None, f"Failed to load image: {image_meta.image_path}"
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-
-        if image.ndim == 2:
-            image = image[:, :, None]
+            image = self._decode_image(image_meta.image_path).numpy()
         projection_matrix = camera_meta.projection_matrix.copy()
         camera_to_world_matrix = image_meta.camera_to_world_matrix.copy()
         world_to_camera_matrix = image_meta.world_to_camera_matrix.copy()
@@ -356,16 +444,10 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
 
         # If you passed in masks, we'll set set these in the data dictionary
         if image_meta.mask_path != "":
-            if image_meta.mask_path.endswith(".jpg") or image_meta.mask_path.endswith(".jpeg"):
-                img_data = torchvision.io.read_file(image_meta.mask_path)
-                mask = torchvision.io.decode_jpeg(img_data, device="cpu")[0].numpy()
-            elif image_meta.mask_path.endswith(".png"):
-                img_data = torchvision.io.read_file(image_meta.mask_path)
-                mask = torchvision.io.decode_png(img_data)[0].numpy()
+            if self._cached_masks is not None:
+                mask: torch.Tensor | np.ndarray = self._cached_masks[index]
             else:
-                mask = cv2.imread(image_meta.mask_path, cv2.IMREAD_GRAYSCALE)
-                assert mask is not None, f"Failed to load mask: {image_meta.mask_path}"
-            mask = mask > 127
+                mask = self._decode_mask(image_meta.mask_path).numpy()
 
             data["mask_path"] = image_meta.mask_path
             data["mask"] = mask

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_dataset.py
@@ -122,82 +122,58 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         dataset_indices = dataset_indices.astype(np.int64)
 
         self._indices: np.ndarray = dataset_indices
-        self._cached_images: dict[int, torch.Tensor] | None = None
-        self._cached_masks: dict[int, torch.Tensor] | None = None
+        self._cached_images: dict[str, torch.Tensor] | None = None
+        self._cached_masks: dict[str, torch.Tensor] | None = None
         if cache_images:
             self._cache_images()
 
     @staticmethod
-    def _decode_image(path: str) -> torch.Tensor:
+    def _decode_raster(path: str, *, is_mask: bool) -> torch.Tensor:
+        """Decode an image or mask into a contiguous CPU tensor."""
+        path_lower = path.lower()
+        if path_lower.endswith((".jpg", ".jpeg", ".png")):
+            encoded = torchvision.io.read_file(path)
+            raster = torchvision.io.decode_image(encoded)
+            raster = raster[0] if is_mask else raster.permute(1, 2, 0)
+        else:
+            raster_np = cv2.imread(path, cv2.IMREAD_GRAYSCALE if is_mask else cv2.IMREAD_UNCHANGED)
+            assert raster_np is not None, f"Failed to load {'mask' if is_mask else 'image'}: {path}"
+            if not is_mask:
+                raster_np = cv2.cvtColor(raster_np, cv2.COLOR_BGR2RGB)
+            raster = torch.from_numpy(raster_np)
+
+        if not is_mask and raster.ndim == 2:
+            raster = raster[:, :, None]
+        return raster.contiguous()
+
+    @classmethod
+    def _decode_image(cls, path: str) -> torch.Tensor:
         """Decode an image into a contiguous HWC RGB tensor on the CPU."""
-        path_lower = path.lower()
-        if path_lower.endswith((".jpg", ".jpeg")):
-            encoded = torchvision.io.read_file(path)
-            image = torchvision.io.decode_jpeg(encoded, device="cpu")
-            assert isinstance(image, torch.Tensor)
-            image = image.permute(1, 2, 0)
-        elif path_lower.endswith(".png"):
-            encoded = torchvision.io.read_file(path)
-            image = torchvision.io.decode_png(encoded).permute(1, 2, 0)
-        else:
-            image_np = cv2.imread(path, cv2.IMREAD_UNCHANGED)
-            assert image_np is not None, f"Failed to load image: {path}"
-            image_np = cv2.cvtColor(image_np, cv2.COLOR_BGR2RGB)
-            image = torch.from_numpy(image_np)
+        return cls._decode_raster(path, is_mask=False)
 
-        if image.ndim == 2:
-            image = image[:, :, None]
-        return image.contiguous()
-
-    @staticmethod
-    def _decode_mask(path: str) -> torch.Tensor:
+    @classmethod
+    def _decode_mask(cls, path: str) -> torch.Tensor:
         """Decode a mask into a contiguous HW boolean tensor on the CPU."""
-        path_lower = path.lower()
-        if path_lower.endswith((".jpg", ".jpeg")):
-            encoded = torchvision.io.read_file(path)
-            mask = torchvision.io.decode_jpeg(encoded, device="cpu")[0]
-        elif path_lower.endswith(".png"):
-            encoded = torchvision.io.read_file(path)
-            mask = torchvision.io.decode_png(encoded)[0]
-        else:
-            mask_np = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
-            assert mask_np is not None, f"Failed to load mask: {path}"
-            mask = torch.from_numpy(mask_np)
-        return (mask > 127).contiguous()
+        return (cls._decode_raster(path, is_mask=True) > 127).contiguous()
 
     def _cache_images(self) -> None:
         """Decode this dataset's images and masks into read-only shared-memory tensors."""
         unique_indices = list(dict.fromkeys(self._indices.tolist()))
         self._logger.info(f"Caching {len(unique_indices):,} decoded images in shared host memory.")
 
-        cached_images_by_path: dict[str, torch.Tensor] = {}
-        cached_masks_by_path: dict[str, torch.Tensor] = {}
-        cached_images: dict[int, torch.Tensor] = {}
-        cached_masks: dict[int, torch.Tensor] = {}
+        cached_images: dict[str, torch.Tensor] = {}
+        cached_masks: dict[str, torch.Tensor] = {}
 
         try:
             progress = tqdm.tqdm(unique_indices, unit="imgs", desc="Caching decoded training images")
             for index in progress:
                 image_meta = self._sfm_scene.images[index]
-                image = cached_images_by_path.get(image_meta.image_path)
-                if image is None:
-                    image = self._decode_image(image_meta.image_path)
-                    image.share_memory_()
-                    cached_images_by_path[image_meta.image_path] = image
-                cached_images[index] = image
+                if image_meta.image_path not in cached_images:
+                    cached_images[image_meta.image_path] = self._decode_image(image_meta.image_path).share_memory_()
 
-                if image_meta.mask_path != "":
-                    mask = cached_masks_by_path.get(image_meta.mask_path)
-                    if mask is None:
-                        mask = self._decode_mask(image_meta.mask_path)
-                        mask.share_memory_()
-                        cached_masks_by_path[image_meta.mask_path] = mask
-                    cached_masks[index] = mask
+                if image_meta.mask_path != "" and image_meta.mask_path not in cached_masks:
+                    cached_masks[image_meta.mask_path] = self._decode_mask(image_meta.mask_path).share_memory_()
         except RuntimeError as error:
-            cached_images.clear()
-            cached_masks.clear()
-            cached_images_by_path.clear()
-            cached_masks_by_path.clear()
             raise RuntimeError(
                 "Failed to cache decoded training images in shared memory. Increase the host/shared-memory "
                 "capacity or disable cache_training_images."
@@ -205,10 +181,10 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
 
         self._cached_images = cached_images
         self._cached_masks = cached_masks
-        image_bytes = sum(image.numel() * image.element_size() for image in cached_images_by_path.values())
-        mask_bytes = sum(mask.numel() * mask.element_size() for mask in cached_masks_by_path.values())
+        image_bytes = sum(image.numel() * image.element_size() for image in cached_images.values())
+        mask_bytes = sum(mask.numel() * mask.element_size() for mask in cached_masks.values())
         self._logger.info(
-            f"Cached {len(cached_images_by_path):,} decoded images and {len(cached_masks_by_path):,} masks "
+            f"Cached {len(cached_images):,} decoded images and {len(cached_masks):,} masks "
             f"using {(image_bytes + mask_bytes) / 2**30:.2f} GiB of shared host memory."
         )
 
@@ -411,7 +387,7 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         camera_meta: SfmCameraMetadata = image_meta.camera_metadata
 
         if self._cached_images is not None:
-            image: torch.Tensor | np.ndarray = self._cached_images[index]
+            image: torch.Tensor | np.ndarray = self._cached_images[image_meta.image_path]
         else:
             image = self._decode_image(image_meta.image_path).numpy()
         projection_matrix = camera_meta.projection_matrix.copy()
@@ -445,7 +421,7 @@ class SfmDataset(torch.utils.data.Dataset, Iterable):
         # If you passed in masks, we'll set set these in the data dictionary
         if image_meta.mask_path != "":
             if self._cached_masks is not None:
-                mask: torch.Tensor | np.ndarray = self._cached_masks[index]
+                mask: torch.Tensor | np.ndarray = self._cached_masks[image_meta.mask_path]
             else:
                 mask = self._decode_mask(image_meta.mask_path).numpy()
 

--- a/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splat_reconstruction.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn.functional as nnf
 import torch.utils.data
 from torch.utils import _pytree
+from torch.utils.data import default_collate
 import tqdm
 from fvdb.utils.metrics import psnr, ssim
 from fvdb.viz import Scene
@@ -38,6 +39,30 @@ from .gaussian_splat_reconstruction_writer import (
     GaussianSplatReconstructionBaseWriter,
     GaussianSplatReconstructionWriter,
 )
+
+
+def _collate_cached_sfm_batch(batch: list[dict[str, Any]]) -> dict[str, Any]:
+    """Add a batch dimension to shared rasters without copying their storage.
+
+    This collator is used only for batch-size-one training with an in-memory image
+    cache. Metadata and uncached values retain PyTorch's standard collation behavior.
+    """
+    if len(batch) != 1:
+        return default_collate(batch)
+
+    datum = batch[0]
+    shared_rasters = {
+        key: value
+        for key, value in datum.items()
+        if key in ("image", "mask") and isinstance(value, torch.Tensor) and value.is_shared()
+    }
+    if not shared_rasters:
+        return default_collate(batch)
+
+    collated = default_collate([{key: value for key, value in datum.items() if key not in shared_rasters}])
+    for key, value in shared_rasters.items():
+        collated[key] = value.unsqueeze(0)
+    return collated
 
 
 def _scale_shift_invariant_l1(
@@ -157,6 +182,15 @@ class GaussianSplatReconstructionConfig:
     to run the forward pass on crops and accumulate gradients. This can help reduce memory usage.
 
     Default: ``1`` (no cropping, use full images).
+    """
+
+    cache_training_images: bool = False
+    """
+    Decode training images and masks once into shared host memory and reuse them across epochs and DataLoader
+    workers. This avoids repeated image decoding but can consume substantial host and shared memory for
+    high-resolution datasets. Validation images are not cached.
+
+    Default: ``False``
     """
 
     sh_degree: int = 3
@@ -828,6 +862,7 @@ class GaussianSplatReconstruction:
             dataset_indices=train_indices,
             return_visible_points=(self.config.sparse_depth_reg > 0.0),
             load_attributes=dense_depth_load,
+            cache_images=self.config.cache_training_images,
         )
         self._validation_dataset = SfmDataset(sfm_scene=sfm_scene, dataset_indices=val_indices)
 
@@ -1250,6 +1285,11 @@ class GaussianSplatReconstruction:
             num_workers=8,
             persistent_workers=True,
             pin_memory=True,
+            collate_fn=(
+                _collate_cached_sfm_batch
+                if self.config.batch_size == 1 and self.training_dataset.images_cached
+                else None
+            ),
         )
 
         if self.config.batch_size > 1:

--- a/tests/benchmarks/contract.py
+++ b/tests/benchmarks/contract.py
@@ -56,6 +56,7 @@ RECONSTRUCTION_CONFIG_KEYS = {
     "save_at_percent",
     "batch_size",
     "crops_per_image",
+    "cache_training_images",
     "sh_degree",
     "increase_sh_degree_every_epoch",
     "ssim_lambda",

--- a/tests/unit/test_gaussian_splat_dataset.py
+++ b/tests/unit/test_gaussian_splat_dataset.py
@@ -8,9 +8,12 @@ import unittest
 
 import cv2
 import numpy as np
+import torch
+import torch.utils.data
 
 from fvdb_reality_capture import CameraModel
 from fvdb_reality_capture.radiance_fields.gaussian_splat_dataset import SfmDataset
+from fvdb_reality_capture.radiance_fields.gaussian_splat_reconstruction import _collate_cached_sfm_batch
 from fvdb_reality_capture.sfm_scene import SfmCache, SfmCameraMetadata, SfmPosedImageMetadata, SfmScene
 
 
@@ -32,10 +35,17 @@ class GaussianSplatDatasetTests(unittest.TestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    def _make_scene(self) -> tuple[SfmScene, SfmCameraMetadata]:
+    def _make_scene(self, with_mask: bool = False) -> tuple[SfmScene, SfmCameraMetadata]:
         image_path = self.root / "image.png"
         image = np.zeros((8, 10, 3), dtype=np.uint8)
         self.assertTrue(cv2.imwrite(str(image_path), image))
+        mask_path = ""
+        if with_mask:
+            mask = np.zeros((8, 10), dtype=np.uint8)
+            mask[:4] = 255
+            mask_file = self.root / "mask.png"
+            self.assertTrue(cv2.imwrite(str(mask_file), mask))
+            mask_path = str(mask_file)
 
         camera_metadata = SfmCameraMetadata(
             img_width=10,
@@ -53,7 +63,7 @@ class GaussianSplatDatasetTests(unittest.TestCase):
             camera_metadata=camera_metadata,
             camera_id=1,
             image_path=str(image_path),
-            mask_path="",
+            mask_path=mask_path,
             point_indices=np.array([], dtype=np.int64),
             image_id=0,
         )
@@ -85,3 +95,63 @@ class GaussianSplatDatasetTests(unittest.TestCase):
         datum["distortion_coeffs"][0] = 999.0
 
         self.assertAlmostEqual(float(camera_metadata.distortion_coeffs[0]), 0.1)
+
+    def test_dataset_caches_images_and_masks_in_shared_memory(self):
+        scene, _ = self._make_scene(with_mask=True)
+
+        dataset = SfmDataset(scene, cache_images=True)
+        first = dataset[0]
+
+        self.assertTrue(dataset.images_cached)
+        self.assertIsInstance(first["image"], torch.Tensor)
+        self.assertIsInstance(first["mask"], torch.Tensor)
+        self.assertTrue(first["image"].is_shared())
+        self.assertTrue(first["mask"].is_shared())
+        self.assertEqual(tuple(first["image"].shape), (8, 10, 3))
+        self.assertEqual(tuple(first["mask"].shape), (8, 10))
+        self.assertTrue(torch.all(first["image"] == 0))
+        self.assertTrue(torch.all(first["mask"][:4]))
+        self.assertTrue(torch.all(~first["mask"][4:]))
+
+        # Changing the source files after construction must not change cached data.
+        self.assertTrue(cv2.imwrite(scene.images[0].image_path, np.full((8, 10, 3), 255, dtype=np.uint8)))
+        self.assertTrue(cv2.imwrite(scene.images[0].mask_path, np.zeros((8, 10), dtype=np.uint8)))
+        second = dataset[0]
+        self.assertEqual(first["image"].data_ptr(), second["image"].data_ptr())
+        self.assertEqual(first["mask"].data_ptr(), second["mask"].data_ptr())
+        self.assertTrue(torch.all(second["image"] == 0))
+        self.assertTrue(torch.all(second["mask"][:4]))
+
+        uncached = SfmDataset(scene)[0]
+        self.assertIsInstance(uncached["image"], np.ndarray)
+        self.assertTrue(np.all(uncached["image"] == 255))
+        self.assertFalse(np.any(uncached["mask"]))
+
+    def test_cached_batch_collation_does_not_copy_shared_rasters(self):
+        scene, _ = self._make_scene(with_mask=True)
+        datum = SfmDataset(scene, cache_images=True)[0]
+
+        collated = _collate_cached_sfm_batch([datum])
+
+        self.assertEqual(tuple(collated["image"].shape), (1, 8, 10, 3))
+        self.assertEqual(tuple(collated["mask"].shape), (1, 8, 10))
+        self.assertEqual(collated["image"].data_ptr(), datum["image"].data_ptr())
+        self.assertEqual(collated["mask"].data_ptr(), datum["mask"].data_ptr())
+
+    def test_dataloader_worker_reads_cached_shared_rasters(self):
+        scene, _ = self._make_scene(with_mask=True)
+        dataset = SfmDataset(scene, cache_images=True)
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=1,
+            num_workers=1,
+            collate_fn=_collate_cached_sfm_batch,
+        )
+
+        batches = list(dataloader)
+
+        self.assertEqual(len(batches), 1)
+        self.assertTrue(batches[0]["image"].is_shared())
+        self.assertTrue(batches[0]["mask"].is_shared())
+        self.assertTrue(torch.all(batches[0]["image"] == 0))
+        self.assertTrue(torch.all(batches[0]["mask"][:, :4]))


### PR DESCRIPTION
This PR adds `--cfg.cache-training-images` which loads all of the images into host memory prior to running the training. Even with the PyTorch dataloader running in separate parallel processes, this is often more efficient than re-reading and decoding the image each time it is needed during training. In the early steps of a reconstruction, this can save around 20% off the time per training step.