### PR TITLE
CI: provision EC2 runners through shared workflows, with retry and backoff

### DIFF
--- a/.github/workflows/gsplat-l4-tests.yml
+++ b/.github/workflows/gsplat-l4-tests.yml
@@ -31,24 +31,12 @@ jobs:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Start L4 GPU runner
     needs: versions
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 GPU runner
-        id: start-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-instance-type: g6.xlarge
-          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: g6.xlarge
+      az-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
   gsplat-tests:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
@@ -122,17 +110,9 @@ jobs:
     needs:
       - start-gpu-runner
       - gsplat-tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          label: ${{ needs.start-gpu-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-gpu-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-gpu-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-gpu-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,24 +108,12 @@ jobs:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' && needs.get-fvdb-core-commit-hash.outputs.should_skip != 'true' }}
     name: Start CPU-only EC2 runner for build
     needs: [get-fvdb-core-commit-hash, versions]
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-build-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 runner
-        id: start-build-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-instance-type: m6a.8xlarge
-          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: m6a.8xlarge
+      az-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
   fvdb-reality-capture-build:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: fvdb-reality-capture Build
@@ -213,21 +201,12 @@ jobs:
     needs:
       - start-build-runner # required to get output from the start-build-runner job
       - fvdb-reality-capture-build # required to wait when the main job is done
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          label: ${{ needs.start-build-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-build-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
 
   ##############################################################################
@@ -237,24 +216,12 @@ jobs:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Start EC2 GPU runner for benchmarks
     needs: [fvdb-reality-capture-build, versions]
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-tests-gpu-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 GPU runner
-        id: start-tests-gpu-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
-          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+      az-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
   ##############################################################################
   # RUN FVDB REALITY CAPTURE UNIT BENCHMARKS
@@ -409,20 +376,12 @@ jobs:
     needs:
       - start-benchmarks-gpu-runner
       - fvdb-reality-capture-unit-benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          label: ${{ needs.start-benchmarks-gpu-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-benchmarks-gpu-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-benchmarks-gpu-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-benchmarks-gpu-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
   ##############################################################################
   # START COMPARATIVE BENCHMARKS GPU RUNNER
@@ -431,24 +390,12 @@ jobs:
     if: ${{ github.repository == 'openvdb/fvdb-reality-capture' }}
     name: Start EC2 GPU runner for comparative benchmarks
     needs: [fvdb-reality-capture-build, versions]
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 GPU runner
-        id: start-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-instance-type: g6.xlarge
-          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+      az-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
   ##############################################################################
   # RUN COMPARATIVE BENCHMARKS
@@ -613,17 +560,9 @@ jobs:
     needs:
       - start-comparative-gpu-runner
       - fvdb-reality-capture-comparative-benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          label: ${{ needs.start-comparative-gpu-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-comparative-gpu-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-comparative-gpu-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-comparative-gpu-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -389,24 +389,12 @@ jobs:
     name: Start GPU EC2 runner for validation
     needs: [pr-flags, fvdb-rc-build, discover-fvdb-core, versions]
     if: ${{ !cancelled() && needs.discover-fvdb-core.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 GPU runner
-        id: start-validation-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-instance-type: g6.xlarge
-          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
-    outputs:
-      label: ${{ steps.start-validation-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-validation-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: g6.xlarge
+      az-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
   validate-smoke-test:
     name: Smoke test fvdb-core + fvdb-reality-capture
@@ -539,18 +527,10 @@ jobs:
       - start-validation-runner
       - validate-smoke-test
       - validate-unit-tests
-    runs-on: ubuntu-latest
     if: ${{ always() && needs.start-validation-runner.result != 'skipped' }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-validation-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-validation-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-validation-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-validation-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/start-ec2-runner.yml
+++ b/.github/workflows/start-ec2-runner.yml
@@ -1,0 +1,129 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start a self-hosted EC2 runner, retrying with backoff when the region has no
+# capacity for the requested instance type.
+#
+# Every workflow that needs an EC2 runner calls this instead of inlining the
+# machulav action, so the retry policy (attempt count, backoff, the AZ sweep,
+# the action version, the IAM role) lives in exactly one place and cannot drift
+# between tests.yml, nightly.yml, publish.yml and gsplat-l4-tests.yml.
+name: Start EC2 Runner
+
+on:
+  workflow_call:
+    inputs:
+      instance-type:
+        description: EC2 instance type to launch, e.g. m6a.8xlarge or g6.xlarge.
+        type: string
+        required: true
+      az-config:
+        description: >-
+          JSON array of availability-zone configs, tried in order by the action
+          within a single attempt. Usually needs.versions.outputs.aws-*-az-config.
+        type: string
+        required: true
+      aws-role:
+        description: IAM role to assume via OIDC.
+        type: string
+        required: false
+        default: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
+      aws-region:
+        description: AWS region to launch in.
+        type: string
+        required: false
+        default: us-east-2
+      backoff-seconds:
+        description: >-
+          Seconds to wait after the first failed attempt. The second wait is
+          twice this, so the default gives 90s then 180s between three attempts.
+        type: number
+        required: false
+        default: 90
+    secrets:
+      RUNNER_TOKEN:
+        description: Token used to register the runner with this repository.
+        required: true
+    outputs:
+      label:
+        description: Runner label to pass as `runs-on` in the job being provisioned.
+        value: ${{ jobs.start.outputs.label }}
+      ec2-instance-id:
+        description: Instance id, to be handed back to stop-ec2-runner.yml.
+        value: ${{ jobs.start.outputs.ec2-instance-id }}
+
+permissions:
+  contents: read
+  id-token: write # Need ID token write permission to use OIDC
+
+jobs:
+  start:
+    name: Start EC2 runner
+    runs-on: ubuntu-latest
+    # Exactly one attempt can succeed: each is skipped unless every earlier one
+    # failed, so at most one of these outputs is non-empty and `||` picks it.
+    outputs:
+      label: ${{ steps.a1.outputs.label || steps.a2.outputs.label || steps.a3.outputs.label }}
+      ec2-instance-id: ${{ steps.a1.outputs.ec2-instance-id || steps.a2.outputs.ec2-instance-id || steps.a3.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Start EC2 runner (attempt 1)
+        id: a1
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: start
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          ec2-instance-type: ${{ inputs.instance-type }}
+          availability-zones-config: ${{ inputs.az-config }}
+
+      - name: Back off before attempt 2
+        if: steps.a1.outcome == 'failure'
+        env:
+          BACKOFF: ${{ inputs.backoff-seconds }}
+        run: |
+          echo "::warning::Runner start attempt 1 found no capacity; retrying in ${BACKOFF}s."
+          sleep "${BACKOFF}"
+
+      - name: Start EC2 runner (attempt 2)
+        id: a2
+        if: steps.a1.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: start
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          ec2-instance-type: ${{ inputs.instance-type }}
+          availability-zones-config: ${{ inputs.az-config }}
+
+      - name: Back off before attempt 3
+        if: steps.a1.outcome == 'failure' && steps.a2.outcome == 'failure'
+        env:
+          BACKOFF: ${{ inputs.backoff-seconds }}
+        run: |
+          echo "::warning::Runner start attempt 2 found no capacity; retrying in $((BACKOFF * 2))s."
+          sleep "$((BACKOFF * 2))"
+
+      - name: Start EC2 runner (attempt 3)
+        id: a3
+        if: steps.a1.outcome == 'failure' && steps.a2.outcome == 'failure'
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: start
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          ec2-instance-type: ${{ inputs.instance-type }}
+          availability-zones-config: ${{ inputs.az-config }}
+
+      - name: Fail if no attempt obtained capacity
+        if: steps.a1.outcome == 'failure' && steps.a2.outcome == 'failure' && steps.a3.outcome == 'failure'
+        env:
+          INSTANCE_TYPE: ${{ inputs.instance-type }}
+        run: |
+          echo "::error::Could not obtain a ${INSTANCE_TYPE} instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+          exit 1

--- a/.github/workflows/stop-ec2-runner.yml
+++ b/.github/workflows/stop-ec2-runner.yml
@@ -1,0 +1,57 @@
+# Copyright Contributors to the OpenVDB Project
+# SPDX-License-Identifier: Apache-2.0
+#
+# De-register and terminate a self-hosted EC2 runner started by
+# start-ec2-runner.yml. Callers keep their own `needs:` and
+# `if: always() && needs.<start-job>.result != 'skipped'` guards; this workflow
+# is only the teardown itself.
+name: Stop EC2 Runner
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: Runner label emitted by start-ec2-runner.yml.
+        type: string
+        required: true
+      ec2-instance-id:
+        description: Instance id emitted by start-ec2-runner.yml.
+        type: string
+        required: true
+      aws-role:
+        description: IAM role to assume via OIDC.
+        type: string
+        required: false
+        default: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
+      aws-region:
+        description: AWS region the instance is running in.
+        type: string
+        required: false
+        default: us-east-2
+    secrets:
+      RUNNER_TOKEN:
+        description: Token used to de-register the runner.
+        required: true
+
+permissions:
+  contents: read
+  id-token: write # Need ID token write permission to use OIDC
+
+jobs:
+  stop:
+    name: Stop EC2 runner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: stop
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          label: ${{ inputs.label }}
+          ec2-instance-id: ${{ inputs.ec2-instance-id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,24 +58,12 @@ jobs:
     name: Start CPU-only EC2 runner for build
     needs: [check-changes, versions]
     if: needs.check-changes.outputs.should_test == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-build-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-build-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 runner
-        id: start-build-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-instance-type: m6a.8xlarge
-          availability-zones-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: m6a.8xlarge
+      az-config: ${{ needs.versions.outputs.aws-cpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
   fvdb-reality-capture-build:
     name: fvdb-reality-capture Build
     needs: start-build-runner # required to start the main job when the runner is ready
@@ -183,22 +171,14 @@ jobs:
     needs:
       - start-build-runner # required to get output from the start-build-runner job
       - fvdb-reality-capture-build # required to wait when the main job is done
-    runs-on: ubuntu-latest
     # Don't try to stop a runner that was never started (docs-only PRs skip start-build-runner).
     if: ${{ always() && needs.start-build-runner.result != 'skipped' }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          label: ${{ needs.start-build-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-build-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
 
   ##############################################################################
@@ -207,24 +187,12 @@ jobs:
   start-tests-gpu-runner:
     name: Start EC2 GPU runner for tests
     needs: [fvdb-reality-capture-build, versions]
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-tests-gpu-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-tests-gpu-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Start EC2 GPU runner
-        id: start-tests-gpu-runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: start
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          ec2-instance-type: g6.xlarge # 4 CPU-core, L4 GPU
-          availability-zones-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    uses: ./.github/workflows/start-ec2-runner.yml
+    with:
+      instance-type: g6.xlarge # 4 CPU-core, L4 GPU
+      az-config: ${{ needs.versions.outputs.aws-gpu-az-config }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}
 
   ##############################################################################
   # RUN FVDB REALITY CAPTURE UNIT TESTS
@@ -363,20 +331,11 @@ jobs:
     needs:
       - start-tests-gpu-runner # required to get output from the start-tests-gpu-runner job
       - fvdb-reality-capture-unit-tests # required to wait when the main job is done
-      #- fvdb-reality-capture-docs-test # required to wait when the main job is done
-    runs-on: ubuntu-latest
     # Don't try to stop a runner that was never started (docs-only PRs skip start-tests-gpu-runner).
     if: ${{ always() && needs.start-tests-gpu-runner.result != 'skipped' }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::420032683002:role/openvdb-fvdb-github-actions-role
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.4.3
-        with:
-          mode: stop
-          github-token: ${{ secrets.EC2_RUNNERS_ACTION }}
-          label: ${{ needs.start-tests-gpu-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-tests-gpu-runner.outputs.ec2-instance-id }}
+    uses: ./.github/workflows/stop-ec2-runner.yml
+    with:
+      label: ${{ needs.start-tests-gpu-runner.outputs.label }}
+      ec2-instance-id: ${{ needs.start-tests-gpu-runner.outputs.ec2-instance-id }}
+    secrets:
+      RUNNER_TOKEN: ${{ secrets.EC2_RUNNERS_ACTION }}


### PR DESCRIPTION
## Summary

Replaces #327. CI keeps failing because us-east-2 has no capacity for the requested instance type at the moment the runner is requested. `machulav/ec2-github-runner` sweeps the availability zones in `availability-zones-config` within one attempt (#326), but it never retries the sweep, so a transient region-wide shortage fails the whole run. Retrying twice, 90s and then 180s later, turns most of those into a slow pass instead of a red build.

#327 inlined that retry ladder at every call site — ~30 lines of near-identical YAML in six places that can drift independently. This replaces it: the ladder goes in a reusable workflow instead.

## What changed

Two new local reusable workflows hold the retry policy, the action version, the AWS OIDC step, the IAM role ARN and the teardown:

* `.github/workflows/start-ec2-runner.yml`
* `.github/workflows/stop-ec2-runner.yml`

`tests.yml`, `nightly.yml`, `publish.yml` and `gsplat-l4-tests.yml` now call them — six start jobs and six stop jobs. **226 lines of duplicated YAML removed, 84 added.**

Two things that were duplicated and are now single-sourced:

* The IAM role ARN and `us-east-2` were repeated verbatim at all twelve call sites. They are now defaults on the reusable workflows, so a call site only names them if it differs.
* The token forwards explicitly as `RUNNER_TOKEN`. That deliberately preserves the two secrets already in use — `EC2_RUNNERS_ACTION` for tests/nightly/gsplat, `GH_PERSONAL_ACCESS_TOKEN` for publish — at their existing call sites rather than quietly consolidating them. Worth a follow-up decision, but not smuggled into this PR.

## Testing

* `actionlint` 1.7.7: clean.
* Parsed every reusable-workflow caller job to confirm none carries a key incompatible with `uses:` (`runs-on`, `steps`, `env`, `container`, …), and that no dangling `steps.*` references remain.

The equivalent change for fvdb-core is openvdb/fvdb-core#760.

Because these workflows only run on the real EC2 fleet, the first genuine exercise of the new provisioning path is the run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
