### PR TITLE
CI: use all three us-east-2 availability zones for EC2 runners

### DIFF
--- a/.github/versions.json
+++ b/.github/versions.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Shared CI configuration. Mirrors the aws block of openvdb/fvdb-core's .github/versions.json so the two repos provision runners the same way; keep the subnet list in sync with that file.",
+  "aws": {
+    "role": "arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role",
+    "region": "us-east-2",
+    "cpu_ami": "ami-0e14a711dad782a70",
+    "gpu_ami": "ami-0f5c0b65fde08ae43",
+    "subnets": [
+      { "az": "us-east-2a", "id": "subnet-0b75bb13b6048a2f1" },
+      { "az": "us-east-2b", "id": "subnet-03f2320d6e6e0005b" },
+      { "az": "us-east-2c", "id": "subnet-0c551606873c36095" }
+    ],
+    "security_group": "sg-0cd08bd89d6212223"
+  }
+}

--- a/.github/workflows/gsplat-l4-tests.yml
+++ b/.github/workflows/gsplat-l4-tests.yml
@@ -23,9 +23,14 @@ permissions:
   id-token: write
 
 jobs:
+  versions:
+    name: Load versions
+    uses: ./.github/workflows/load-versions.yml
+
   start-gpu-runner:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Start L4 GPU runner
+    needs: versions
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-runner.outputs.label }}
@@ -42,10 +47,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-image-id: ami-0f5c0b65fde08ae43
           ec2-instance-type: g6.xlarge
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   gsplat-tests:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}

--- a/.github/workflows/load-versions.yml
+++ b/.github/workflows/load-versions.yml
@@ -1,0 +1,47 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+
+name: Load Versions
+on:
+  workflow_call:
+    outputs:
+      aws-role:
+        value: ${{ jobs.load.outputs.aws-role }}
+      aws-region:
+        value: ${{ jobs.load.outputs.aws-region }}
+      aws-cpu-az-config:
+        value: ${{ jobs.load.outputs.aws-cpu-az-config }}
+      aws-gpu-az-config:
+        value: ${{ jobs.load.outputs.aws-gpu-az-config }}
+
+permissions:
+  contents: read
+
+jobs:
+  load:
+    runs-on: ubuntu-latest
+    outputs:
+      aws-role: ${{ steps.parse.outputs.aws-role }}
+      aws-region: ${{ steps.parse.outputs.aws-region }}
+      aws-cpu-az-config: ${{ steps.parse.outputs.aws-cpu-az-config }}
+      aws-gpu-az-config: ${{ steps.parse.outputs.aws-gpu-az-config }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/versions.json
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Parse versions.json
+        id: parse
+        run: |
+          set -euo pipefail
+          CFG=".github/versions.json"
+          # One entry per availability zone. machulav/ec2-github-runner tries each
+          # in sequence, so a zone that is out of capacity for the requested
+          # instance type no longer fails the whole job.
+          {
+            echo "aws-role=$(jq -r '.aws.role' $CFG)"
+            echo "aws-region=$(jq -r '.aws.region' $CFG)"
+            echo "aws-cpu-az-config=$(jq -c '.aws as $a | [$a.subnets[] | {imageId: $a.cpu_ami, subnetId: .id, securityGroupId: $a.security_group}]' $CFG)"
+            echo "aws-gpu-az-config=$(jq -c '.aws as $a | [$a.subnets[] | {imageId: $a.gpu_ami, subnetId: .id, securityGroupId: $a.security_group}]' $CFG)"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,10 @@ permissions:
   id-token: write
 
 jobs:
+  versions:
+    name: Load versions
+    uses: ./.github/workflows/load-versions.yml
+
   # Get current commit hash of fvdb-core main and store in a variable
   get-fvdb-core-commit-hash:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
@@ -103,7 +107,7 @@ jobs:
   start-build-runner:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' && needs.get-fvdb-core-commit-hash.outputs.should_skip != 'true' }}
     name: Start CPU-only EC2 runner for build
-    needs: get-fvdb-core-commit-hash
+    needs: [get-fvdb-core-commit-hash, versions]
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-build-runner.outputs.label }}
@@ -120,10 +124,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-image-id: ami-0e14a711dad782a70
           ec2-instance-type: m6a.8xlarge
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
   fvdb-reality-capture-build:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: fvdb-reality-capture Build
@@ -234,7 +236,7 @@ jobs:
   start-benchmarks-gpu-runner:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Start EC2 GPU runner for benchmarks
-    needs: fvdb-reality-capture-build
+    needs: [fvdb-reality-capture-build, versions]
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-tests-gpu-runner.outputs.label }}
@@ -251,10 +253,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-image-id: ami-0f5c0b65fde08ae43
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   ##############################################################################
   # RUN FVDB REALITY CAPTURE UNIT BENCHMARKS
@@ -430,7 +430,7 @@ jobs:
   start-comparative-gpu-runner:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Start EC2 GPU runner for comparative benchmarks
-    needs: fvdb-reality-capture-build
+    needs: [fvdb-reality-capture-build, versions]
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-runner.outputs.label }}
@@ -447,10 +447,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-image-id: ami-0f5c0b65fde08ae43
           ec2-instance-type: g6.xlarge
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   ##############################################################################
   # RUN COMPARATIVE BENCHMARKS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,10 @@ permissions:
   id-token: write
 
 jobs:
+  versions:
+    name: Load versions
+    uses: ./.github/workflows/load-versions.yml
+
   ##############################################################################
   # DETERMINE PUBLISH ROUTING
   ##############################################################################
@@ -383,7 +387,7 @@ jobs:
 
   start-validation-runner:
     name: Start GPU EC2 runner for validation
-    needs: [pr-flags, fvdb-rc-build, discover-fvdb-core]
+    needs: [pr-flags, fvdb-rc-build, discover-fvdb-core, versions]
     if: ${{ !cancelled() && needs.discover-fvdb-core.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
@@ -398,10 +402,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-0f5c0b65fde08ae43
           ec2-instance-type: g6.xlarge
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
     outputs:
       label: ${{ steps.start-validation-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-validation-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,10 @@ permissions:
   id-token: write
 
 jobs:
+  versions:
+    name: Load versions
+    uses: ./.github/workflows/load-versions.yml
+
   # Detect whether the PR touches source files or only docs/non-code paths.
   # The expensive build/test jobs are gated on this so docs-only PRs skip the
   # work while still reporting the required status checks (skipped == passed).
@@ -52,7 +56,7 @@ jobs:
   ##############################################################################
   start-build-runner:
     name: Start CPU-only EC2 runner for build
-    needs: check-changes
+    needs: [check-changes, versions]
     if: needs.check-changes.outputs.should_test == 'true'
     runs-on: ubuntu-latest
     outputs:
@@ -70,10 +74,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-image-id: ami-0e14a711dad782a70
           ec2-instance-type: m6a.8xlarge
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
   fvdb-reality-capture-build:
     name: fvdb-reality-capture Build
     needs: start-build-runner # required to start the main job when the runner is ready
@@ -204,7 +206,7 @@ jobs:
   ##############################################################################
   start-tests-gpu-runner:
     name: Start EC2 GPU runner for tests
-    needs: fvdb-reality-capture-build
+    needs: [fvdb-reality-capture-build, versions]
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-tests-gpu-runner.outputs.label }}
@@ -221,10 +223,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-image-id: ami-0f5c0b65fde08ae43
           ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
-          subnet-id: subnet-03f2320d6e6e0005b
-          security-group-id: sg-0cd08bd89d6212223
+          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
 
   ##############################################################################
   # RUN FVDB REALITY CAPTURE UNIT TESTS


### PR DESCRIPTION
## Problem

Runner provisioning fails whenever the single pinned subnet's AZ is out of capacity, e.g. [this run](https://github.com/openvdb/fvdb-reality-capture/actions/runs/33483320875/job/100041163560):

```
Attempting to start EC2 instance using 1 availability zone configuration(s)
Trying availability zone configuration 1/1
##[warning]Failed to start EC2 instance ... We currently do not have sufficient
g6.xlarge capacity in the Availability Zone you requested (us-east-2b). ... You can
currently get g6.xlarge capacity by ... choosing us-east-2a, us-east-2c.
##[error]All availability zone configurations failed
```

AWS states outright that the other two zones had capacity.

A subnet belongs to exactly one AZ, and **all seven** runner-start sites in this repo pinned `subnet-03f2320d6e6e0005b` (us-east-2b) — so one zone running short takes out GPU CI across `nightly`, `tests`, `gsplat-l4-tests` and `publish` simultaneously.

## Change

`machulav/ec2-github-runner` already supports this: `availability-zones-config` takes a JSON array of `{imageId, subnetId, securityGroupId}` and *"will try each configuration in sequence until a successful instance is launched"*. The "1 availability zone configuration(s)" line above is its fallback when that input isn't supplied.

**fvdb-core already adopted this in openvdb/fvdb-core#705** (@swahtz, merged 2026-07-27). This ports the same approach rather than inventing a second one:

- `.github/versions.json` — mirrors fvdb-core's `aws` block, with all three subnets
- `.github/workflows/load-versions.yml` — reusable workflow exposing `aws-cpu-az-config` / `aws-gpu-az-config`, built with the same `jq` expressions core uses
- All seven start jobs gain `needs: versions` and swap `ec2-image-id`/`subnet-id`/`security-group-id` for the matching config

| Workflow | Sites | Types |
|---|---|---|
| `nightly.yml` | 3 | `m6a.8xlarge`, `g6.xlarge` ×2 |
| `tests.yml` | 2 | `m6a.8xlarge`, `g6.xlarge` |
| `gsplat-l4-tests.yml` | 1 | `g6.xlarge` |
| `publish.yml` | 1 | `g6.xlarge` |

This repo already used the **same AMIs, security group and region** as fvdb-core, so only the two extra subnets are new. AMIs are region- rather than zone-scoped, so they work unchanged across all three zones.

## Testing

CI provisioning can only really be proven by running it, but everything statically checkable was verified:

- `versions.json` parses; the `jq` expressions emit exactly the `imageId`/`subnetId`/`securityGroupId` array the action documents
- All five workflows parse as YAML
- Every start job resolves an az-config, depends on `versions`, and retains **no** stale `ec2-image-id`/`subnet-id`/`security-group-id`
- CPU jobs (`m6a.8xlarge`) map to `aws-cpu-az-config`, GPU jobs (`g6.xlarge`) to `aws-gpu-az-config`

## Note

`versions.json` is intentionally minimal — only the `aws` block this needs, rather than copying fvdb-core's cuda/python/torch/publish-matrix sections. It's a natural home if this repo later wants to centralise those too. **The subnet list must stay in sync with fvdb-core's**; a comment in the file says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)