### PR TITLE
Fix misattributed contributors when sparse rendering duplicate pixels

### DIFF
--- a/fvdb_reality_capture/radiance_fields/gaussian_splatting.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splatting.py
@@ -4248,9 +4248,61 @@ class GaussianSplat3d:
         ids_jt = JaggedTensor(impl=ids)
         weights_jt = JaggedTensor(impl=weights)
         if has_dups:
-            ids_jt = pixels_jt.jagged_like(ids_jt.jdata.index_select(0, inverse_indices))
-            weights_jt = pixels_jt.jagged_like(weights_jt.jdata.index_select(0, inverse_indices))
+            # `ids`/`weights` are CONTRIBUTION-major: one row per (pixel, contributor),
+            # with each pixel owning a variable-length segment. They therefore cannot be
+            # indexed by pixel the way a per-pixel result can (see sparse_render, which
+            # does exactly that on a one-row-per-pixel array and is correct). A duplicated
+            # pixel needs a copy of its unique pixel's whole segment.
+            #
+            # Both tensors share the same jagged structure, so the index arithmetic is
+            # computed once and applied to each payload.
+            plan = self._contribution_expansion_plan(ids_jt, pixels_jt, inverse_indices)
+            ids_jt = self._apply_contribution_expansion(plan, ids_jt)
+            weights_jt = self._apply_contribution_expansion(plan, weights_jt)
         return ids_jt, weights_jt
+
+    @staticmethod
+    def _contribution_expansion_plan(
+        unique_jt: JaggedTensor,
+        pixels_jt: JaggedTensor,
+        inverse_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Index arithmetic for re-expanding a per-(pixel, contributor) result.
+
+        Maps the deduplicated pixel list back onto the caller's pixel list by repeating
+        each unique pixel's whole contribution segment. Depends only on the jagged
+        structure, not on the payload, so callers with several equally-shaped tensors
+        (ids and weights) build one plan and apply it to each.
+
+        Returns ``(gather, offsets, list_ids)`` for
+        :meth:`JaggedTensor.from_data_offsets_and_list_ids`.
+        """
+        device = unique_jt.jdata.device
+        offsets_unique = unique_jt.joffsets.to(device)
+        starts = offsets_unique[inverse_indices]  # segment start per output pixel
+        counts = offsets_unique[1:][inverse_indices] - starts  # segment length per output pixel
+
+        offsets = torch.zeros(counts.numel() + 1, dtype=torch.long, device=device)
+        offsets[1:] = counts.cumsum(0)
+
+        segment = torch.repeat_interleave(torch.arange(counts.numel(), device=device), counts)
+        within = torch.arange(int(offsets[-1]), device=device) - offsets[segment]
+        gather = starts[segment] + within
+
+        # Rebuild (camera, pixel-within-camera) ids from the ORIGINAL pixel list.
+        camera = pixels_jt.jidx.to(device).long()
+        within_camera = torch.arange(camera.numel(), device=device) - pixels_jt.joffsets.to(device)[camera]
+        list_ids = torch.stack([camera, within_camera], dim=1).to(torch.int32)
+        return gather, offsets, list_ids
+
+    @staticmethod
+    def _apply_contribution_expansion(
+        plan: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        jt: JaggedTensor,
+    ) -> JaggedTensor:
+        """Apply a plan from :meth:`_contribution_expansion_plan` to one payload."""
+        gather, offsets, list_ids = plan
+        return JaggedTensor.from_data_offsets_and_list_ids(jt.jdata.index_select(0, gather), offsets, list_ids)
 
     def relocate_gaussians(
         self,

--- a/tests/unit/test_gaussian_splat_3d.py
+++ b/tests/unit/test_gaussian_splat_3d.py
@@ -3953,6 +3953,88 @@ class TestGaussianRenderSparseDuplicatePixels(BaseGaussianTestCase):
             "Sparse alphas with duplicates does not match dense",
         )
 
+    def test_sparse_render_contributing_gaussian_ids_with_duplicates(self):
+        """A duplicated pixel must get a copy of its own contributor list.
+
+        Regression test: the re-expansion used to index a CONTRIBUTION-major array
+        with pixel indices, which handed pixels contributors belonging to other
+        pixels, and collapsed the result from a 2-level to a 1-level JaggedTensor.
+        """
+        pixels, _, _ = self._make_pixels_with_duplicates(num_unique=40, num_extra_dupes=10)
+        top_k = 8
+
+        def render(px):
+            return self.gs3d.sparse_render_contributing_gaussian_ids(
+                JaggedTensor([px]).to(self.device),
+                self.cam_to_world_mats[0:1],
+                self.projection_mats[0:1],
+                self.width,
+                self.height,
+                self.near_plane,
+                self.far_plane,
+                top_k_contributors=top_k,
+            )
+
+        ids, weights = render(pixels)
+
+        # Nesting must not depend on whether duplicates were present: one inner
+        # list per requested pixel, in the order they were requested.
+        self.assertEqual(ids.ldim, 2)
+        self.assertEqual(weights.ldim, 2)
+        self.assertEqual(len(ids.lshape[0]), pixels.size(0))
+
+        # Each pixel's contributor segment must equal that pixel rendered alone,
+        # including for both copies of a duplicated pixel.
+        offsets = ids.joffsets.cpu().tolist()
+        alone: dict[tuple[int, int], torch.Tensor] = {}
+        for i in range(pixels.size(0)):
+            key = (int(pixels[i, 0]), int(pixels[i, 1]))
+            if key not in alone:
+                alone[key] = render(pixels[i : i + 1])[0].jdata.flatten()
+            segment = ids.jdata.flatten()[offsets[i] : offsets[i + 1]]
+            self.assertTrue(
+                torch.equal(segment, alone[key]),
+                f"pixel {key} got contributors {segment.tolist()} " f"but renders {alone[key].tolist()} on its own",
+            )
+
+    def test_sparse_render_contributing_gaussian_ids_duplicates_match_unique(self):
+        """Rendering [a, b, a] must agree with rendering [a, b] on a and b."""
+        pixels, _, _ = self._make_pixels_with_duplicates(num_unique=20, num_extra_dupes=5)
+        unique_pixels = torch.unique(pixels, dim=0)
+
+        def render(px):
+            return self.gs3d.sparse_render_contributing_gaussian_ids(
+                JaggedTensor([px]).to(self.device),
+                self.cam_to_world_mats[0:1],
+                self.projection_mats[0:1],
+                self.width,
+                self.height,
+                self.near_plane,
+                self.far_plane,
+                top_k_contributors=8,
+            )
+
+        dup_ids, dup_weights = render(pixels)
+        uniq_ids, uniq_weights = render(unique_pixels)
+
+        dup_offsets = dup_ids.joffsets.cpu().tolist()
+        uniq_offsets = uniq_ids.joffsets.cpu().tolist()
+        index_of = {(int(r), int(c)): i for i, (r, c) in enumerate(unique_pixels.tolist())}
+        for i in range(pixels.size(0)):
+            j = index_of[(int(pixels[i, 0]), int(pixels[i, 1]))]
+            self.assertTrue(
+                torch.equal(
+                    dup_ids.jdata.flatten()[dup_offsets[i] : dup_offsets[i + 1]],
+                    uniq_ids.jdata.flatten()[uniq_offsets[j] : uniq_offsets[j + 1]],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    dup_weights.jdata.flatten()[dup_offsets[i] : dup_offsets[i + 1]],
+                    uniq_weights.jdata.flatten()[uniq_offsets[j] : uniq_offsets[j + 1]],
+                )
+            )
+
     def test_sparse_render_images_with_duplicates(self):
         pixels, y_all, x_all = self._make_pixels_with_duplicates()
         pixels_to_render = JaggedTensor([pixels]).to(self.device)
@@ -4098,18 +4180,38 @@ class TestGaussianRenderSparseDuplicatePixels(BaseGaussianTestCase):
             self.far_plane,
         )
 
-        self.assertEqual(ids.jdata.size(0), pixels.size(0))
+        # One inner list per requested pixel. NOTE: this used to assert
+        # `ids.jdata.size(0) == pixels.size(0)`, i.e. one ROW per pixel, which
+        # described the old collapsed-and-misattributed output rather than the
+        # intended contract -- `jdata` is contribution-major, so its length is the
+        # total number of contributors, not the number of pixels.
+        self.assertEqual(ids.ldim, 2)
+        self.assertEqual(len(ids.lshape[0]), pixels.size(0))
+        self.assertEqual(len(weights.lshape[0]), pixels.size(0))
 
-        coords = pixels.to(self.device)
-        keys = coords[:, 0] * self.width + coords[:, 1]
-        unique_keys, inverse = keys.unique(return_inverse=True)
-        for i in range(unique_keys.size(0)):
-            mask = inverse == i
-            id_vals = ids.jdata[mask]
-            weight_vals = weights.jdata[mask]
-            self.assertTrue(torch.all(id_vals == id_vals[0:1]), "Duplicate pixels have different contributing IDs")
+        # Duplicated pixels must have identical contributor SEGMENTS. Comparing
+        # single rows would pass even when every pixel got another pixel's data.
+        offsets = ids.joffsets.cpu().tolist()
+        keys = (pixels[:, 0] * self.width + pixels[:, 1]).tolist()
+        first_seen: dict[int, int] = {}
+        for i, key in enumerate(keys):
+            j = first_seen.setdefault(key, i)
+            if j == i:
+                continue
             self.assertTrue(
-                torch.allclose(weight_vals, weight_vals[0:1], atol=1e-6, rtol=1e-8),
+                torch.equal(
+                    ids.jdata.flatten()[offsets[i] : offsets[i + 1]],
+                    ids.jdata.flatten()[offsets[j] : offsets[j + 1]],
+                ),
+                "Duplicate pixels have different contributing IDs",
+            )
+            self.assertTrue(
+                torch.allclose(
+                    weights.jdata.flatten()[offsets[i] : offsets[i + 1]],
+                    weights.jdata.flatten()[offsets[j] : offsets[j + 1]],
+                    atol=1e-6,
+                    rtol=1e-8,
+                ),
                 "Duplicate pixels have different contributing weights",
             )
 


### PR DESCRIPTION
Fixes #328.

## The bug

`sparse_render_contributing_gaussian_ids` re-expanded its deduplicated result with

```python
ids_jt = pixels_jt.jagged_like(ids_jt.jdata.index_select(0, inverse_indices))
```

but `ids_jt.jdata` is **contribution-major** — one row per *(pixel, contributor)*, with each pixel owning a variable-length segment. `inverse_indices` is **pixel-indexed**. So this indexes a contribution array using pixel indices: row *k* is the *k*-th contributor overall, which for small *k* belongs to the first unique pixel. Pixels are handed contributors that belong to **other pixels**.

Verified against per-pixel ground truth (each pixel also rendered alone, `top_k=24`):

```
pixel (32,32) -> id 325 | belongs to this pixel? YES at contributor #1
pixel (30,30) -> id   0 | belongs to this pixel? YES at contributor #0
pixel (34,34) -> id 362 | belongs to this pixel? YES at contributor #1
pixel (31,33) -> id  44 | belongs to this pixel? NO   <-- belongs only to (30,30)
pixel (32,32) -> id 325 | belongs to this pixel? YES at contributor #1
```

Rows that look plausible do so only because the gaussians overlap heavily; that is coincidence, not correctness. The result also collapses from a 2-level to a 1-level `JaggedTensor`, so consumers cannot reduce per pixel either — which is what surfaced this, via GARfVDB (#308), where a single duplicated pixel silently changes the code path for a whole 4096-sample batch.

Two neighbouring sites that look identical are **correct and left alone**: `sparse_render` (`:2005`) and `sparse_rasterize_num_contributing_gaussians` (`:3936`) both index arrays that genuinely are one row per pixel.

## The fix

Repeat each unique pixel's whole contribution **segment** rather than a single row.

The index arithmetic depends only on the jagged structure — and `ids` and `weights` share it exactly (verified: identical `joffsets`, `ldim`, `lshape`) — so it is computed once as a plan and applied to each payload:

| | 4096 samples, 41278 contributor rows |
|---|---|
| expand twice, recomputing indices | 0.551 ms |
| **plan once + apply twice** | **0.232 ms (58% faster)** |

Output is bit-identical between the two.

## The existing test asserted the bug

`test_sparse_render_contributing_ids_with_duplicates` required

```python
self.assertEqual(ids.jdata.size(0), pixels.size(0))
```

— the collapsed shape — and then only checked that duplicated pixels agreed **with each other**, which two copies of a wrong answer satisfy. It was self-consistent and vacuous on correctness, which is why this survived. Corrected to compare contributor *segments*, and joined by two tests that check against ground truth:

* each pixel's segment vs that pixel rendered alone;
* the deduplicated path vs a render of the unique set.

All three fail on `main` and pass here. Full `test_gaussian_splat_3d.py`: **159 passed**.

## Related

The gsplat port in #325 changes the underlying representation to padded pixel-major, which makes its `index_select` correct by accident — but it keeps the collapsed 1-level return shape and an explicit comment calling it "the established duplicate-pixel API". Commented there separately; that special case can simply be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
