### PR TITLE
CI: pick the winning runner attempt by outcome, and clean up the losers

### DIFF
--- a/.github/workflows/start-ec2-runner.yml
+++ b/.github/workflows/start-ec2-runner.yml
@@ -60,11 +60,11 @@ jobs:
   start:
     name: Start EC2 runner
     runs-on: ubuntu-latest
-    # Exactly one attempt can succeed: each is skipped unless every earlier one
-    # failed, so at most one of these outputs is non-empty and `||` picks it.
+    # Taken from the attempt that actually SUCCEEDED -- see the select step
+    # below for why "first non-empty" is not the same thing.
     outputs:
-      label: ${{ steps.a1.outputs.label || steps.a2.outputs.label || steps.a3.outputs.label }}
-      ec2-instance-id: ${{ steps.a1.outputs.ec2-instance-id || steps.a2.outputs.ec2-instance-id || steps.a3.outputs.ec2-instance-id }}
+      label: ${{ steps.select.outputs.label }}
+      ec2-instance-id: ${{ steps.select.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -81,6 +81,19 @@ jobs:
           github-token: ${{ secrets.RUNNER_TOKEN }}
           ec2-instance-type: ${{ inputs.instance-type }}
           availability-zones-config: ${{ inputs.az-config }}
+
+      # The action publishes its outputs as soon as the instance launches, i.e.
+      # BEFORE it waits for the runner to register. So a failed attempt can still
+      # have left an instance running -- terminate it rather than leak it.
+      - name: Clean up the instance left behind by attempt 1
+        if: steps.a1.outcome == 'failure' && steps.a1.outputs.ec2-instance-id != ''
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: stop
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          label: ${{ steps.a1.outputs.label }}
+          ec2-instance-id: ${{ steps.a1.outputs.ec2-instance-id }}
 
       - name: Back off before attempt 2
         if: steps.a1.outcome == 'failure'
@@ -101,6 +114,19 @@ jobs:
           ec2-instance-type: ${{ inputs.instance-type }}
           availability-zones-config: ${{ inputs.az-config }}
 
+      # The action publishes its outputs as soon as the instance launches, i.e.
+      # BEFORE it waits for the runner to register. So a failed attempt can still
+      # have left an instance running -- terminate it rather than leak it.
+      - name: Clean up the instance left behind by attempt 2
+        if: steps.a2.outcome == 'failure' && steps.a2.outputs.ec2-instance-id != ''
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: stop
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          label: ${{ steps.a2.outputs.label }}
+          ec2-instance-id: ${{ steps.a2.outputs.ec2-instance-id }}
+
       - name: Back off before attempt 3
         if: steps.a1.outcome == 'failure' && steps.a2.outcome == 'failure'
         env:
@@ -120,10 +146,49 @@ jobs:
           ec2-instance-type: ${{ inputs.instance-type }}
           availability-zones-config: ${{ inputs.az-config }}
 
-      - name: Fail if no attempt obtained capacity
-        if: steps.a1.outcome == 'failure' && steps.a2.outcome == 'failure' && steps.a3.outcome == 'failure'
+      # The action publishes its outputs as soon as the instance launches, i.e.
+      # BEFORE it waits for the runner to register. So a failed attempt can still
+      # have left an instance running -- terminate it rather than leak it.
+      - name: Clean up the instance left behind by attempt 3
+        if: steps.a3.outcome == 'failure' && steps.a3.outputs.ec2-instance-id != ''
+        continue-on-error: true
+        uses: machulav/ec2-github-runner@v2.4.3
+        with:
+          mode: stop
+          github-token: ${{ secrets.RUNNER_TOKEN }}
+          label: ${{ steps.a3.outputs.label }}
+          ec2-instance-id: ${{ steps.a3.outputs.ec2-instance-id }}
+
+      # Pick the outputs of the attempt that succeeded. This must key on the
+      # step OUTCOME, not on which output is non-empty: an attempt whose
+      # instance launched but never registered a runner fails with its outputs
+      # already populated, so "first non-empty" would hand back a dead label --
+      # the dependent job would then queue against a runner that never appears
+      # instead of failing fast.
+      - name: Select the successful attempt
+        id: select
         env:
           INSTANCE_TYPE: ${{ inputs.instance-type }}
+          A1_OUTCOME: ${{ steps.a1.outcome }}
+          A1_LABEL: ${{ steps.a1.outputs.label }}
+          A1_ID: ${{ steps.a1.outputs.ec2-instance-id }}
+          A2_OUTCOME: ${{ steps.a2.outcome }}
+          A2_LABEL: ${{ steps.a2.outputs.label }}
+          A2_ID: ${{ steps.a2.outputs.ec2-instance-id }}
+          A3_OUTCOME: ${{ steps.a3.outcome }}
+          A3_LABEL: ${{ steps.a3.outputs.label }}
+          A3_ID: ${{ steps.a3.outputs.ec2-instance-id }}
         run: |
-          echo "::error::Could not obtain a ${INSTANCE_TYPE} instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
-          exit 1
+          if [ "${A1_OUTCOME}" = "success" ]; then
+            LABEL="${A1_LABEL}"; ID="${A1_ID}"; WON=1
+          elif [ "${A2_OUTCOME}" = "success" ]; then
+            LABEL="${A2_LABEL}"; ID="${A2_ID}"; WON=2
+          elif [ "${A3_OUTCOME}" = "success" ]; then
+            LABEL="${A3_LABEL}"; ID="${A3_ID}"; WON=3
+          else
+            echo "::error::Could not obtain a ${INSTANCE_TYPE} instance after 3 attempts across every configured availability zone; the region is likely out of this instance type."
+            exit 1
+          fi
+          echo "Runner provisioned on attempt ${WON}: ${LABEL} (${ID})"
+          echo "label=${LABEL}" >> "$GITHUB_OUTPUT"
+          echo "ec2-instance-id=${ID}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Follow-up to #329. The retry ladder it shipped handles only one of the two ways a runner start can fail, and picks its outputs in a way that is wrong in the other. Nothing has hit this yet — every start since #329 merged has succeeded on attempt 1, so the backoff path has never actually executed — so this corrects the fault before it can bite rather than after.

## The bug

`machulav/ec2-github-runner` publishes its outputs as soon as the instance launches, **before** it waits for the runner to register ([`src/index.js`](https://github.com/machulav/ec2-github-runner/blob/v2.4.3/src/index.js)):

```js
const result = await aws.startEc2Instance(label, ...);
setOutput(label, ec2InstanceId, region);                 // <-- here
await aws.waitForInstanceRunning(ec2InstanceId, region); // can throw
await gh.waitForRunnerRegistered(label, pollCallback);   // 5-min timeout, throws
```

That gives two distinct failure classes:

| | Outputs after failure |
|---|---|
| **No capacity** — throws in `startEc2Instance` | empty |
| **Launched but never registered** — registration timeout, bad AMI, userdata failure | **populated** |

#329 selected outputs with `${{ steps.a1.outputs.label \|\| steps.a2.outputs.label \|\| ... }}`, which takes the first *non-empty* value rather than the *successful* one. Those coincide in the first class and diverge in the second, where the ladder would hand back the **dead** attempt's label and instance id:

1. The dependent job's `runs-on:` gets a label whose runner never registered, so it **queues until timeout instead of failing fast** — a red build becomes a hung one.
2. Teardown gets the dead attempt's instance id, so the instance the retry actually provisioned **leaks**, billing until someone notices.

## The fix

* **Select on `outcome`, not emptiness**, in an explicit step that also raises the terminal error when no attempt succeeded. Keying on the outcome is what makes "the attempt that worked" and "the first attempt with an output" the same thing again.
* **Stop the instance a failed attempt left running, before retrying.** Needed even with correct selection: nothing else knows those instances exist, because only the winner ever reaches the stop job. Uses the action's own `mode: stop` (terminates *and* de-registers) with `continue-on-error: true`, since de-registration legitimately fails for a runner that never registered.

## Testing

Exercised the selection logic against all five outcome combinations:

| scenario | old result | new result |
|---|---|---|
| a1 succeeds | a1 ✓ | a1 ✓ |
| a1 no capacity, a2 wins | a2 ✓ | a2 ✓ |
| **a1 launched but unregistered, a2 wins** | **a1 ✗ (dead label)** | **a2 ✓** |
| a1+a2 unregistered, a3 wins | a1 ✗ | a3 ✓ |
| all three fail | error ✓ | error ✓ |

`actionlint` clean. The equivalent fix for fvdb-core is openvdb/fvdb-core#760, which has not merged yet, so it carries the correction rather than needing a follow-up.

Note this was not introduced by the reusable-workflow refactor — the inline version in #327 had the same `||` chain. The refactor is why the fix is one file rather than six call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
