### PR TITLE
Route unscented-transform projection through a torch.autograd.Function

### DIFF
--- a/fvdb_reality_capture/radiance_fields/_gaussian_autograd.py
+++ b/fvdb_reality_capture/radiance_fields/_gaussian_autograd.py
@@ -157,6 +157,138 @@ class _ProjectGaussiansFn(torch.autograd.Function):
 
 
 # ---------------------------------------------------------------------------
+#  Projection (unscented transform / distorted cameras)
+# ---------------------------------------------------------------------------
+
+
+class _ProjectGaussiansUnscentedFn(torch.autograd.Function):
+    """Python autograd wrapper for the unscented-transform Gaussian projection forward/backward.
+
+    Companion to `_ProjectGaussiansFn` above, for camera models that require distortion handling
+    (every COLMAP camera model except SIMPLE_PINHOLE/PINHOLE). Before `_C.project_gaussians_
+    unscented_bwd` existed, `_do_projection`'s UT branch called `_C.project_gaussians_
+    unscented_fwd` directly instead of through a `torch.autograd.Function`, so it was
+    structurally disconnected from the autograd graph -- the photometric/image loss produced
+    zero gradient on `means`/`quats`/`log_scales` for any such scene. See
+    `ProjectGaussiansUnscentedBackward.h` (fvdb-core) for the derivation and its scope.
+
+    Scope (matching the CUDA kernel): only `DistortionModel.OPENCV_RADTAN_5` (COLMAP's
+    SIMPLE_RADIAL/RADIAL/OPENCV) is supported, `calc_compensations` (antialiasing) is not yet
+    supported, and there is no gradient w.r.t. `world_to_cam` (camera-pose optimization) or
+    `distortion_coeffs` (calibration is not optimized by any current caller) on this path yet.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        means: torch.Tensor,
+        quats: torch.Tensor,
+        log_scales: torch.Tensor,
+        world_to_cam: torch.Tensor,
+        projection_matrices: torch.Tensor,
+        distortion_coeffs: torch.Tensor,
+        camera_model,
+        image_width: int,
+        image_height: int,
+        eps2d: float,
+        near: float,
+        far: float,
+        min_radius_2d: float,
+        calc_compensations: bool,
+    ):
+        if calc_compensations:
+            raise NotImplementedError(
+                "Antialiasing (calc_compensations=True) is not yet supported by the "
+                "differentiable unscented-transform projection backward."
+            )
+        if int(camera_model) != int(_C.CameraModel.OPENCV_RADTAN_5):
+            raise NotImplementedError(
+                f"The differentiable unscented-transform projection backward currently only "
+                f"supports DistortionModel.OPENCV_RADTAN_5 (COLMAP's SIMPLE_RADIAL/RADIAL/OPENCV "
+                f"camera models); got {camera_model!r}. OPENCV_RATIONAL_8 and the "
+                f"*_THIN_PRISM_* variants are not yet implemented."
+            )
+
+        result = _C.project_gaussians_unscented_fwd(
+            means,
+            quats,
+            log_scales,
+            world_to_cam,
+            world_to_cam,
+            projection_matrices,
+            distortion_coeffs,
+            camera_model,
+            image_width,
+            image_height,
+            eps2d,
+            near,
+            far,
+            min_radius_2d,
+            False,
+        )
+        radii: torch.Tensor = result[0]
+        means2d: torch.Tensor = result[1]
+        depths: torch.Tensor = result[2]
+        conics: torch.Tensor = result[3]
+
+        ctx.save_for_backward(means, quats, log_scales, world_to_cam, projection_matrices, distortion_coeffs, radii, conics)
+        ctx.camera_model = camera_model
+        ctx.image_width = image_width
+        ctx.image_height = image_height
+        ctx.eps2d = eps2d
+
+        return radii, means2d, depths, conics, None
+
+    @staticmethod
+    def backward(ctx: Any, *grad_outputs: torch.Tensor | None) -> tuple[torch.Tensor | None, ...]:
+        grad_means2d = grad_outputs[1]
+        grad_depths = grad_outputs[2]
+        grad_conics = grad_outputs[3]
+        assert grad_means2d is not None
+        assert grad_depths is not None
+        assert grad_conics is not None
+
+        means, quats, log_scales, world_to_cam, projection_matrices, distortion_coeffs, radii, conics = (
+            ctx.saved_tensors
+        )
+
+        d_means, d_quats, d_log_scales = _C.project_gaussians_unscented_bwd(
+            means,
+            quats,
+            log_scales,
+            world_to_cam,
+            projection_matrices,
+            ctx.camera_model,
+            distortion_coeffs,
+            ctx.image_width,
+            ctx.image_height,
+            ctx.eps2d,
+            radii,
+            conics,
+            grad_means2d.contiguous(),
+            grad_depths.contiguous(),
+            grad_conics.contiguous(),
+        )
+
+        return (
+            d_means,
+            d_quats,
+            d_log_scales,
+            None,  # world_to_cam: no camera-pose gradient on this path yet
+            None,  # projection_matrices
+            None,  # distortion_coeffs
+            None,  # camera_model
+            None,  # image_width
+            None,  # image_height
+            None,  # eps2d
+            None,  # near
+            None,  # far
+            None,  # min_radius_2d
+            None,  # calc_compensations
+        )
+
+
+# ---------------------------------------------------------------------------
 #  Projection (analytic, jagged)
 # ---------------------------------------------------------------------------
 

--- a/fvdb_reality_capture/radiance_fields/gaussian_splatting.py
+++ b/fvdb_reality_capture/radiance_fields/gaussian_splatting.py
@@ -16,6 +16,7 @@ from ._gaussian_autograd import (
     _EvaluateGaussianSHFn,
     _ProjectGaussiansJaggedFn,
     _ProjectGaussiansFn,
+    _ProjectGaussiansUnscentedFn,
     _RasterizeScreenSpaceGaussiansFn,
     _RasterizeScreenSpaceGaussiansSparseFn,
     _RasterizeWorldSpaceGaussiansFn,
@@ -1532,11 +1533,23 @@ class GaussianSplat3d:
         if self._use_ut(camera_model, projection_method):
             if distortion_coeffs is None:
                 distortion_coeffs = torch.empty(C, 0, device=means.device, dtype=means.dtype)
-            result = _C.project_gaussians_unscented_fwd(
+            # `_C.project_gaussians_unscented_fwd`/`_bwd` now has a matching CUDA backward
+            # kernel, wired through `_ProjectGaussiansUnscentedFn.apply` below -- previously this
+            # branch called the forward op directly (not through a torch.autograd.Function, as
+            # the analytic branch below does via `_ProjectGaussiansFn.apply`), which silently
+            # disconnected it from the autograd graph: the photometric/image loss produced zero
+            # gradient on means/quats/log_scales for every Gaussian rendered through any camera
+            # model that requires distortion handling (every COLMAP camera model except
+            # SIMPLE_PINHOLE/PINHOLE), leaving only the rendering-independent regularization
+            # terms to act on the model. See ProjectGaussiansUnscentedBackward.h (fvdb-core) for
+            # the derivation and its current scope: only DistortionModel.OPENCV_RADTAN_5
+            # (SIMPLE_RADIAL/RADIAL/OPENCV) and calc_compensations=False are supported by the
+            # CUDA backward yet; `_ProjectGaussiansUnscentedFn.forward` raises NotImplementedError
+            # for anything outside that scope rather than silently mishandling it.
+            radii, means2d, depths, conics, compensations = _ProjectGaussiansUnscentedFn.apply(
                 means,
                 quats,
                 log_scales,
-                w2c,
                 w2c,
                 K,
                 distortion_coeffs,
@@ -1549,9 +1562,6 @@ class GaussianSplat3d:
                 min_radius,
                 antialias,
             )
-            radii, means2d, depths, conics, compensations = result
-            if not antialias:
-                compensations = None
             return radii, means2d, depths, conics, compensations
 
         result = _ProjectGaussiansFn.apply(


### PR DESCRIPTION
## Summary

`GaussianSplat3d._do_projection`'s branch for distorted camera models (every COLMAP model except `SIMPLE_PINHOLE`/`PINHOLE`) called `_C.project_gaussians_unscented_fwd` directly instead of through a `torch.autograd.Function`, unlike the analytic/pinhole branch just below it. This silently disconnected the op from the autograd graph: the photometric/image loss produced **zero gradient** on `means`/`quats`/`log_scales` for any scene using `SIMPLE_RADIAL`, `RADIAL`, or `OPENCV` cameras — no error, no warning. Gaussians never moved from their SfM-seeded positions except via MCMC's stochastic relocation resampling, with loss driven only by rendering-independent regularization terms.

Companion PR on `fvdb-core`, adding the CUDA backward kernel this depends on: openvdb/fvdb-core#766

Full root-cause writeup and validation methodology: openvdb/fvdb-core#767 (see also #333 in this repo, a short cross-link)

## What this changes

- `_gaussian_autograd.py`: adds `_ProjectGaussiansUnscentedFn`, a `torch.autograd.Function` pairing the existing forward op with the new `project_gaussians_unscented_bwd` CUDA kernel. Raises `NotImplementedError` for `calc_compensations=True` or any camera model other than `OPENCV_RADTAN_5`, matching what the new backward kernel actually supports.
- `gaussian_splatting.py`: `_do_projection`'s UT branch now calls `_ProjectGaussiansUnscentedFn.apply(...)` instead of the raw `_C` call.

## Validation

Verified through the actual call path (this repo's own `CameraModel` enum -> `_camera_model_to_cpp` -> the new autograd Function) against the compiled kernel on a real GPU — not just a synthetic direct call. Forward output is bit-identical to the previous direct-call path (same op, just now autograd-tracked); `means.grad`, `quats.grad`, `log_scales.grad` are all finite and nonzero where they previously were `0.0`/`None`. See the companion PR (openvdb/fvdb-core#766) for the finite-difference validation of the kernel itself, including one caveat (an eigenvector-direction approximation in the covariance-orientation gradient, documented and quantified there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
